### PR TITLE
Fix kind health check

### DIFF
--- a/scripts/deploy-kind.sh
+++ b/scripts/deploy-kind.sh
@@ -523,7 +523,7 @@ run_health_checks() {
 
     # Check if nginx ingress controller is accessible on entry point
     local nginx_response
-    nginx_response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 15 "http://localhost:$http_port/" 2>/dev/null)
+    nginx_response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 15 "http://localhost:$http_port/" 2>/dev/null || echo)
 
     if [ "$nginx_response" = "000" ] || [ -z "$nginx_response" ]; then
         echo_error "Ingress Entry Point is not accessible on port $http_port"


### PR DESCRIPTION
Changed the `|| echo "000"` fallback to empty echo in `run_health_checks` because `curl` already returns `000` if it fails.

