### PR TITLE
Fix: UTC Timezone Issue in Test Script Causing Empty Recommendations

### DIFF
--- a/scripts/test-ocp-dataflow-jwt.sh
+++ b/scripts/test-ocp-dataflow-jwt.sh
@@ -504,10 +504,10 @@ cross_platform_date_ago() {
     local target_epoch=$(($(date +%s) - seconds_ago))
 
     # Try BSD date format first (macOS)
-    if date -r "$target_epoch" "$format" 2>/dev/null; then
+    if TZ=UTC date -r "$target_epoch" "$format" 2>/dev/null; then
         return 0
     # Try GNU date format (Linux)
-    elif date -d "@$target_epoch" "$format" 2>/dev/null; then
+    elif TZ=UTC date -d "@$target_epoch" "$format" 2>/dev/null; then
         return 0
     else
         # Fallback: use epoch time directly


### PR DESCRIPTION
## Problem

The ROS API was returning empty arrays of recommendations when querying the database, even after successful data uploads via the test script.

## Root Cause

The `test-ocp-dataflow-jwt.sh` script was generating timestamps using the `cross_platform_date_ago()` function without explicitly forcing UTC timezone. This caused the following issues:

1. **Timezone Mismatch**: The `date` command was using the system's local timezone instead of UTC when formatting epoch timestamps
2. **Incorrect `monitoring.end_time` Values**: The database stored timestamps that were offset by the local timezone, making them appear in the future or past relative to UTC
3. **Query Filtering Failure**: The API queries the database filtering by
`recommendation_sets.monitoring_end_time < time.Now().UTC()`, but because the stored timestamps were in local timezone (not UTC), the comparison failed:
   - If local timezone was ahead of UTC: timestamps appeared in the future → filtered out
   - If local timezone was behind UTC: timestamps appeared too far in the past → may be filtered out by other constraints

## Solution

Modified the `cross_platform_date_ago()` function in `scripts/test-ocp-dataflow-jwt.sh` to explicitly force UTC timezone when formatting dates:

```bash
# Before
if date -r "$target_epoch" "$format" 2>/dev/null; then
elif date -d "@$target_epoch" "$format" 2>/dev/null; then

# After
if TZ=UTC date -r "$target_epoch" "$format" 2>/dev/null; then
elif TZ=UTC date -d "@$target_epoch" "$format" 2>/dev/null; then
```

## Related Issues

- API returns empty recommendations array when data exists in database
- Test script generates timestamps in wrong timezone
- `monitoring.end_time` values incorrect in database

## Notes

- This fix ensures cross-platform compatibility (macOS and Linux)
- The format string already includes `-0000 UTC` as literal text, but the actual timezone interpretation was controlled by the system timezone
- The `TZ=UTC` environment variable forces the date command to interpret and output times in UTC regardless of system timezone settings

