### PR TITLE
Fix: 401 in the UI

### DIFF
--- a/cost-onprem/templates/ui/deployment.yaml
+++ b/cost-onprem/templates/ui/deployment.yaml
@@ -59,6 +59,8 @@ spec:
         - --code-challenge-method=S256
         - --email-domain=*
         - --cookie-secure=true
+        - --cookie-expire={{ .Values.ui.oauthProxy.cookie.expire }}
+        - --cookie-refresh={{ .Values.ui.oauthProxy.cookie.refresh }}
         livenessProbe:
           httpGet:
             path: /ping

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -489,6 +489,11 @@ ui:
     client:
       id: ""
       secret: ""
+    cookie:
+      # Cookie expiration time (720h = 30 days)
+      expire: "720h"
+      refresh: "4m"
+
 
   app:
     image:


### PR DESCRIPTION
### Problem

Users were experiencing 401 Unauthorized errors in the UI after 5 minutes after the first login

### Root Cause

OAuth2 proxy does not refresh tokens automatically by default - this feature must be explicitly enabled.
Keycloak is configured by default to expire access tokens after 5 minutes (`accessTokenLifespan: 300`).

When a user's access token expired:
1. The OAuth proxy cookie remained valid, but contained an expired access token
2. Any subsequent API request (even during active use) would use the expired token
3. The backend API rejected these requests with 401 Unauthorized errors
4. Users were forced to manually refresh the page or re-authenticate

## Solution

Enabled OAuth2 proxy's token refresh feature by configuring the `--cookie-refresh` flag. This allows the proxy to automatically refresh access tokens using the refresh token before they expire.

### Changes Made

1. **Added cookie refresh settings to `values.yaml`**:
   - `ui.oauthProxy.cookie.expire`: Set to `720h` (30 days) to match Keycloak's offline session idle timeout
   - `ui.oauthProxy.cookie.refresh`: Set to `4m` to refresh tokens slightly before the 5-minute expiration

2. **Updated deployment template** (`cost-onprem/templates/ui/deployment.yaml`):
   - Added `--cookie-expire` flag to configure cookie expiration time
   - Added `--cookie-refresh` flag to enable automatic token refresh

### Configuration Details

```yaml
ui:
  oauthProxy:
    cookie:
      expire: "720h"   # 30 days - matches Keycloak offline session idle timeout
      refresh: "4m"     # Refresh 1 minute before 5-minute token expiration
```

### How It Works

1. **Cookie Expiration (`--cookie-expire`)**: 
   - Set to 30 days (720 hours) to match Keycloak's "Client Offline Session Idle" setting
   - Ensures the session cookie remains valid as long as the refresh token is active

2. **Cookie Refresh (`--cookie-refresh`)**:
   - Set to 4 minutes to refresh tokens before the 5-minute expiration
   - **Required flag**: Without this flag, OAuth2 proxy does not refresh tokens automatically
   - When enabled, OAuth2 proxy uses the refresh token to obtain a new access token at the specified interval
   - Users remain authenticated seamlessly without interruption

## References

- [OAuth2 Proxy Cookie Configuration](https://oauth2-proxy.github.io/oauth2-proxy/configuration/session_storage)
- [Keycloak Token Lifespan Settings](https://www.keycloak.org/docs/latest/server_admin/#_token-lifespan)

