### PR TITLE
Unify ROS image configuration to reduce duplication

### DIFF
--- a/cost-onprem/templates/ros/api/deployment.yaml
+++ b/cost-onprem/templates/ros/api/deployment.yaml
@@ -76,8 +76,8 @@ spec:
             {{- toYaml .Values.jwtAuth.envoy.resources | nindent 12 }}
         {{- end }}
         - name: ros-api
-          image: "{{ .Values.ros.api.image.repository }}:{{ .Values.ros.api.image.tag }}"
-          imagePullPolicy: {{ .Values.ros.api.image.pullPolicy | default .Values.global.pullPolicy }}
+          image: "{{ .Values.ros.image.repository }}:{{ .Values.ros.image.tag }}"
+          imagePullPolicy: {{ .Values.ros.image.pullPolicy | default .Values.global.pullPolicy }}
           securityContext:
             {{- include "cost-onprem.securityContext.nonRoot" . | nindent 12 }}
           command: ["sh", "-c"]

--- a/cost-onprem/templates/ros/housekeeper/cronjob-partition-cleaner.yaml
+++ b/cost-onprem/templates/ros/housekeeper/cronjob-partition-cleaner.yaml
@@ -27,8 +27,8 @@ spec:
           {{- end }}
           containers:
           - name: ros-partition-cleaner
-            image: {{ .Values.ros.housekeeper.partitionCleaner.image.repository }}:{{ .Values.ros.housekeeper.partitionCleaner.image.tag }}
-            imagePullPolicy: {{ .Values.ros.housekeeper.partitionCleaner.image.pullPolicy | default .Values.global.pullPolicy }}
+            image: {{ .Values.ros.image.repository }}:{{ .Values.ros.image.tag }}
+            imagePullPolicy: {{ .Values.ros.image.pullPolicy | default .Values.global.pullPolicy }}
             command: ["sh"]
             args: ["-c", "./rosocp db migrate up && ./rosocp start housekeeper --partitions"]
             env:

--- a/cost-onprem/templates/ros/housekeeper/deployment.yaml
+++ b/cost-onprem/templates/ros/housekeeper/deployment.yaml
@@ -34,8 +34,8 @@ spec:
         {{- include "cost-onprem.initContainer.waitForSourcesApi" . | nindent 8 }}
       containers:
         - name: ros-housekeeper
-          image: "{{ .Values.ros.housekeeper.image.repository }}:{{ .Values.ros.housekeeper.image.tag }}"
-          imagePullPolicy: {{ .Values.ros.housekeeper.image.pullPolicy | default .Values.global.pullPolicy }}
+          image: "{{ .Values.ros.image.repository }}:{{ .Values.ros.image.tag }}"
+          imagePullPolicy: {{ .Values.ros.image.pullPolicy | default .Values.global.pullPolicy }}
           command: ["sh", "-c"]
           args:
             - |

--- a/cost-onprem/templates/ros/processor/deployment.yaml
+++ b/cost-onprem/templates/ros/processor/deployment.yaml
@@ -33,8 +33,8 @@ spec:
         {{- include "cost-onprem.initContainer.waitForKruize" . | nindent 8 }}
       containers:
         - name: ros-processor
-          image: "{{ .Values.ros.processor.image.repository }}:{{ .Values.ros.processor.image.tag }}"
-          imagePullPolicy: {{ .Values.ros.processor.image.pullPolicy | default .Values.global.pullPolicy }}
+          image: "{{ .Values.ros.image.repository }}:{{ .Values.ros.image.tag }}"
+          imagePullPolicy: {{ .Values.ros.image.pullPolicy | default .Values.global.pullPolicy }}
           command: ["sh", "-c"]
           args:
             - |

--- a/cost-onprem/templates/ros/recommendation-poller/deployment.yaml
+++ b/cost-onprem/templates/ros/recommendation-poller/deployment.yaml
@@ -33,8 +33,8 @@ spec:
         {{- include "cost-onprem.initContainer.waitForKruize" . | nindent 8 }}
       containers:
         - name: ros-rec-poller
-          image: "{{ .Values.ros.recommendationPoller.image.repository }}:{{ .Values.ros.recommendationPoller.image.tag }}"
-          imagePullPolicy: {{ .Values.ros.recommendationPoller.image.pullPolicy | default .Values.global.pullPolicy }}
+          image: "{{ .Values.ros.image.repository }}:{{ .Values.ros.image.tag }}"
+          imagePullPolicy: {{ .Values.ros.image.pullPolicy | default .Values.global.pullPolicy }}
           command: ["sh", "-c"]
           args:
             - |

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -51,6 +51,14 @@ auth:
 # ROS (Resource Optimization Service) - Top-level Service
 # -----------------------------------------------------------------------------
 ros:
+  # Unified image configuration for all ROS components
+  # All ROS services (api, processor, recommendationPoller, housekeeper, partitionCleaner)
+  # use the same image
+  image:
+    repository: quay.io/insights-onprem/ros-ocp-backend
+    tag: "latest"
+    pullPolicy: Always
+
   # Service Account
   serviceAccount:
     create: true
@@ -58,11 +66,6 @@ ros:
 
   # API Component - REST API for ROS
   api:
-    image:
-      repository: quay.io/insights-onprem/ros-ocp-backend
-      tag: "latest"
-      pullPolicy: Always
-
     port: 8000
     metricsPort: 9000
     pathPrefix: /api
@@ -76,11 +79,6 @@ ros:
 
   # Processor Component - Processes uploaded data
   processor:
-    image:
-      repository: quay.io/insights-onprem/ros-ocp-backend
-      tag: "latest"
-      pullPolicy: Always
-
     metricsPort: 9000
     logLevel: INFO
     serviceName: ros-processor
@@ -95,11 +93,6 @@ ros:
 
   # Recommendation Poller Component - Polls Kruize for recommendations
   recommendationPoller:
-    image:
-      repository: quay.io/insights-onprem/ros-ocp-backend
-      tag: "latest"
-      pullPolicy: Always
-
     metricsPort: 9000
     logLevel: INFO
     serviceName: ros-recommendation-poller
@@ -114,11 +107,6 @@ ros:
 
   # Housekeeper Component - Maintenance and cleanup tasks
   housekeeper:
-    image:
-      repository: quay.io/insights-onprem/ros-ocp-backend
-      tag: "latest"
-      pullPolicy: Always
-
     logLevel: INFO
     serviceName: ros-housekeeper-sources
 
@@ -126,10 +114,6 @@ ros:
     partitionCleaner:
       enabled: true
       schedule: "0 0 */15 * *"  # Every 15 days at midnight
-      image:
-        repository: quay.io/insights-onprem/ros-ocp-backend
-        tag: "latest"
-        pullPolicy: Always
       serviceName: ros-housekeeper-partition
       logLevel: INFO
       resources:


### PR DESCRIPTION
Consolidates all ROS service image definitions into a single location at `ros.image` level, eliminating duplicate configuration across multiple components.

Changes:
- Add unified ros.image configuration (repository, tag, pullPolicy)
- Remove duplicate image configs from ros.api, ros.processor, ros.recommendationPoller, ros.housekeeper, and ros.housekeeper.partitionCleaner
- Update all ROS deployments and cronjobs to reference ros.image

Benefits:
- Single source of truth for ROS image configuration
- Easier version management across all ROS services
- Reduced configuration duplication and maintenance overhead
- Guaranteed consistency across all ROS components

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Signed-off-by: Moti Asayag <masayag@redhat.com>