### PR TITLE
Fix: ROS image to latest

### DIFF
--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -49,7 +49,7 @@ ros:
   # use the same image
   image:
     repository: quay.io/insights-onprem/ros-ocp-backend
-    tag: "sources"
+    tag: "latest"
     pullPolicy: Always
 
   # Service Account


### PR DESCRIPTION
## Summary

Updates the ROS image tag to use the latest version.

## Changes

- `cost-onprem/values.yaml`: Changed `ros.image.tag` from `"sources"` to `"latest"`