### PR TITLE
Disable ingress authentication for vanilla Kubernetes deployments

### DIFF
--- a/ros-ocp/Chart.yaml
+++ b/ros-ocp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ros-ocp
 description: A Helm chart for ROS-OCP Backend services
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "latest"
 
 keywords:

--- a/ros-ocp/templates/deployment-ingress.yaml
+++ b/ros-ocp/templates/deployment-ingress.yaml
@@ -133,9 +133,13 @@ spec:
             - name: KAFKA_RETRIES
               value: {{ .Values.ingress.kafka.retries | quote }}
 
-            # Authentication configuration
+            # Authentication configuration (only available on OpenShift with Keycloak)
             - name: AUTH_ENABLED
+              {{- if eq (include "ros-ocp.isOpenShift" .) "true" }}
               value: {{ .Values.ingress.auth.enabled | quote }}
+              {{- else }}
+              value: "false"
+              {{- end }}
             # Logging configuration
             - name: LOG_LEVEL
               value: {{ .Values.ingress.logging.level | quote }}

--- a/ros-ocp/values.yaml
+++ b/ros-ocp/values.yaml
@@ -184,8 +184,11 @@ ingress:
     clientId: "insights-ros-ingress"
     batchSize: 16384
     retries: 3
+  # Authentication configuration
+  # Note: Authentication is only available on OpenShift with Keycloak/RHSSO.
+  # On vanilla Kubernetes/KIND, authentication is automatically disabled regardless of this setting.
   auth:
-    enabled: true
+    enabled: true  # Only applies to OpenShift deployments
     allowedOrgs: []
   logging:
     level: "info"


### PR DESCRIPTION
- Add platform-aware authentication logic in deployment-ingress.yaml
- Authentication now automatically disabled on Kubernetes/KIND
- Authentication remains configurable on OpenShift (for Keycloak/RHSSO)
- Add documentation in values.yaml explaining platform-specific behavior
- Fixes issue where JWT auth was incorrectly enabled on KIND clusters

Rationale: JWT authentication with Keycloak is only available on OpenShift. Vanilla Kubernetes/KIND deployments should never attempt to use authentication as there is no Keycloak/RHSSO infrastructure available.