### PR TITLE
FLPATH-2760: Remove code duplication between ros-ocp-backend and ros-helm-chart repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,35 @@ Kubernetes Helm chart for deploying the complete ROS-OCP backend stack.
 
 ## Quick Start
 
-### Option 1: Install Latest Release (Recommended)
+### Two-Step Deployment Process
+
+#### Step 1: Setup KIND Cluster (Development)
 ```bash
-# Automated installation of the latest release from GitHub
+# Create KIND cluster with ingress controller
+./scripts/deploy-kind.sh
+```
+
+#### Step 2: Deploy ROS-OCP Services
+```bash
+# Install latest release from GitHub (recommended)
 ./scripts/install-helm-chart.sh
+
+# Or use local chart for development
+USE_LOCAL_CHART=true LOCAL_CHART_PATH=../ros-ocp ./scripts/install-helm-chart.sh
 
 # Or specify custom namespace and release name
 NAMESPACE=my-namespace HELM_RELEASE_NAME=my-release ./scripts/install-helm-chart.sh
 ```
 
-### Option 2: Manual Installation from Source
-```bash
-# Local Helm installation from source (development mode)
-USE_LOCAL_CHART=true ./scripts/install-helm-chart.sh
-```
-
-### Option 3: Direct Helm Installation
+### Alternative: Direct Helm Installation
 ```bash
 # Download latest release manually and install
 LATEST_URL=$(curl -s https://api.github.com/repos/insights-onprem/ros-helm-chart/releases/latest | jq -r '.assets[] | select(.name | endswith(".tgz")) | .browser_download_url')
 curl -L -o ros-ocp-latest.tgz "$LATEST_URL"
 helm install ros-ocp ros-ocp-latest.tgz -n ros-ocp --create-namespace
 ```
+
+📖 **For detailed step-by-step instructions, see the [Quick Start Guide](docs/quickstart.md)**
 
 ## Chart Structure
 
@@ -48,6 +55,9 @@ ros-helm-chart/
 │       ├── *-serviceaccount.yaml           # Service accounts (2 files)
 │       ├── clusterrole*.yaml               # RBAC cluster roles (2 files)
 │       └── auth-cluster-roles-*.yaml       # Authentication roles (1 file)
+├── docs/                                   # Documentation
+│   ├── quickstart.md                       # Step-by-step deployment guide
+│   └── troubleshooting.md                  # Common issues and solutions
 ├── scripts/                                # Installation and deployment scripts
 │   ├── deploy-kind.sh                      # KIND cluster setup for development
 │   ├── install-helm-chart.sh               # Install/upgrade from GitHub releases or local source
@@ -169,15 +179,17 @@ The installation script automatically detects the platform and configures the ap
 ## Access Points
 
 ### Kubernetes (KIND) Deployment
-All services are accessible through the ingress controller on port **32061**:
+After successful deployment, all services are accessible through the ingress controller on port **32061**:
 
-- **Ingress Health Check**: http://localhost:32061/ready
-- **ROS-OCP API Status**: http://localhost:32061/status
-- **ROS-OCP API**: http://localhost:32061/api/ros/*
-- **Kruize API**: http://localhost:32061/api/kruize/listPerformanceProfiles
-- **Sources API**: http://localhost:32061/api/sources/*
-- **File Upload (Ingress)**: http://localhost:32061/api/ingress/*
-- **MinIO Console**: http://localhost:32061/minio (minioaccesskey/miniosecretkey) - Kubernetes only
+| Service | URL | Description |
+|---------|-----|-------------|
+| **Ingress Health** | http://localhost:32061/ready | Health check endpoint |
+| **ROS-OCP API** | http://localhost:32061/status | Main REST API status |
+| **ROS-OCP API** | http://localhost:32061/api/ros/* | Recommendations API |
+| **Kruize API** | http://localhost:32061/api/kruize/* | Optimization engine |
+| **Sources API** | http://localhost:32061/api/sources/* | Source management |
+| **File Upload** | http://localhost:32061/api/ingress/* | Data upload endpoint |
+| **MinIO Console** | http://localhost:32061/minio | Storage admin UI (minioaccesskey/miniosecretkey) |
 
 ### OpenShift Deployment
 Services are accessible through OpenShift Routes:
@@ -252,11 +264,11 @@ helm status ros-ocp -n ros-ocp
 For local development and testing using ephemeral KIND clusters:
 
 ```bash
-# Setup: Create KIND cluster with ingress
-scripts/deploy-kind.sh
+# Step 1: Create KIND cluster with ingress
+./scripts/deploy-kind.sh
 
-# Deploy: Auto-detects platform and deploys chart
-scripts/install-helm-chart.sh
+# Step 2: Deploy ROS-OCP services
+./scripts/install-helm-chart.sh
 
 # Access: All services available at http://localhost:32061
 ```
@@ -561,6 +573,8 @@ kubectl logs -n ros-ocp -l app.kubernetes.io/name=rosocp-processor
 ```bash
 kubectl get pvc -n ros-ocp
 ```
+
+🔧 **For comprehensive troubleshooting, see the [Troubleshooting Guide](docs/troubleshooting.md)**
 
 ### Script Installation Issues
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,422 @@
+# ROS-OCP Kubernetes Quick Start Guide
+
+This guide walks you through deploying and testing the ROS-OCP backend services on both Kubernetes and OpenShift clusters using the Helm chart from the [ros-helm-chart repository](https://github.com/insights-onprem/ros-helm-chart).
+
+## Helm Chart Location
+
+The ROS-OCP Helm chart is maintained in a separate repository: **[insights-onprem/ros-helm-chart](https://github.com/insights-onprem/ros-helm-chart)**
+
+### Deployment Methods
+
+The deployment scripts provide flexible options for both Kubernetes and OpenShift:
+
+1. **KIND Cluster Setup** (Development): The `deploy-kind.sh` script creates and configures a KIND cluster with ingress controller
+2. **Helm Chart Deployment**: The `install-helm-chart.sh` script deploys the ROS-OCP services with automatic platform detection
+3. **Development Mode**: Use `USE_LOCAL_CHART=true` to install from a local chart directory
+
+### Chart Features
+
+- **46 Kubernetes templates** for complete ROS-OCP stack deployment
+- **Platform detection** (Kubernetes vs OpenShift) with appropriate resource selection
+- **Automated CI/CD** with lint validation, version checking, and deployment testing
+- **Comprehensive documentation** and troubleshooting guides
+
+## Prerequisites
+
+### System Resources
+Ensure your system has adequate resources for the deployment:
+- **Memory**: At least 8GB RAM (12GB+ recommended)
+- **CPU**: 4+ cores
+- **Storage**: 10GB+ free disk space
+
+The deployment includes:
+- 3 PostgreSQL databases (256Mi each)
+- Kafka + Zookeeper (512Mi + 256Mi)
+- Kruize optimization engine (1-2Gi - most memory intensive)
+- Various application services (256-512Mi each)
+
+### Required Tools
+Install these tools on your system:
+
+**For Kubernetes/KIND Development:**
+```bash
+# macOS
+brew install kind kubectl helm podman
+
+# Linux (Ubuntu/Debian)
+# Install KIND
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+
+# Install kubectl, helm, podman via package manager
+sudo apt-get update
+sudo apt-get install -y kubectl helm podman
+```
+
+**For OpenShift:**
+```bash
+# Install OpenShift CLI
+# Download from: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
+# Or use package manager
+brew install openshift-cli  # macOS
+```
+
+### Verify Installation
+```bash
+# For Kubernetes/KIND
+kind --version
+kubectl version --client
+helm version
+podman --version
+
+# For OpenShift
+oc version
+kubectl version --client
+helm version
+```
+
+## Quick Deployment
+
+### Option 1: Kubernetes/KIND Development
+
+#### 1. Navigate to Scripts Directory
+```bash
+cd /path/to/ros-helm-chart/scripts/
+```
+
+#### 2. Setup KIND Cluster
+```bash
+# Create KIND cluster with ingress controller
+./deploy-kind.sh
+```
+
+The script will:
+- ✅ Check prerequisites (kubectl, kind, container runtime)
+- ✅ Create KIND cluster with proper networking
+- ✅ Install NGINX ingress controller
+- ✅ Configure port mapping (32061 for HTTP access)
+
+#### 3. Deploy ROS-OCP Services
+```bash
+# Deploy using latest GitHub release (recommended)
+./install-helm-chart.sh
+```
+
+### Option 2: OpenShift Production
+
+#### 1. Navigate to Scripts Directory
+```bash
+cd /path/to/ros-helm-chart/scripts/
+```
+
+#### 2. Deploy ROS-OCP Services
+```bash
+# Deploy directly to OpenShift (script auto-detects platform)
+./install-helm-chart.sh
+
+# Or use local chart for development
+USE_LOCAL_CHART=true LOCAL_CHART_PATH=../ros-ocp ./install-helm-chart.sh
+```
+
+The script will:
+- ✅ Download latest Helm chart release from GitHub
+- ✅ Deploy all services with platform detection
+- ✅ Run comprehensive health checks
+- ✅ Verify connectivity and authentication
+
+**Expected Output:**
+```
+[INFO] Running health checks...
+[SUCCESS] ✓ Ingress API is accessible via http://localhost:32061/ready
+[SUCCESS] ✓ ROS-OCP API is accessible via http://localhost:32061/status
+[SUCCESS] ✓ Kruize API is accessible via http://localhost:32061/api/kruize/listPerformanceProfiles
+[SUCCESS] All core services are healthy and operational!
+```
+
+#### 4. Verify Deployment
+```bash
+# Check deployment status
+./install-helm-chart.sh status
+
+# Run health checks
+./install-helm-chart.sh health
+```
+
+### Alternative: Manual Helm Chart Installation
+
+If you prefer to manually install the Helm chart or need a specific version:
+
+#### 1. Create KIND Cluster
+```bash
+# Create KIND cluster with ingress support
+./deploy-kind.sh
+```
+
+#### 2. Install Latest Chart Release
+```bash
+# Download and install latest chart release
+LATEST_URL=$(curl -s https://api.github.com/repos/insights-onprem/ros-helm-chart/releases/latest | jq -r '.assets[] | select(.name | endswith(".tgz")) | .browser_download_url')
+curl -L -o ros-ocp-latest.tgz "$LATEST_URL"
+helm install ros-ocp ros-ocp-latest.tgz -n ros-ocp --create-namespace
+```
+
+#### 3. Install Specific Chart Version
+```bash
+# Install a specific version (e.g., v0.1.0)
+VERSION="v0.1.0"
+curl -L -o ros-ocp-${VERSION}.tgz "https://github.com/insights-onprem/ros-helm-chart/releases/download/${VERSION}/ros-ocp-${VERSION}.tgz"
+helm install ros-ocp ros-ocp-${VERSION}.tgz -n ros-ocp --create-namespace
+```
+
+#### 4. Development Mode (Local Chart)
+```bash
+# Use local chart source for development
+USE_LOCAL_CHART=true LOCAL_CHART_PATH=../ros-ocp ./install-helm-chart.sh
+
+# Or direct Helm installation
+helm install ros-ocp ./ros-ocp -n ros-ocp --create-namespace
+```
+
+## Access Points
+
+After successful deployment, these services are available via the ingress controller on **port 32061**:
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| **Ingress Health** | http://localhost:32061/ready | Health check endpoint |
+| **ROS-OCP API** | http://localhost:32061/status | Main REST API status |
+| **ROS-OCP API** | http://localhost:32061/api/ros/* | Recommendations API |
+| **Kruize API** | http://localhost:32061/api/kruize/* | Optimization engine |
+| **Sources API** | http://localhost:32061/api/sources/* | Source management |
+| **File Upload** | http://localhost:32061/api/ingress/* | Data upload endpoint |
+| **MinIO Console** | http://localhost:32061/minio | Storage admin UI (minioaccesskey/miniosecretkey) |
+
+### Quick Access Test
+```bash
+# Test Ingress health
+curl http://localhost:32061/ready
+
+# Test ROS-OCP API
+curl http://localhost:32061/status
+
+# Test Kruize API
+curl http://localhost:32061/api/kruize/listPerformanceProfiles
+```
+
+## End-to-End Data Flow Testing
+
+### 1. Run Complete Test
+```bash
+# This tests the full data pipeline
+# Note: Run from ros-ocp-backend repository
+git clone https://github.com/gciavarrini/ros-ocp-backend.git
+cd ros-ocp-backend/deployment/kubernetes/scripts/
+./test-k8s-dataflow.sh
+```
+
+The test will:
+- ✅ Upload test CSV data via Ingress API
+- ✅ Simulate Koku service processing
+- ✅ Copy data to MinIO ros-data bucket
+- ✅ Publish Kafka event for processor
+- ✅ Verify data processing and database storage
+- ✅ Check Kruize experiment creation
+
+**Expected Output:**
+```
+[INFO] ROS-OCP Kubernetes Data Flow Test
+==================================
+[SUCCESS] Step 1: Upload completed successfully
+[SUCCESS] Steps 2-3: Koku simulation and Kafka event completed successfully
+[SUCCESS] Found 1 workload records in database
+[SUCCESS] All health checks passed!
+[SUCCESS] Data flow test completed!
+```
+
+### 2. View Service Logs
+```bash
+# List available services
+# Note: Run from ros-ocp-backend repository
+git clone https://github.com/gciavarrini/ros-ocp-backend.git
+cd ros-ocp-backend/deployment/kubernetes/scripts/
+
+# For Kubernetes/KIND deployments
+./test-k8s-dataflow.sh logs
+
+# For OpenShift deployments
+./test-ocp-dataflow.sh logs
+
+# View specific service logs
+./test-k8s-dataflow.sh logs rosocp-processor    # Kubernetes
+./test-ocp-dataflow.sh logs rosocp-processor    # OpenShift
+```
+
+### 3. Monitor Processing
+```bash
+# Watch pods in real-time
+kubectl get pods -n ros-ocp -w
+
+# Check persistent volumes
+kubectl get pvc -n ros-ocp
+
+# View all services
+kubectl get svc -n ros-ocp
+```
+
+## Manual Testing
+
+### Upload Test File
+```bash
+# Create test CSV file
+cat > test-data.csv << 'EOF'
+report_period_start,report_period_end,interval_start,interval_end,container_name,pod,owner_name,owner_kind,workload,workload_type,namespace,image_name,node,resource_id,cpu_request_container_avg,cpu_request_container_sum,cpu_limit_container_avg,cpu_limit_container_sum,cpu_usage_container_avg,cpu_usage_container_min,cpu_usage_container_max,cpu_usage_container_sum,cpu_throttle_container_avg,cpu_throttle_container_max,cpu_throttle_container_sum,memory_request_container_avg,memory_request_container_sum,memory_limit_container_avg,memory_limit_container_sum,memory_usage_container_avg,memory_usage_container_min,memory_usage_container_max,memory_usage_container_sum,memory_rss_usage_container_avg,memory_rss_usage_container_min,memory_rss_usage_container_max,memory_rss_usage_container_sum
+2024-01-01,2024-01-01,2024-01-01 00:00:00 -0000 UTC,2024-01-01 00:15:00 -0000 UTC,test-container,test-pod-123,test-deployment,Deployment,test-workload,deployment,test-namespace,quay.io/test/image:latest,worker-node-1,resource-123,100,100,200,200,50,10,90,50,0,0,0,512,512,1024,1024,256,128,384,256,200,100,300,200
+EOF
+
+# Important: For Kruize compatibility, ensure:
+# - report_period_start and report_period_end should match for short intervals
+# - Use timezone format '-0000 UTC' instead of 'Z' for Go time parsing compatibility
+# - Keep interval duration under 30 minutes for optimal Kruize validation
+
+# Upload via Ingress API
+curl -X POST \
+  -F "file=@test-data.csv" \
+  -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidHlwZSI6IlVzZXIiLCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSJ9fX0K" \
+  -H "x-rh-request-id: manual-test-$(date +%s)" \
+  http://localhost:32061/api/ingress/v1/upload
+```
+
+### Check Database
+```bash
+# Connect to ROS database
+kubectl exec -it -n ros-ocp deployment/ros-ocp-db-ros -- \
+  psql -U postgres -d postgres -c "SELECT COUNT(*) FROM workloads;"
+```
+
+### Monitor Kafka Topics
+```bash
+# List topics
+kubectl exec -n ros-ocp deployment/ros-ocp-kafka -- \
+  kafka-topics --list --bootstrap-server localhost:29092
+
+# Monitor events
+kubectl exec -n ros-ocp deployment/ros-ocp-kafka -- \
+  kafka-console-consumer --bootstrap-server localhost:29092 \
+  --topic hccm.ros.events --from-beginning
+```
+
+## Configuration
+
+### Environment Variables
+```bash
+# Customize deployment
+export KIND_CLUSTER_NAME=my-ros-cluster
+export HELM_RELEASE_NAME=my-ros-ocp
+export NAMESPACE=my-namespace
+
+# Deploy with custom settings
+./deploy-kind.sh
+```
+
+### Helm Values Override
+```bash
+# Create custom values file
+cat > my-values.yaml << EOF
+global:
+  storageClass: "fast-ssd"
+
+database:
+  ros:
+    storage:
+      size: 20Gi
+
+resources:
+  application:
+    requests:
+      memory: "256Mi"
+      cpu: "200m"
+EOF
+
+# Deploy with custom values (using latest release from ros-helm-chart repository)
+LATEST_URL=$(curl -s https://api.github.com/repos/insights-onprem/ros-helm-chart/releases/latest | jq -r '.assets[] | select(.name | endswith(".tgz")) | .browser_download_url')
+curl -L -o ros-ocp-latest.tgz "$LATEST_URL"
+helm upgrade --install ros-ocp ros-ocp-latest.tgz \
+  --namespace ros-ocp \
+  --create-namespace \
+  -f my-values.yaml
+```
+
+## Cleanup
+
+### Remove Deployment Only
+```bash
+# Remove Helm release and namespace
+./install-helm-chart.sh cleanup
+```
+
+### Remove Everything
+```bash
+# Delete entire KIND cluster
+./deploy-kind.sh cleanup --all
+```
+
+### Manual Cleanup
+```bash
+# Delete Helm release
+helm uninstall ros-ocp -n ros-ocp
+
+# Delete namespace
+kubectl delete namespace ros-ocp
+
+# Delete KIND cluster
+kind delete cluster --name ros-ocp-cluster
+```
+
+## Quick Status Check
+
+Use this script to verify all services are working:
+
+```bash
+#!/bin/bash
+echo "=== ROS-OCP Status Check ==="
+
+# Check pod status
+echo "Pod Status:"
+kubectl get pods -n ros-ocp
+
+# Check services with issues
+echo -e "\nPods with issues:"
+kubectl get pods -n ros-ocp --field-selector=status.phase!=Running
+
+# Check Kafka connectivity
+echo -e "\nKafka connectivity test:"
+kubectl exec -n ros-ocp deployment/ros-ocp-rosocp-processor -- nc -zv ros-ocp-kafka 29092 2>/dev/null && echo "✓ Kafka accessible" || echo "✗ Kafka connection failed"
+
+# Check API endpoints
+echo -e "\nAPI Health Checks:"
+curl -s http://localhost:32061/ready >/dev/null && echo "✓ Ingress API" || echo "✗ Ingress API failed"
+curl -s http://localhost:32061/status >/dev/null && echo "✓ ROS-OCP API" || echo "✗ ROS-OCP API failed"
+curl -s http://localhost:32061/api/kruize/listPerformanceProfiles >/dev/null && echo "✓ Kruize API" || echo "✗ Kruize API failed"
+
+echo -e "\nFor detailed troubleshooting, run: ./test-k8s-dataflow.sh health"
+```
+
+## Next Steps
+
+After successful deployment:
+
+1. **Explore APIs**: Use the access points to interact with services
+2. **Load Test Data**: Upload your own cost management files
+3. **Monitor Metrics**: Check Kruize recommendations and optimizations
+4. **Scale Services**: Modify Helm values to scale deployments
+5. **Production Setup**: Adapt for real Kubernetes clusters
+
+## Support
+
+For issues or questions:
+- Check [Troubleshooting Guide](troubleshooting.md)
+- Review test output: Clone [ros-ocp-backend](https://github.com/gciavarrini/ros-ocp-backend) and run:
+  - Kubernetes: `./deployment/kubernetes/scripts/test-k8s-dataflow.sh`
+  - OpenShift: `./deployment/kubernetes/scripts/test-ocp-dataflow.sh`
+- Check pod logs: `kubectl logs -n ros-ocp <pod-name>`
+- Verify configuration: `helm get values ros-ocp -n ros-ocp`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,131 @@
+# Troubleshooting
+
+## Common Issues
+
+**Pods getting OOMKilled (Out of Memory):**
+```bash
+# Check pod status for OOMKilled
+kubectl get pods -n ros-ocp
+
+# If you see OOMKilled status, increase memory limits
+# Create custom values file
+cat > low-resource-values.yaml << EOF
+resources:
+  kruize:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
+  database:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "250m"
+
+  application:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+EOF
+
+# Upgrade with reduced resources
+VALUES_FILE=low-resource-values.yaml ./install-helm-chart.sh
+```
+
+**Kruize listExperiments API error:**
+
+The Kruize `/listExperiments` endpoint may show errors related to missing `KruizeLMExperimentEntry` entity. This is a known issue with the current Kruize image version, but experiments are still being created and processed correctly in the database.
+
+```bash
+# Workaround: Check experiments directly in database
+kubectl exec -n ros-ocp ros-ocp-db-kruize-0 -- \
+  psql -U postgres -d postgres -c "SELECT experiment_name, status FROM kruize_experiments;"
+```
+
+**Kafka connectivity issues (Connection refused errors):**
+
+This is a common issue affecting multiple services (processor, recommendation-poller, housekeeper).
+
+```bash
+# Step 1: Check current Kafka status
+kubectl get pods -n ros-ocp -l app.kubernetes.io/name=kafka
+kubectl logs -n ros-ocp -l app.kubernetes.io/name=kafka --tail=20
+
+# Step 2: Apply Kafka networking fix and restart
+./install-helm-chart.sh
+kubectl rollout restart statefulset/ros-ocp-kafka -n ros-ocp
+
+# Step 3: Wait for Kafka to be ready
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kafka -n ros-ocp --timeout=300s
+
+# Step 4: Restart all dependent services
+kubectl rollout restart deployment/ros-ocp-rosocp-processor -n ros-ocp
+kubectl rollout restart deployment/ros-ocp-rosocp-recommendation-poller -n ros-ocp
+kubectl rollout restart deployment/ros-ocp-rosocp-housekeeper -n ros-ocp
+kubectl rollout restart deployment/ros-ocp-ingress -n ros-ocp
+
+# Step 5: Verify connectivity
+kubectl logs -n ros-ocp -l app.kubernetes.io/name=rosocp-processor --tail=10
+kubectl exec -n ros-ocp deployment/ros-ocp-rosocp-processor -- nc -zv ros-ocp-kafka 29092
+```
+
+**Alternative: Complete redeployment if issues persist:**
+```bash
+# Delete and redeploy if Kafka issues persist
+./install-helm-chart.sh cleanup --complete
+./deploy-kind.sh
+./install-helm-chart.sh
+```
+
+**Pods not starting:**
+```bash
+# Check pod status and events
+kubectl get pods -n ros-ocp
+kubectl describe pod -n ros-ocp <pod-name>
+
+# Check logs
+kubectl logs -n ros-ocp <pod-name>
+```
+
+**Services not accessible:**
+```bash
+# Check if services are created
+kubectl get svc -n ros-ocp
+
+# Test port forwarding as alternative
+kubectl port-forward -n ros-ocp svc/ros-ocp-ingress 3000:3000
+kubectl port-forward -n ros-ocp svc/ros-ocp-rosocp-api 8001:8000
+```
+
+**Storage issues:**
+```bash
+# Check persistent volume claims
+kubectl get pvc -n ros-ocp
+
+# Check storage class
+kubectl get storageclass
+```
+
+### Debug Commands
+
+```bash
+# Get all resources in namespace
+kubectl get all -n ros-ocp
+
+# Check Helm release status
+helm status ros-ocp -n ros-ocp
+
+# View Helm values
+helm get values ros-ocp -n ros-ocp
+
+# Check cluster info
+kubectl cluster-info
+```

--- a/scripts/deploy-kind.sh
+++ b/scripts/deploy-kind.sh
@@ -33,6 +33,7 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ros-ocp-cluster}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-podman}
+INGRESS_DEBUG_LEVEL=${INGRESS_DEBUG_LEVEL:-0}
 
 echo_info() {
     echo -e "${BLUE}[INFO]${NC} $1"
@@ -347,6 +348,27 @@ install_ingress_controller() {
     echo_info "Waiting for ingress controller deployment to be created..."
     sleep 10
 
+    # Configure debug logging if requested
+    if [ "$INGRESS_DEBUG_LEVEL" -gt 0 ]; then
+        echo_info "Enabling debug logs in NGINX ingress controller (level: $INGRESS_DEBUG_LEVEL)..."
+        kubectl patch deployment ingress-nginx-controller -n ingress-nginx --type='json' -p="[
+            {
+                \"op\": \"add\",
+                \"path\": \"/spec/template/spec/containers/0/args/-\",
+                \"value\": \"--v=$INGRESS_DEBUG_LEVEL\"
+            },
+            {
+                \"op\": \"add\",
+                \"path\": \"/spec/template/spec/containers/0/args/-\",
+                \"value\": \"--logtostderr=true\"
+            }
+        ]" || echo_warning "Debug logging patch failed, continuing..."
+
+        # Give time for the patch to take effect
+        echo_info "Waiting for debug configuration to take effect..."
+        sleep 5
+    fi
+
     # Wait for the deployment to be ready
     echo_info "Waiting for ingress-nginx controller deployment to be ready..."
     kubectl wait --namespace ingress-nginx \
@@ -357,161 +379,6 @@ install_ingress_controller() {
     echo_success "NGINX Ingress Controller is ready"
 }
 
-# Function to create authentication setup for insights-ros-ingress
-create_auth_setup() {
-    echo_info "Setting up authentication for insights-ros-ingress..."
-
-    # Create service account for insights-ros-ingress
-    local service_account="insights-ros-ingress"
-
-    if kubectl get serviceaccount "$service_account" -n "$NAMESPACE" >/dev/null 2>&1; then
-        echo_warning "Service account '$service_account' already exists in namespace '$NAMESPACE'"
-    else
-        kubectl create serviceaccount "$service_account" -n "$NAMESPACE"
-        echo_success "Service account '$service_account' created"
-    fi
-
-    # Create ClusterRoleBinding for system:auth-delegator (required for TokenReviewer API)
-    local cluster_role_binding="${service_account}-token-reviewer"
-
-    if kubectl get clusterrolebinding "$cluster_role_binding" >/dev/null 2>&1; then
-        echo_warning "ClusterRoleBinding '$cluster_role_binding' already exists"
-    else
-        cat <<EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: $cluster_role_binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-- kind: ServiceAccount
-  name: $service_account
-  namespace: $NAMESPACE
-EOF
-        echo_success "ClusterRoleBinding '$cluster_role_binding' created"
-    fi
-
-    # Create a long-lived token secret for the service account
-    local token_secret="${service_account}-token"
-
-    if kubectl get secret "$token_secret" -n "$NAMESPACE" >/dev/null 2>&1; then
-        echo_warning "Token secret '$token_secret' already exists"
-    else
-        cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Secret
-metadata:
-  name: $token_secret
-  namespace: $NAMESPACE
-  annotations:
-    kubernetes.io/service-account.name: $service_account
-type: kubernetes.io/service-account-token
-EOF
-        echo_success "Token secret '$token_secret' created"
-    fi
-
-    # Wait for the token to be generated
-    echo_info "Waiting for service account token to be generated..."
-    local retries=30
-    local count=0
-
-    while [ $count -lt $retries ]; do
-        if kubectl get secret "$token_secret" -n "$NAMESPACE" -o jsonpath='{.data.token}' >/dev/null 2>&1; then
-            local token_data
-            token_data=$(kubectl get secret "$token_secret" -n "$NAMESPACE" -o jsonpath='{.data.token}')
-            if [ -n "$token_data" ]; then
-                echo_success "Service account token generated successfully"
-                break
-            fi
-        fi
-        echo_info "Waiting for token generation... ($((count + 1))/$retries)"
-        sleep 2
-        count=$((count + 1))
-    done
-
-    if [ $count -eq $retries ]; then
-        echo_error "Failed to generate service account token after $retries attempts"
-        return 1
-    fi
-
-    # Save authentication configuration for test scripts
-    local kubeconfig_path="/tmp/dev-kubeconfig"
-    local cluster_server
-    cluster_server=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name=='kind-${KIND_CLUSTER_NAME}')].cluster.server}")
-    local token
-    token=$(kubectl get secret "$token_secret" -n "$NAMESPACE" -o jsonpath='{.data.token}' | base64 -d)
-
-    # Create kubeconfig file for test scripts
-    cat > "$kubeconfig_path" <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: $cluster_server
-    insecure-skip-tls-verify: true
-  name: kind-dev
-contexts:
-- context:
-    cluster: kind-dev
-    user: $service_account
-    namespace: $NAMESPACE
-  name: kind-dev
-current-context: kind-dev
-users:
-- name: $service_account
-  user:
-    token: $token
-EOF
-
-    echo_success "Test kubeconfig created at $kubeconfig_path"
-    echo_info "This kubeconfig can be used by test scripts for authentication"
-
-    return 0
-}
-
-# Function to deploy Helm chart
-deploy_helm_chart() {
-    echo_info "Deploying ROS-OCP Helm chart..."
-
-    # Check if Helm chart directory exists
-    if [ ! -d "../ros-ocp" ]; then
-        echo_error "Helm chart directory not found: ../helm/ros-ocp"
-        return 1
-    fi
-
-    # Install or upgrade the Helm release
-    helm upgrade --install "$HELM_RELEASE_NAME" ../ros-ocp \
-        --namespace "$NAMESPACE" \
-        --create-namespace \
-        --set global.storageClass="$STORAGE_CLASS" \
-        --timeout=600s \
-        --wait
-
-    if [ $? -eq 0 ]; then
-        echo_success "Helm chart deployed successfully"
-    else
-        echo_error "Failed to deploy Helm chart"
-        return 1
-    fi
-}
-
-# Function to wait for pods to be ready
-wait_for_pods() {
-    echo_info "Waiting for pods to be ready..."
-
-    # Wait for all pods to be ready (excluding jobs)
-    kubectl wait --for=condition=ready pod -l "app.kubernetes.io/instance=$HELM_RELEASE_NAME" \
-        --namespace "$NAMESPACE" \
-        --timeout=600s \
-        --field-selector=status.phase!=Succeeded
-
-    echo_success "All pods are ready"
-}
-
-# Function to check ingress controller readiness
 check_ingress_readiness() {
     echo_info "Checking ingress controller readiness..."
 
@@ -558,7 +425,7 @@ check_ingress_readiness() {
             # Test actual connectivity to the ingress controller using KIND-mapped port
             local test_port="32061"
             echo_info "Testing connectivity to ingress controller on KIND-mapped port $test_port..."
-            if curl -f -s "http://localhost:$test_port/" >/dev/null 2>&1; then
+            if curl -f -s --connect-timeout 5 --max-time 15 "http://localhost:$test_port/" >/dev/null 2>&1; then
                 echo_success "✓ Ingress controller is accessible via HTTP"
                 all_ready=true
                 break
@@ -643,12 +510,9 @@ show_status() {
 }
 
 
-# Function to run health checks with authentication
+# Function to run health checks for KIND cluster infrastructure
 run_health_checks() {
-    echo_info "Running health checks with authentication..."
-
-    # Health checks will run with or without authentication
-    echo_info "Running connectivity health checks..."
+    echo_info "Running KIND cluster infrastructure health checks..."
 
     local failed_checks=0
 
@@ -657,30 +521,9 @@ run_health_checks() {
 
     echo_info "Using KIND-mapped HTTP port: $http_port"
 
-    # Get authentication token for testing
-    local auth_token=""
-    if [ -f "/tmp/dev-kubeconfig" ]; then
-        auth_token=$(kubectl --kubeconfig=/tmp/dev-kubeconfig config view --raw -o jsonpath='{.users[0].user.token}' 2>/dev/null || echo "")
-    fi
-
-    if [ -z "$auth_token" ]; then
-        # Try kubectl/oc whoami -t to generate token from current user context
-        auth_token=$(kubectl whoami -t 2>/dev/null || oc whoami -t 2>/dev/null || echo "")
-    fi
-
-    if [ -z "$auth_token" ]; then
-        # For KIND clusters, we can skip authentication for basic health checks
-        # The deploy script runs health checks primarily to verify connectivity
-        echo_warning "No authentication token available for health checks"
-        echo_info "Running health checks without authentication (KIND cluster admin context)"
-        echo_info "Note: API endpoints may return 401, but this indicates the services are responding"
-    else
-        echo_info "Using authentication token for health checks"
-    fi
-
     # Check if nginx ingress controller is accessible on entry point
     local nginx_response
-    nginx_response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$http_port/" 2>/dev/null || echo "000")
+    nginx_response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 15 "http://localhost:$http_port/" 2>/dev/null || echo "000")
 
     if [ "$nginx_response" = "000" ] || [ -z "$nginx_response" ]; then
         echo_error "Ingress Entry Point is not accessible on port $http_port"
@@ -689,54 +532,27 @@ run_health_checks() {
         echo_success "Ingress Entry Point is accessible on port $http_port (HTTP ${nginx_response})"
     fi
 
-    # Check if ROS-OCP ingress API is accessible via ingress with authentication
-    local ingress_response=$(curl -s -o /dev/null -w "%{http_code}" \
-        -H "Authorization: Bearer $auth_token" \
-        "http://localhost:$http_port/api/ingress/v1/version" 2>/dev/null || echo "000")
-
-    if [ "$ingress_response" = "200" ] || [ "$ingress_response" = "401" ]; then
-        echo_success "ROS-OCP Ingress API is accessible via ingress on port $http_port (HTTP ${ingress_response})"
+    # Check ingress controller status
+    echo_info "Checking ingress controller status..."
+    local ingress_pods=$(kubectl get pods -n ingress-nginx --no-headers 2>/dev/null | wc -l)
+    if [ "$ingress_pods" -gt 0 ]; then
+        echo_success "✓ Ingress controller is running ($ingress_pods pods)"
     else
-        echo_error "ROS-OCP Ingress API is not accessible via ingress on port $http_port (HTTP ${ingress_response})"
+        echo_error "✗ Ingress controller not found"
         failed_checks=$((failed_checks + 1))
     fi
 
-    # Check if ROS-OCP API is accessible via ingress with authentication
-    local api_response=$(curl -s -o /dev/null -w "%{http_code}" \
-        -H "Authorization: Bearer $auth_token" \
-        "http://localhost:$http_port/status" 2>/dev/null || echo "000")
+    # Note about ROS-OCP services
+    echo_info "ℹ This health check only validates KIND cluster infrastructure"
+    echo_info "  To deploy ROS-OCP services: ./install-helm-chart.sh"
+    echo_info "  To test ROS-OCP services: ./install-helm-chart.sh health"
 
-    if [ "$api_response" = "200" ] || [ "$api_response" = "401" ]; then
-        echo_success "ROS-OCP API is accessible via ingress on port $http_port (HTTP ${api_response})"
-    else
-        echo_error "ROS-OCP API is not accessible via ingress on port $http_port (HTTP ${api_response})"
-        failed_checks=$((failed_checks + 1))
-    fi
-
-    # Check if Kruize is accessible via ingress with authentication
-    local kruize_response=$(curl -s -o /dev/null -w "%{http_code}" \
-        -H "Authorization: Bearer $auth_token" \
-        "http://localhost:$http_port/api/kruize/listPerformanceProfiles" 2>/dev/null || echo "000")
-
-    if [ "$kruize_response" = "200" ] || [ "$kruize_response" = "401" ]; then
-        echo_success "Kruize API is accessible via ingress on port $http_port (HTTP ${kruize_response})"
-    else
-        echo_error "Kruize API is not accessible via ingress on port $http_port (HTTP ${kruize_response})"
-        failed_checks=$((failed_checks + 1))
-    fi
-
-    # Check if MinIO console is accessible via ingress (no auth required for console)
-    if curl -f -s "http://localhost:$http_port/minio/" >/dev/null; then
-        echo_success "MinIO console is accessible via ingress on port $http_port"
-    else
-        echo_error "MinIO console is not accessible via ingress on port $http_port"
-        failed_checks=$((failed_checks + 1))
-    fi
-
+    # Summary
     if [ $failed_checks -eq 0 ]; then
-        echo_success "All health checks passed with authentication!"
+        echo_success "✓ KIND cluster infrastructure is healthy and ready for ROS-OCP deployment!"
     else
-        echo_warning "$failed_checks health check(s) failed"
+        echo_error "✗ $failed_checks infrastructure health check(s) failed"
+        echo_info "Check ingress controller status: kubectl get pods -n ingress-nginx"
     fi
 
     return $failed_checks
@@ -761,45 +577,12 @@ main() {
     echo "=== MAIN FUNCTION START ==="
     echo_info "Starting KIND cluster setup for ROS-OCP..."
 
-    # Check required commands
-    echo_info "Checking required commands..."
-    local missing_commands=()
-
-    echo "Checking kind command..."
-    if ! command -v kind >/dev/null 2>&1; then
-        echo "kind command not found"
-        missing_commands+=("kind")
-    else
-        echo "kind command found: $(which kind)"
-    fi
-
-    echo "Checking kubectl command..."
-    if ! command -v kubectl >/dev/null 2>&1; then
-        echo "kubectl command not found"
-        missing_commands+=("kubectl")
-    else
-        echo "kubectl command found: $(which kubectl)"
-    fi
-
-        echo "Checking container runtime..."
-        if ! command -v "$CONTAINER_RUNTIME" >/dev/null 2>&1; then
-            echo "$CONTAINER_RUNTIME command not found"
-            missing_commands+=("$CONTAINER_RUNTIME")
-        else
-            echo "$CONTAINER_RUNTIME command found: $(which $CONTAINER_RUNTIME)"
-        fi
-
-    if [ ${#missing_commands[@]} -gt 0 ]; then
-        echo_error "Missing required commands: ${missing_commands[*]}"
-        echo_error "Please install the missing commands and try again"
+    # Check prerequisites (includes container runtime detection and PID limit warnings)
+    echo "Calling check_prerequisites..."
+    if ! check_prerequisites; then
+        echo_error "Prerequisites check failed"
         return 1
     fi
-
-    echo_success "✓ All required commands are available"
-
-    # Detect container runtime
-    echo "Calling detect_container_runtime..."
-    detect_container_runtime
 
     # Clean up existing KIND artifacts
     echo "Calling cleanup_kind_artifacts..."
@@ -833,6 +616,10 @@ case "${1:-}" in
         show_status
         exit 0
         ;;
+    "health")
+        run_health_checks
+        exit $?
+        ;;
     "help"|"-h"|"--help")
         echo "Usage: $0 [command]"
         echo ""
@@ -840,24 +627,27 @@ case "${1:-}" in
         echo "  (none)          - Setup KIND cluster for ROS-OCP"
         echo "  cleanup --all   - Delete entire KIND cluster"
         echo "  status          - Show cluster status"
+        echo "  health          - Run health checks on existing cluster"
         echo "  help            - Show this help message"
         echo ""
         echo "Environment Variables:"
-        echo "  KIND_CLUSTER_NAME - Name of KIND cluster (default: ros-ocp-cluster)"
-        echo "  CONTAINER_RUNTIME - Container runtime to use (default: podman, supports: podman, docker, auto)"
+        echo "  KIND_CLUSTER_NAME     - Name of KIND cluster (default: ros-ocp-cluster)"
+        echo "  CONTAINER_RUNTIME     - Container runtime to use (default: podman, supports: podman, docker, auto)"
+        echo "  INGRESS_DEBUG_LEVEL   - NGINX ingress debug verbosity level (default: 0=disabled, 1-4=debug levels)"
         echo ""
         echo "Requirements:"
         echo "  - Container runtime must be installed and running (default: podman)"
         echo "  - kubectl and kind must be installed"
         echo "  - Container Runtime: Minimum 6GB memory allocation"
         echo ""
-        echo "Authentication:"
-        echo "  This script sets up authentication tokens required for testing."
-        echo "  If authentication tokens are not available, the script will FAIL."
-        echo "  Authentication sources checked:"
-        echo "    - Service account 'insights-ros-ingress' with token secret"
-        echo "    - Dev kubeconfig file at /tmp/dev-kubeconfig"
-        echo "    - insights-ros-ingress pod with service account token"
+        echo "Debug Logging:"
+        echo "  Set INGRESS_DEBUG_LEVEL to enable NGINX ingress controller debug logging:"
+        echo "    0 - Disabled (default)"
+        echo "    1 - Basic info logging"
+        echo "    2 - Detailed info logging (recommended for debugging)"
+        echo "    3 - Very detailed debugging"
+        echo "    4 - Extremely verbose (use with caution)"
+        echo "  Example: INGRESS_DEBUG_LEVEL=2 ./deploy-kind.sh"
         echo ""
         echo "Two-Step Deployment:"
         echo "  1. ./deploy-kind.sh       - Setup KIND cluster"
@@ -867,7 +657,8 @@ case "${1:-}" in
         echo "  After successful setup, run ./install-helm-chart.sh to deploy ROS-OCP"
         exit 0
         ;;
+    *)
+        # Default case - run main function for cluster setup
+        main "$@"
+        ;;
 esac
-
-# Run main function
-main "$@"

--- a/scripts/install-helm-chart.sh
+++ b/scripts/install-helm-chart.sh
@@ -179,28 +179,28 @@ create_storage_credentials_secret() {
         else
             # Try to create ODF credentials from noobaa-admin secret (from create_secret_odf.sh logic)
             echo_info "ODF credentials secret not found. Attempting to create from noobaa-admin secret..."
-            
+
             if kubectl get secret noobaa-admin -n openshift-storage >/dev/null 2>&1; then
                 echo_info "Found noobaa-admin secret, extracting ODF credentials..."
-                
+
                 # Extract credentials from noobaa-admin secret (using create_secret_odf.sh logic)
                 local access_key=$(kubectl get secret noobaa-admin -n openshift-storage -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
                 local secret_key=$(kubectl get secret noobaa-admin -n openshift-storage -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
-                
+
                 # Create ODF credentials secret first
                 kubectl create secret generic "$odf_secret_name" \
                     --namespace="$NAMESPACE" \
                     --from-literal=access-key="$access_key" \
                     --from-literal=secret-key="$secret_key"
-                
+
                 echo_success "Created ODF credentials secret from noobaa-admin"
-                
+
                 # Now create storage credentials secret
                 kubectl create secret generic "$secret_name" \
                     --namespace="$NAMESPACE" \
                     --from-literal=access-key="$access_key" \
                     --from-literal=secret-key="$secret_key"
-                
+
                 echo_success "Storage credentials secret created from noobaa-admin credentials"
             else
                 echo_error "Neither ODF credentials secret '$odf_secret_name' nor noobaa-admin secret found"


### PR DESCRIPTION
The quickstart guide was only covering Kubernetes/KIND setups, but our Helm chart works great on OpenShift too. Updated the docs to show both deployment paths.

## Key Updates
- Quickstart now covers both Kubernetes and OpenShift scenarios
- Added OpenShift CLI setup instructions alongside KIND/kubectl
- Split deployment into two clear options: development (KIND) vs production (OpenShift)
- Updated test script references to point to the right repo locations
- Made the support section more helpful for both platforms
