### PR TITLE
Fix cleanup process and environment variable support

### DIFF
--- a/tests/suites/cost_management/conftest.py
+++ b/tests/suites/cost_management/conftest.py
@@ -96,7 +96,7 @@ def cleanup_old_cost_val_clusters(namespace: str, db_pod: str, listener_pod: str
             "DELETE FROM reporting_common_costusagereportmanifest WHERE cluster_id LIKE 'cost-val-%'"
         )
         
-        # Get all schemas and clean summary tables
+        # Get all schemas and clean summary tables + tenant provider mappings
         schemas = execute_db_query(
             namespace, db_pod, "koku", "koku",
             "SELECT DISTINCT schema_name FROM api_customer WHERE schema_name IS NOT NULL"
@@ -113,6 +113,30 @@ def cleanup_old_cost_val_clusters(namespace: str, db_pod: str, listener_pod: str
                         )
                     except Exception:
                         pass  # Table might not exist in all schemas
+                    
+                    # Delete tenant-provider mappings (FK constraint on api_provider)
+                    try:
+                        execute_db_query(
+                            namespace, db_pod, "koku", "koku",
+                            f"""
+                            DELETE FROM {schema}.reporting_tenant_api_provider 
+                            WHERE provider_id IN (
+                                SELECT uuid FROM public.api_provider 
+                                WHERE name LIKE 'cost-validation%'
+                            )
+                            """
+                        )
+                    except Exception:
+                        pass  # Table might not exist in all schemas
+        
+        # Delete providers (after FK references are removed)
+        try:
+            execute_db_query(
+                namespace, db_pod, "koku", "koku",
+                "DELETE FROM public.api_provider WHERE name LIKE 'cost-validation%'"
+            )
+        except Exception:
+            pass  # May fail if no matching providers
                         
     except Exception as e:
         print(f"       Warning: Could not clean database records: {e}")
@@ -155,8 +179,16 @@ def cost_validation_data(cluster_config, s3_config, jwt_token, ingress_url, org_
     3. Uploads data via JWT-authenticated ingress
     4. Waits for Koku to process and populate summary tables
     5. Yields the test context
-    6. Cleans up all test data on teardown
+    6. Cleans up all test data on teardown (if E2E_CLEANUP_AFTER=true)
+    
+    Environment Variables:
+    - E2E_CLEANUP_BEFORE: Run cleanup before tests (default: true)
+    - E2E_CLEANUP_AFTER: Run cleanup after tests (default: true)
     """
+    # Check cleanup settings
+    cleanup_before = os.environ.get("E2E_CLEANUP_BEFORE", "true").lower() == "true"
+    cleanup_after = os.environ.get("E2E_CLEANUP_AFTER", "true").lower() == "true"
+    
     # Check NISE availability
     if not ensure_nise_available():
         pytest.skip("NISE not available and could not be installed")
@@ -187,11 +219,16 @@ def cost_validation_data(cluster_config, s3_config, jwt_token, ingress_url, org_
         print("COST VALIDATION TEST SETUP (Self-Contained)")
         print(f"{'='*60}")
         print(f"  Cluster ID: {cluster_id}")
+        print(f"  Cleanup before: {cleanup_before}")
+        print(f"  Cleanup after: {cleanup_after}")
         
         # Pre-test cleanup: Remove any leftover cost-val clusters from previous runs
-        print("\n  [0/5] Pre-test cleanup...")
-        cleanup_old_cost_val_clusters(cluster_config.namespace, db_pod, listener_pod, sources_url, org_id)
-        print("       Cleanup complete")
+        if cleanup_before:
+            print("\n  [0/5] Pre-test cleanup...")
+            cleanup_old_cost_val_clusters(cluster_config.namespace, db_pod, listener_pod, sources_url, org_id)
+            print("       Cleanup complete")
+        else:
+            print("\n  [0/5] Pre-test cleanup SKIPPED (E2E_CLEANUP_BEFORE=false)")
         
         # Step 1: Generate NISE data
         # Use 2 days ago to yesterday to get exactly 24 hours of data
@@ -295,29 +332,37 @@ def cost_validation_data(cluster_config, s3_config, jwt_token, ingress_url, org_
         }
         
     finally:
-        # Cleanup
+        # Cleanup (only if enabled)
         print(f"\n{'='*60}")
-        print("COST VALIDATION TEST CLEANUP")
-        print(f"{'='*60}")
+        if cleanup_after:
+            print("COST VALIDATION TEST CLEANUP")
+            print(f"{'='*60}")
+            
+            if source_registration:
+                if delete_source(
+                    cluster_config.namespace,
+                    listener_pod,
+                    sources_url,
+                    source_registration.source_id,
+                    org_id,
+                ):
+                    print(f"  Deleted source {source_registration.source_id}")
+                else:
+                    print(f"  Warning: Could not delete source {source_registration.source_id}")
+            
+            if db_pod:
+                if cleanup_database_records(cluster_config.namespace, db_pod, cluster_id):
+                    print("  Cleaned up database records")
+                else:
+                    print("  Warning: Could not clean database records")
+        else:
+            print("COST VALIDATION TEST CLEANUP SKIPPED (E2E_CLEANUP_AFTER=false)")
+            print(f"{'='*60}")
+            print(f"  Data preserved for cluster: {cluster_id}")
+            if source_registration:
+                print(f"  Source ID: {source_registration.source_id}")
         
-        if source_registration:
-            if delete_source(
-                cluster_config.namespace,
-                listener_pod,
-                sources_url,
-                source_registration.source_id,
-                org_id,
-            ):
-                print(f"  Deleted source {source_registration.source_id}")
-            else:
-                print(f"  Warning: Could not delete source {source_registration.source_id}")
-        
-        if db_pod:
-            if cleanup_database_records(cluster_config.namespace, db_pod, cluster_id):
-                print("  Cleaned up database records")
-            else:
-                print("  Warning: Could not clean database records")
-        
+        # Always clean up temp directory (local files only)
         if temp_dir and os.path.exists(temp_dir):
             shutil.rmtree(temp_dir, ignore_errors=True)
             print("  Cleaned up temp directory")

--- a/tests/suites/e2e/test_complete_flow.py
+++ b/tests/suites/e2e/test_complete_flow.py
@@ -617,36 +617,43 @@ class TestCompleteDataFlow:
             "s3_config_dict": s3_config_dict,
         }
         
-        # Post-test cleanup
-        print("\n" + "=" * 60)
-        print("POST-TEST CLEANUP")
-        print("=" * 60)
-        
-        # Delete the source
-        print("  🗑️  Deleting test source...")
-        exec_in_pod(
-            cluster_config.namespace,
-            listener_pod,
-            [
-                "curl", "-s", "-X", "DELETE",
-                f"{sources_api_url}/sources/{source_id}",
-                "-H", f"x-rh-sources-org-id: {org_id}",
-            ],
-            container="sources-listener",
-        )
-        print(f"     ✅ Deleted source {source_id}")
-        
-        # Full cleanup if enabled
-        if cleanup_after and db_pod:
-            full_cleanup(
-                namespace=cluster_config.namespace,
-                db_pod=db_pod,
-                org_id=org_id,
-                s3_config=s3_config_dict,
-                cluster_id=e2e_cluster_id,  # Only clean this test's cluster
-                restart_services=False,  # Don't restart services after tests
-                verbose=True,
+        # Post-test cleanup (only if enabled)
+        if cleanup_after:
+            print("\n" + "=" * 60)
+            print("POST-TEST CLEANUP")
+            print("=" * 60)
+            
+            # Delete the source
+            print("  🗑️  Deleting test source...")
+            exec_in_pod(
+                cluster_config.namespace,
+                listener_pod,
+                [
+                    "curl", "-s", "-X", "DELETE",
+                    f"{sources_api_url}/sources/{source_id}",
+                    "-H", f"x-rh-sources-org-id: {org_id}",
+                ],
+                container="sources-listener",
             )
+            print(f"     ✅ Deleted source {source_id}")
+            
+            # Full cleanup
+            if db_pod:
+                full_cleanup(
+                    namespace=cluster_config.namespace,
+                    db_pod=db_pod,
+                    org_id=org_id,
+                    s3_config=s3_config_dict,
+                    cluster_id=e2e_cluster_id,  # Only clean this test's cluster
+                    restart_services=False,  # Don't restart services after tests
+                    verbose=True,
+                )
+        else:
+            print("\n" + "=" * 60)
+            print("POST-TEST CLEANUP SKIPPED (E2E_CLEANUP_AFTER=false)")
+            print("=" * 60)
+            print(f"  Data preserved for cluster: {e2e_cluster_id}")
+            print(f"  Source ID: {source_id}")
 
     # =========================================================================
     # Test Steps - Ordered to validate the complete pipeline


### PR DESCRIPTION
**Summary:**

1. **`tests/suites/cost_management/conftest.py`**
   - Pre-test cleanup respects `E2E_CLEANUP_BEFORE`
   - Post-test cleanup respects `E2E_CLEANUP_AFTER`
   - Added FK cascade handling for `reporting_tenant_api_provider`

2. **`tests/suites/e2e/test_complete_flow.py`**
   - Post-test cleanup (source deletion + full cleanup) respects `E2E_CLEANUP_AFTER`

Tests pass and UI shows data.
UI (I have not analyzed if this is correctly displayed data, but it's no longer empty after a test runs without cleanup):
<img width="1898" height="960" alt="Screenshot 2026-01-29 at 2 42 14 PM" src="https://github.com/user-attachments/assets/ead93747-2bed-4f71-a613-8e56bdbcff90" />


| Run | `E2E_CLEANUP_AFTER` | Result | Data After |
|-----|---------------------|--------|------------|
| **Run 1** | `true` (default) | 12 passed | **Cleaned** (0 rows) |
| **Run 2** | `false` | 12 passed | **Preserved** (source, provider, summary data) |

The cleanup environment variables should work correctly.
