### PR TITLE
Gate cloud-only celery workers on cloudProviderSupported, move to clo…

### DIFF
--- a/cost-onprem/templates/_helpers-koku.tpl
+++ b/cost-onprem/templates/_helpers-koku.tpl
@@ -55,6 +55,15 @@ Usage: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type"
 {{- end -}}
 
 {{/*
+Cloud provider support (AWS, Azure, GCP). When false, cloud-only celery workers
+(download, refresh, hcs, subs*) are not deployed. Hard-coded until cloud support
+is introduced (FLPATH-3098).
+*/}}
+{{- define "cost-onprem.koku.cloudProviderSupported" -}}
+false
+{{- end -}}
+
+{{/*
 =============================================================================
 Internal Port Constants
 =============================================================================

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-download-penalty.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-download-penalty.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "hcs") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "download-penalty") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "hcs") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-penalty") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.hcs.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.downloadPenalty.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "hcs") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "download-penalty") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "hcs") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-penalty") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.hcs.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.downloadPenalty.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.hcs.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.downloadPenalty.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,4 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-download-xl.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-download-xl.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "subs-extraction") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "download-xl") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-extraction") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-xl") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.subsExtraction.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.downloadXl.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "subs-extraction") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "download-xl") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-extraction") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-xl") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.subsExtraction.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.downloadXl.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.subsExtraction.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.downloadXl.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,5 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-download.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-download.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "refresh-penalty") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "download") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-penalty") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.refreshPenalty.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.download.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "refresh-penalty") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "download") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-penalty") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.refreshPenalty.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.download.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.refreshPenalty.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.download.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,4 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-hcs.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-hcs.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "refresh-xl") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "hcs") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-xl") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "hcs") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.refreshXl.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.hcs.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "refresh-xl") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "hcs") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-xl") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "hcs") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.refreshXl.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.hcs.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.refreshXl.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.hcs.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,4 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-refresh-penalty.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-refresh-penalty.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "subs-transmission") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "refresh-penalty") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-transmission") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-penalty") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.subsTransmission.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.refreshPenalty.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "subs-transmission") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "refresh-penalty") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-transmission") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-penalty") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.subsTransmission.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.refreshPenalty.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.subsTransmission.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.refreshPenalty.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,5 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-refresh-xl.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-refresh-xl.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "download-xl") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "refresh-xl") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-xl") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-xl") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.downloadXl.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.refreshXl.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "download-xl") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "refresh-xl") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-xl") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "refresh-xl") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.downloadXl.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.refreshXl.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.downloadXl.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.refreshXl.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,4 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-refresh.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-refresh.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,4 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-subs-extraction.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-subs-extraction.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "download") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "subs-extraction") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-extraction") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.download.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.subsExtraction.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "download") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "subs-extraction") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-extraction") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.download.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.subsExtraction.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.download.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.subsExtraction.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,4 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
+{{- end }}

--- a/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-subs-transmission.yaml
+++ b/cost-onprem/templates/cost-management/celery/cloud-providers/deployment-worker-subs-transmission.yaml
@@ -1,19 +1,20 @@
+{{- if eq (include "cost-onprem.koku.cloudProviderSupported" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "download-penalty") }}
+  name: {{ include "cost-onprem.koku.celery.worker.name" (dict "context" . "type" "subs-transmission") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-penalty") | nindent 4 }}
+    {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-transmission") | nindent 4 }}
 spec:
-  replicas: {{ .Values.costManagement.celery.workers.downloadPenalty.replicas }}
+  replicas: {{ .Values.costManagement.celery.workers.subsTransmission.replicas }}
   selector:
     matchLabels:
-      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "download-penalty") | nindent 6 }}
+      {{- include "cost-onprem.koku.celery.worker.selectorLabels" (dict "context" . "type" "subs-transmission") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "download-penalty") | nindent 8 }}
+        {{- include "cost-onprem.koku.celery.worker.labels" (dict "context" . "type" "subs-transmission") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cost-onprem.koku.serviceAccountName" . }}
       automountServiceAccountToken: false
@@ -41,7 +42,7 @@ spec:
         - name: CELERY_LOG_LEVEL
           value: "info"
         - name: WORKER_QUEUES
-          value: {{ .Values.costManagement.celery.workers.downloadPenalty.queue | quote }}
+          value: {{ .Values.costManagement.celery.workers.subsTransmission.queue | quote }}
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
         {{- range $key, $value := .Values.costManagement.celery.workers.commonEnv }}
         - name: {{ $key }}
@@ -49,7 +50,7 @@ spec:
         {{- end }}
 
         resources:
-          {{- toYaml .Values.costManagement.celery.workers.downloadPenalty.resources | nindent 10 }}
+          {{- toYaml .Values.costManagement.celery.workers.subsTransmission.resources | nindent 10 }}
 
         volumeMounts:
         {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
@@ -59,4 +60,4 @@ spec:
 
       volumes:
       {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
-
+{{- end }}


### PR DESCRIPTION
…ud-providers/

- Add cost-onprem.koku.cloudProviderSupported helper (hard-coded false) in _helpers-koku.tpl; cloud-only workers deploy only when true (FLPATH-3098)
- Move 9 cloud-only worker deployments into celery/cloud-providers/: refresh, refreshXl, refreshPenalty, download, downloadXl, downloadPenalty, hcs, subsExtraction, subsTransmission
- OCP/supported workers remain in celery/ root

Resource impact: Celery workers before 24 pods / 2.4 cores / 6.5 Gi
→ after (default) 15 pods / 1.5 cores / 3.7 Gi. Saves 9 pods, ~0.9 cores,
~2.8 Gi memory when cloud providers are not enabled.

- Update docs/operations/resource-requirements.md for gated workers and
  default OCP-only footprint.
