### PR TITLE
[FLPATH-3050] refactor: replace Redis terminology with Valkey throughout codebase

### DIFF
--- a/.cursor/prompts/run-tests.md
+++ b/.cursor/prompts/run-tests.md
@@ -48,7 +48,7 @@ NAMESPACE=cost-onprem ./scripts/run-pytest.sh --extended
 ```bash
 E2E_CLEANUP_BEFORE=true   # Clean before tests (default)
 E2E_CLEANUP_AFTER=true    # Clean after tests (default)
-E2E_RESTART_SERVICES=false # Restart Redis/listener (optional)
+E2E_RESTART_SERVICES=false # Restart Valkey/listener (optional)
 ```
 
 ## Output

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -74,7 +74,7 @@ Environment variables for cleanup control:
 ```bash
 E2E_CLEANUP_BEFORE=true   # Clean before tests (default)
 E2E_CLEANUP_AFTER=true    # Clean after tests (default)
-E2E_RESTART_SERVICES=false # Restart Redis/listener (optional)
+E2E_RESTART_SERVICES=false # Restart Valkey/listener (optional)
 ```
 
 ## When Modifying Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ NAMESPACE=cost-onprem-ocp ./scripts/run-pytest.sh --extended
 ```bash
 E2E_CLEANUP_BEFORE=true   # Clean before tests (default)
 E2E_CLEANUP_AFTER=true    # Clean after tests (default)
-E2E_RESTART_SERVICES=false # Restart Redis/listener (optional)
+E2E_RESTART_SERVICES=false # Restart Valkey/listener (optional)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cost-onprem-chart/
 - **ROS Housekeeper**: Maintenance tasks and data cleanup
 - **Kruize Autotune**: Optimization recommendation engine (direct authentication, protected by network policies)
 - **Sources API**: Source management and integration (middleware-based authentication for protected endpoints, unauthenticated metadata endpoints for internal use)
-- **Redis/Valkey**: Caching layer for performance
+- **Valkey**: Caching layer for performance
 
 **Security Architecture**:
 - **Ingress Authentication**: Envoy sidecar with JWT validation (Keycloak) for external uploads

--- a/cost-onprem/templates/_helpers-init-containers.tpl
+++ b/cost-onprem/templates/_helpers-init-containers.tpl
@@ -129,7 +129,7 @@ Usage: {{ include "cost-onprem.initContainer.waitForSourcesApi" . | nindent 8 }}
 {{- end -}}
 
 {{/*
-Wait for Cache (Redis/Valkey) init container
+Wait for Cache (Valkey) init container
 Usage: {{ include "cost-onprem.initContainer.waitForCache" . | nindent 8 }}
 */}}
 {{- define "cost-onprem.initContainer.waitForCache" -}}

--- a/cost-onprem/templates/_helpers-koku.tpl
+++ b/cost-onprem/templates/_helpers-koku.tpl
@@ -101,14 +101,14 @@ Valkey Connection Helpers (cache/broker)
 {{/*
 Valkey host
 */}}
-{{- define "cost-onprem.koku.redis.host" -}}
+{{- define "cost-onprem.koku.valkey.host" -}}
 {{- printf "%s-valkey" (include "cost-onprem.fullname" .) -}}
 {{- end -}}
 
 {{/*
 Valkey port
 */}}
-{{- define "cost-onprem.koku.redis.port" -}}
+{{- define "cost-onprem.koku.valkey.port" -}}
 {{- .Values.valkey.port | default 6379 -}}
 {{- end -}}
 
@@ -292,10 +292,11 @@ Common environment variables for Koku API and Celery
     secretKeyRef:
       name: {{ include "cost-onprem.koku.database.secretName" . }}
       key: koku-password
+# Valkey connection
 - name: REDIS_HOST
-  value: {{ include "cost-onprem.koku.redis.host" . | quote }}
+  value: {{ include "cost-onprem.koku.valkey.host" . | quote }}
 - name: REDIS_PORT
-  value: {{ include "cost-onprem.koku.redis.port" . | quote }}
+  value: {{ include "cost-onprem.koku.valkey.port" . | quote }}
 - name: CELERY_RESULT_EXPIRES
   value: {{ .Values.costManagement.celery.resultExpires | default "28800" | quote }}
 - name: INSIGHTS_KAFKA_HOST

--- a/cost-onprem/templates/cost-management/masu/deployment-listener.yaml
+++ b/cost-onprem/templates/cost-management/masu/deployment-listener.yaml
@@ -76,7 +76,7 @@ spec:
           value: {{ .Values.costManagement.kafka.topic | quote }}
         {{- end }}
 
-        # Common Koku environment variables (includes DB, Redis, S3, Kafka, etc.)
+        # Common Koku environment variables (includes DB, Valkey, S3, Kafka, etc.)
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
 
         # POD_CPU_LIMIT is required for gunicorn worker calculation

--- a/cost-onprem/templates/cost-management/masu/deployment.yaml
+++ b/cost-onprem/templates/cost-management/masu/deployment.yaml
@@ -57,7 +57,7 @@ spec:
 
         # Environment variables
         env:
-        # Common Koku environment variables (includes DB, Redis, S3, etc.)
+        # Common Koku environment variables (includes DB, Valkey, S3, etc.)
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
 
         # POD_CPU_LIMIT is required for gunicorn worker calculation

--- a/cost-onprem/templates/cost-management/sources/deployment-sources-listener.yaml
+++ b/cost-onprem/templates/cost-management/sources/deployment-sources-listener.yaml
@@ -78,7 +78,7 @@ spec:
         - name: SOURCES_API_PREFIX
           value: /api/sources/v1.0
 
-        # Common Koku environment variables (DB, Redis, S3, Kafka, etc.)
+        # Common Koku environment variables (DB, Valkey, S3, Kafka, etc.)
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
 
         volumeMounts:

--- a/cost-onprem/templates/sources-api/deployment.yaml
+++ b/cost-onprem/templates/sources-api/deployment.yaml
@@ -58,6 +58,7 @@ spec:
               value: {{ .Values.database.sources.name | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.sourcesApi.logLevel | quote }}
+            # Valkey cache
             - name: REDIS_CACHE_HOST
               value: {{ include "cost-onprem.fullname" . }}-{{ $cacheName }}
             - name: REDIS_CACHE_PORT

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -5,7 +5,7 @@
 # - ROS (Resource Optimization Service)
 # - Cost Management Service (future)
 # - Sources API
-# - Shared infrastructure (PostgreSQL, Kafka, Redis/Valkey, MinIO/ODF)
+# - Shared infrastructure (PostgreSQL, Kafka, Valkey, MinIO/ODF)
 #
 # Naming conventions:
 # - Use camelCase for all variable names

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -351,9 +351,9 @@ kubectl get pods -n kafka -l name=strimzi-cluster-operator
 **Steps**:
 
 ```bash
-# 1. Clear Redis/Valkey cache (uses valkey-cli, Redis-compatible)
-REDIS_POD=$(kubectl get pod -n cost-onprem -l app.kubernetes.io/component=cache -o jsonpath='{.items[0].metadata.name}')
-kubectl exec -n cost-onprem $REDIS_POD -- valkey-cli FLUSHALL
+# 1. Clear Valkey cache
+VALKEY_POD=$(kubectl get pod -n cost-onprem -l app.kubernetes.io/component=cache -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n cost-onprem $VALKEY_POD -- valkey-cli FLUSHALL
 
 # 2. Restart Koku listener to clear in-memory state
 kubectl delete pod -n cost-onprem -l app.kubernetes.io/component=listener

--- a/scripts/e2e_validator/clients/celery_client.py
+++ b/scripts/e2e_validator/clients/celery_client.py
@@ -2,7 +2,7 @@
 Celery Client Wrapper
 ======================
 
-Direct Celery connection via Redis.
+Direct Celery connection via Valkey.
 """
 
 from celery import Celery
@@ -10,13 +10,13 @@ from typing import Dict, Optional
 
 
 class CeleryClient:
-    """Direct Celery connection via Redis"""
+    """Direct Celery connection via Valkey"""
 
     def __init__(self, redis_url: str):
         """Initialize Celery client
 
         Args:
-            redis_url: Redis connection URL (e.g., redis://redis:6379/0)
+            redis_url: Valkey connection URL (e.g., redis://valkey:6379/0)
         """
         self.redis_url = redis_url
         self.celery = Celery(broker=redis_url, backend=redis_url)

--- a/scripts/e2e_validator/phases/data_upload.py
+++ b/scripts/e2e_validator/phases/data_upload.py
@@ -157,7 +157,7 @@ generators:
         }
 
     def _restart_koku_components_for_cache_clear(self):
-        """Restart Redis and Koku listener to clear stale caches.
+        """Restart Valkey and Koku listener to clear stale caches.
 
         This ensures a clean state by clearing any cached processing state.
         """
@@ -169,20 +169,20 @@ generators:
         print(f"\n🔄 Clearing Koku caches (workaround for table_exists cache bug)...")
 
         try:
-            # Restart Redis to clear cache
-            print(f"  🗑️  Restarting Redis to clear cache...")
+            # Restart Valkey to clear cache
+            print(f"  🗑️  Restarting Valkey to clear cache...")
             subprocess.run(
                 ['kubectl', 'delete', 'pod', '-n', namespace, '-l', 'app.kubernetes.io/component=cache'],
                 capture_output=True, timeout=30
             )
 
-            # Wait for Redis to come back
+            # Wait for Valkey to come back
             subprocess.run(
                 ['kubectl', 'wait', '--for=condition=ready', 'pod',
                  '-l', 'app.kubernetes.io/component=cache', '-n', namespace, '--timeout=60s'],
                 capture_output=True, timeout=70
             )
-            print(f"  ✅ Redis restarted")
+            print(f"  ✅ Valkey restarted")
 
             # Restart listener to clear in-memory state
             print(f"  🔄 Restarting Koku listener...")
@@ -204,7 +204,7 @@ generators:
 
         except Exception as e:
             print(f"  ⚠️  Warning: Could not restart components: {e}")
-            print(f"  ℹ️  You may need to manually restart Redis and listener pods")
+            print(f"  ℹ️  You may need to manually restart Valkey and listener pods")
 
     def check_existing_data(self) -> Dict[str, any]:
         """Check if VALID test data already exists

--- a/scripts/requirements-e2e.txt
+++ b/scripts/requirements-e2e.txt
@@ -5,7 +5,7 @@
 kubernetes>=28.1.0
 boto3>=1.34.0
 celery>=5.3.4
-redis>=5.0.1
+redis>=5.0.1  # Standard Python client (works with Valkey)
 requests>=2.31.0
 click>=8.1.7
 urllib3>=2.1.0

--- a/tests/suites/e2e/test_complete_flow.py
+++ b/tests/suites/e2e/test_complete_flow.py
@@ -15,7 +15,7 @@ Environment Variables:
   - E2E_NISE_STATIC_REPORT: Path to custom NISE static report file
   - E2E_CLEANUP_BEFORE=true/false: Run cleanup before tests (default: true)
   - E2E_CLEANUP_AFTER=true/false: Run cleanup after tests (default: true)
-  - E2E_RESTART_SERVICES=true: Restart Redis/listener during cleanup (slower but thorough)
+  - E2E_RESTART_SERVICES=true: Restart Valkey/listener during cleanup (slower but thorough)
 """
 
 import os
@@ -428,7 +428,7 @@ class TestCompleteDataFlow:
         Cleanup includes:
           - S3 data files from previous runs
           - Database processing records
-          - Optionally Redis cache and listener restart (if E2E_RESTART_SERVICES=1)
+          - Optionally Valkey cache and listener restart (if E2E_RESTART_SERVICES=1)
         """
         from utils import exec_in_pod, get_pod_by_label
         import json


### PR DESCRIPTION
## Summary

Systematically replaces all Redis terminology with Valkey throughout the Helm chart, documentation, and test scripts for consistency with our Valkey cache implementation.

This addresses **TASK-010** from [CHART_IMPROVEMENTS.md](https://issues.redhat.com/secure/attachment/13597912/CHART_IMPROVEMENTS.md).

---

## Changes

### 1. Helm Chart Updates (5 files)

**Helper Functions Renamed:**
- `cost-onprem.koku.redis.host` → `cost-onprem.koku.valkey.host`
- `cost-onprem.koku.redis.port` → `cost-onprem.koku.valkey.port`

**Comments Updated:**
- All template comments now reference "Valkey" instead of "Redis"
- Removed unnecessary "Redis-compatible" disclaimers

**Files:**
- `cost-onprem/templates/_helpers-koku.tpl`
- `cost-onprem/templates/_helpers-init-containers.tpl`
- `cost-onprem/templates/cost-management/masu/deployment.yaml`
- `cost-onprem/templates/cost-management/masu/deployment-listener.yaml`
- `cost-onprem/templates/sources-api/deployment.yaml`

### 2. Documentation Updates (4 files)

**Updated References:**
- README.md: Architecture description
- docs/troubleshooting.md: Cache clearing instructions
- CLAUDE.md, .cursor/rules/testing.mdc, .cursor/prompts/run-tests.md: Testing documentation

**Example:**
```bash
# Before:
REDIS_POD=$(kubectl get pod ...)
# After:
VALKEY_POD=$(kubectl get pod ...)
```

### 3. Test Scripts & E2E Validators (5 files)

**Function Renames:**
- `restart_redis()` → `restart_valkey()`

**Variable Renames:**
- `redis_ok` → `valkey_ok`
- `redis_result` → `valkey_result`

**Output Messages:**
- `REDIS_CONNECTED=True` → `VALKEY_CONNECTED=True`
- `REDIS_ERROR` → `VALKEY_ERROR`

**Files:**
- `tests/cleanup.py`
- `tests/suites/e2e/test_complete_flow.py`
- `scripts/e2e_validator/clients/celery_client.py`
- `scripts/e2e_validator/phases/data_upload.py`
- `scripts/e2e_validator/phases/deployment_validation.py`

### 4. Configuration (2 files)

- `cost-onprem/values.yaml`: Updated infrastructure comment
- `scripts/requirements-e2e.txt`: Simplified package comment

---

## What Was NOT Changed (Application Requirements)

The following remain unchanged because they are **required by the application code** (Koku, Sources API):

### Environment Variable Names:
```yaml
REDIS_HOST=cost-onprem-valkey  # Name stays REDIS_HOST
REDIS_PORT=6379                # Name stays REDIS_PORT
```
**Reason:** Koku's `settings.py` explicitly reads `REDIS_HOST` and `REDIS_PORT`

### Python Package:
```python
redis>=5.0.1  # Package name stays 'redis'
```
**Reason:** Koku imports `redis` package (not `valkey`)

### Protocol URL:
```python
redis://valkey:6379/0  # Protocol stays 'redis://'
```
**Reason:** Celery/Django require this protocol format

These are **not backward compatibility concerns** (no existing deployments) - they are current application requirements we cannot change without modifying upstream application code.

---

## Validation

### ✅ Helm Lint
```bash
helm lint cost-onprem/
# Result: 1 chart(s) linted, 0 chart(s) failed
```

### ✅ E2E Test Suite 1: Cost Management OCP Dataflow
**Duration:** 7m 7s  
**Result:** ✅ PASSED

All 7 phases passed:
- Preflight checks
- Database migrations
- Kafka validation
- Provider setup
- Data upload
- Data processing
- Validation

### ✅ E2E Test Suite 2: JWT Authentication Dataflow
**Duration:** 3m 36s  
**Result:** ✅ PASSED

Complete pipeline validated:
- JWT token generation (Keycloak)
- Authenticated upload (Envoy)
- Data processing (Koku → Kafka → ROS)
- Kruize recommendations generated

### ✅ Valkey Pod Verification
```bash
NAME: cost-onprem-valkey-6b4596674c-vnn2k
STATUS: Running
IMAGE: registry.redhat.io/rhel10/valkey-8:latest
```

**Environment variables correctly set:**
```
REDIS_HOST=cost-onprem-valkey
REDIS_PORT=6379
```

---

## Deployment Impact

**Non-breaking change:**
- Pure terminology update
- No functional changes to cache behavior
- Applications continue using same environment variables and protocols
- Existing deployments (if any) will continue to work

---

## Files Changed

**Total:** 18 files, 52 insertions, 50 deletions

**Breakdown:**
- 5 Helm templates
- 4 documentation files
- 5 test/validator Python files
- 3 Cursor rules/prompts
- 1 values.yaml

---

## Related

- **Jira:** [FLPATH-3050](https://issues.redhat.com/browse/FLPATH-3050)
- **Task:** TASK-010 from [CHART_IMPROVEMENTS.md](https://issues.redhat.com/secure/attachment/13597912/CHART_IMPROVEMENTS.md)
- **Severity:** MEDIUM (Code Quality)
- **Effort:** S (Small)
- **Category:** Terminology consistency
