### PR TITLE
FLPATH-2968 - Adjust error handling in deployment + test scripts to fail script execution

### DIFF
--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -362,10 +362,12 @@ deploy_rhbk() {
         export VERBOSE="true"
     fi
     
-    execute_script "${SCRIPT_DEPLOY_RHBK}" #|| log_warning "RHBK deployment had issues but continuing..."
+    if ! execute_script "${SCRIPT_DEPLOY_RHBK}"; then
+        log_error "Red Hat Build of Keycloak (RHBK) deployment failed"
+        exit 1
+    fi
     
     log_success "Red Hat Build of Keycloak (RHBK) deployment completed"
-    return 0
 }
 
 deploy_strimzi() {
@@ -387,10 +389,12 @@ deploy_strimzi() {
         export VERBOSE="true"
     fi
     
-    execute_script "${SCRIPT_DEPLOY_STRIMZI}" #|| log_warning "Strimzi deployment had issues but continuing..."
+    if ! execute_script "${SCRIPT_DEPLOY_STRIMZI}"; then
+        log_error "Kafka/Strimzi deployment failed"
+        exit 1
+    fi
     
     log_success "Kafka/Strimzi deployment completed"
-    return 0
 }
 
 deploy_helm_chart() {
@@ -416,17 +420,17 @@ deploy_helm_chart() {
     fi
     
     if ! execute_script "${SCRIPT_INSTALL_HELM}"; then
-        log_warning "Helm chart deployment had issues but continuing..."
+        log_error "Helm chart deployment failed"
         log_info ""
         log_info "To troubleshoot:"
         log_info "  1. Check Helm release status: helm list -n ${NAMESPACE}"
         log_info "  2. Check pod status: oc get pods -n ${NAMESPACE}"
         log_info "  3. View pod logs: oc logs -n ${NAMESPACE} <pod-name>"
         log_info "  4. Check events: oc get events -n ${NAMESPACE} --sort-by='.lastTimestamp'"
+        exit 1
     fi
     
     log_success "Cost On-Prem Helm chart deployment completed"
-    return 0
 }
 
 download_openshift_values() {
@@ -494,7 +498,10 @@ test_jwt_flow() {
         export VERBOSE="true"
     fi
     
-    execute_script "${SCRIPT_TEST_JWT}" || log_warning "JWT authentication test had issues but continuing..."
+    if ! execute_script "${SCRIPT_TEST_JWT}"; then
+        log_error "JWT authentication test failed"
+        exit 1
+    fi
     
     log_success "JWT authentication test completed"
 }


### PR DESCRIPTION
- Update deploy_rhbk and deploy_strimzi functions to exit on failure of script execution, logging appropriate error messages.
- Modify deploy_helm_chart to log an error and exit on Helm chart deployment failure instead of continuing.
- Improve test_jwt_flow function to exit on JWT authentication test failure with an error log.