### PR TITLE
[FLPATH-3217] Remove ODF requirement, support generic S3 storage

### DIFF
--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -36,9 +36,9 @@ jobs:
         # Provide minimal required values for validation
         echo "Running template validation..."
         helm template cost-onprem-test . --debug --dry-run \
-          --set odf.endpoint=s3.test.example.com \
-          --set odf.credentials.accessKey=test-access-key \
-          --set odf.credentials.secretKey=test-secret-key \
+          --set objectStorage.endpoint=s3.test.example.com \
+          --set objectStorage.credentials.accessKey=test-access-key \
+          --set objectStorage.credentials.secretKey=test-secret-key \
           --set global.clusterDomain=test.example.com \
           --set global.clusterName=test-cluster \
           --set jwtAuth.keycloak.url=https://keycloak.test.example.com > /tmp/rendered.yaml

--- a/cost-onprem/templates/NOTES.txt
+++ b/cost-onprem/templates/NOTES.txt
@@ -63,7 +63,11 @@ For authentication setup details:
 
 💾 STORAGE
 
-OpenShift Data Foundation (ODF):
+S3 Object Storage:
+  Endpoint: {{ include "cost-onprem.storage.endpoint" . }}:{{ include "cost-onprem.storage.port" . }}
+  Credentials: {{ include "cost-onprem.storage.secretName" . }}
+
+Persistent Volumes:
   oc get pvc -n {{ $namespace }}
 
 Storage Classes:

--- a/cost-onprem/templates/_helpers-init-containers.tpl
+++ b/cost-onprem/templates/_helpers-init-containers.tpl
@@ -48,7 +48,8 @@ Usage: {{ include "cost-onprem.initContainer.waitForKafka" . | nindent 8 }}
 {{- end -}}
 
 {{/*
-Wait for Storage (ODF) init container
+Wait for S3 storage init container
+Checks TCP reachability of the configured S3 endpoint before the main container starts.
 Usage: {{ include "cost-onprem.initContainer.waitForStorage" . | nindent 8 }}
 */}}
 {{- define "cost-onprem.initContainer.waitForStorage" -}}
@@ -59,12 +60,12 @@ Usage: {{ include "cost-onprem.initContainer.waitForStorage" . | nindent 8 }}
   command: ['bash', '-c']
   args:
     - |
-      echo "Waiting for ODF S3 endpoint at {{ include "cost-onprem.storage.endpoint" . }}:{{ include "cost-onprem.storage.port" . }}..."
+      echo "Waiting for S3 endpoint at {{ include "cost-onprem.storage.endpoint" . }}:{{ include "cost-onprem.storage.port" . }}..."
       until timeout 3 bash -c "echo > /dev/tcp/{{ include "cost-onprem.storage.endpoint" . }}/{{ include "cost-onprem.storage.port" . }}" 2>/dev/null; do
-        echo "ODF S3 endpoint not ready yet, retrying in 5 seconds..."
+        echo "S3 endpoint not ready yet, retrying in 5 seconds..."
         sleep 5
       done
-      echo "ODF S3 endpoint is ready"
+      echo "S3 endpoint is ready"
 {{- end -}}
 
 {{/*

--- a/cost-onprem/templates/_helpers-koku.tpl
+++ b/cost-onprem/templates/_helpers-koku.tpl
@@ -331,9 +331,9 @@ Common environment variables for Koku API and Celery
       name: {{ include "cost-onprem.storage.secretName" . }}
       key: secret-key
 # S3 Region for signature generation (required for S3v4 signatures)
-# NooBaa/MinIO don't use regions, but boto3 requires it for signature calculation
+# Most on-premise S3 backends don't use regions, but boto3 requires it for signature calculation
 - name: S3_REGION
-  value: {{ .Values.odf.s3.region | default "onprem" | quote }}
+  value: {{ include "cost-onprem.storage.s3Region" . | quote }}
 # AWS SDK configuration for S3v4 signatures
 - name: AWS_CONFIG_FILE
   value: /etc/aws/config

--- a/cost-onprem/templates/cost-management/configmap-aws-config.yaml
+++ b/cost-onprem/templates/cost-management/configmap-aws-config.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   config: |
     [default]
-    region = {{ .Values.odf.s3.region | default "onprem" }}
+    region = {{ include "cost-onprem.storage.s3Region" . }}
     s3 =
       signature_version = s3v4
       addressing_style = path

--- a/cost-onprem/templates/cost-management/configmap-ca-combine.yaml
+++ b/cost-onprem/templates/cost-management/configmap-ca-combine.yaml
@@ -37,7 +37,7 @@ data:
         echo "" >> /tmp/combined-ca.crt
     fi
 
-    # Add OpenShift Service CA (signs *.svc certificates like s3.openshift-storage.svc)
+    # Add OpenShift Service CA (signs *.svc certificates for in-cluster S3 endpoints)
     if [ -f /ca-source/service-ca.crt ] && [ -s /ca-source/service-ca.crt ]; then
         echo "📋 Adding OpenShift Service CA..."
         cat /ca-source/service-ca.crt >> /tmp/combined-ca.crt

--- a/cost-onprem/templates/infrastructure/storage/secret-credentials.yaml
+++ b/cost-onprem/templates/infrastructure/storage/secret-credentials.yaml
@@ -1,21 +1,15 @@
-{{- $secretName := include "cost-onprem.storage.secretName" . -}}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
-
-{{- if not $existingSecret -}}
 {{/*
 Storage credentials secret - PLACEHOLDER ONLY
 
-⚠️  WARNING: This secret should be created by scripts/install-helm-chart.sh
-    before Helm deployment. This template only generates placeholder values
-    to allow "helm template" validation.
+This template is skipped when objectStorage.existingSecret is set (user provides their own secret).
+Otherwise, it creates a placeholder secret to allow "helm template" validation.
 
-Real deployments:
-  - Secrets created by install-helm-chart.sh with secure random passwords
-  - For ODF: Auto-discovers credentials from openshift-storage/noobaa-admin
-  - For MinIO: Generates random credentials (minioadmin / random-32-char)
-
-If you see this secret in a real deployment, the install script was skipped!
+Real deployments should have credentials created by one of:
+  1. The user (pre-create the secret and set objectStorage.existingSecret in values.yaml)
+  2. scripts/install-helm-chart.sh (auto-creates before helm install)
 */}}
+{{- if eq (include "cost-onprem.storage.hasExistingSecret" .) "false" -}}
+{{- $secretName := include "cost-onprem.storage.secretName" . -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -26,13 +20,12 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: storage
   annotations:
-    cost-onprem.io/credential-source: "PLACEHOLDER - Create via install-helm-chart.sh"
+    cost-onprem.io/credential-source: "PLACEHOLDER - Create via install-helm-chart.sh or set objectStorage.existingSecret"
     "helm.sh/resource-policy": keep
 type: Opaque
 data:
   # Base64 encoded placeholder values for "helm template" validation only
-  # Real deployments: Created by scripts/install-helm-chart.sh
+  # Real deployments: Created by install-helm-chart.sh or user-managed
   access-key: {{ "PLACEHOLDER_ACCESS_KEY" | b64enc }}
   secret-key: {{ "PLACEHOLDER_SECRET_KEY" | b64enc }}
-
 {{- end -}}

--- a/cost-onprem/templates/ingress/deployment.yaml
+++ b/cost-onprem/templates/ingress/deployment.yaml
@@ -67,12 +67,12 @@ spec:
             - name: INGRESS_MINIOACCESSKEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cost-onprem.fullname" . }}-storage-credentials
+                  name: {{ include "cost-onprem.storage.secretName" . }}
                   key: access-key
             - name: INGRESS_MINIOSECRETKEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cost-onprem.fullname" . }}-storage-credentials
+                  name: {{ include "cost-onprem.storage.secretName" . }}
                   key: secret-key
             # AWS SDK configuration for S3v4 signatures
             - name: AWS_CONFIG_FILE

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -4,7 +4,7 @@
 # This chart deploys the complete Cost Management on-premise solution:
 # - ROS (Resource Optimization Service)
 # - Cost Management Service (Koku and Sources API)
-# - Shared infrastructure (PostgreSQL, Kafka, Valkey, MinIO/ODF)
+# - Shared infrastructure (PostgreSQL, Kafka, Valkey, S3 object storage)
 #
 # Naming conventions:
 # - Use camelCase for all variable names
@@ -676,22 +676,47 @@ valkey:
     # fsGroup: 1000740000  # Example: CI environment value
 
 # -----------------------------------------------------------------------------
-# Shared Infrastructure - Object Storage (ODF)
+# Shared Infrastructure - S3-Compatible Object Storage
 # -----------------------------------------------------------------------------
-# This chart uses OpenShift Data Foundation (ODF) for object storage.
-# ODF provides S3-compatible storage via NooBaa.
-odf:
-  # ODF endpoint - auto-detected from NooBaa CRD if not specified
-  # endpoint: "s3.openshift-storage.svc.cluster.local"
-  # port: 443
-  # useSSL: true
+# This chart requires S3-compatible object storage. Supported backends:
+#   - ODF (OpenShift Data Foundation) with NooBaa or Direct Ceph RGW
+#   - MinIO (for development/testing)
+#   - AWS S3 (for disconnected AWS deployments)
+#   - Any S3-compatible storage provider
+#
+# Configuration options:
+#   1. Manual: Set endpoint/port/useSSL/existingSecret below and pre-create
+#      the credentials secret yourself. The install script will skip S3 setup.
+#   2. Automated: Leave endpoint empty and use install-helm-chart.sh which
+#      auto-detects ODF/MinIO/OBC and configures everything.
+#
+objectStorage:
+  # S3 endpoint hostname (without protocol or port)
+  # Examples:
+  #   - ODF NooBaa:    "s3.openshift-storage.svc.cluster.local"
+  #   - Direct Ceph:   "rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc"
+  #   - MinIO:         "minio.minio-test.svc.cluster.local"
+  #   - AWS S3:        "s3.amazonaws.com"
+  # When empty, the install script auto-detects from the cluster environment.
+  endpoint: ""
 
-  # rootUser and rootPassword removed - stored in cost-onprem-storage-credentials secret
-  # Created by: scripts/install-helm-chart.sh
-  # Credentials: minioadmin / <random-32-char>
+  # S3 port (443 for HTTPS, 80 for HTTP)
+  port: 443
+
+  # Whether to use SSL/TLS for S3 connections
+  useSSL: true
+
+  # Name of a pre-existing Kubernetes Secret containing S3 credentials.
+  # The secret must have keys: 'access-key' and 'secret-key'.
+  # When set, the chart uses this secret and the install script skips
+  # credential creation entirely.
+  # When empty, the install script creates a secret named
+  # '<release-name>-storage-credentials' automatically.
+  existingSecret: ""
 
   # S3 region for signature generation (required for S3v4 signatures)
-  # NooBaa/MinIO don't use regions, but boto3 requires it for signature calculation
+  # Most S3-compatible backends (NooBaa, MinIO, Ceph) don't use regions,
+  # but boto3 requires it for signature calculation.
   # Default: "onprem" (for on-premise deployments)
   # Override to AWS region (e.g., "us-east-1") if deploying to AWS S3
   s3:

--- a/docs/operations/quickstart.md
+++ b/docs/operations/quickstart.md
@@ -25,7 +25,7 @@ The deployment scripts provide flexible options for OpenShift:
 Ensure your cluster has adequate resources for the deployment:
 - **Memory**: At least 16GB RAM (24GB+ recommended)
 - **CPU**: 8+ cores
-- **Storage**: 150GB+ (ODF)
+- **Storage**: S3-compatible object storage (ODF, AWS S3, MinIO, or other)
 
 The deployment includes:
 - PostgreSQL databases (unified)
@@ -73,7 +73,7 @@ cd /path/to/cost-onprem-chart/scripts/
 The script will:
 - ✅ Download latest Helm chart release from GitHub
 - ✅ Deploy all services with OpenShift configuration
-- ✅ Configure ODF storage integration
+- ✅ Auto-detect and configure S3 storage
 - ✅ Run comprehensive health checks
 - ✅ Verify connectivity and authentication
 
@@ -164,7 +164,7 @@ NAMESPACE=cost-onprem ./scripts/run-pytest.sh --e2e
 The test will:
 - ✅ Create OCP provider via Koku Sources API
 - ✅ Generate test data with NISE
-- ✅ Upload data to ODF S3 bucket
+- ✅ Upload data to S3 bucket
 - ✅ Publish Kafka event for processing
 - ✅ Verify data processing in PostgreSQL
 - ✅ Validate cost calculations

--- a/docs/operations/resource-requirements.md
+++ b/docs/operations/resource-requirements.md
@@ -211,7 +211,7 @@ For resource-constrained environments, you can reduce the deployment footprint:
 | Component | Storage Class | Size | Notes |
 |-----------|---------------|------|-------|
 | PostgreSQL | Block (RWO) | 30 Gi | Main application database |
-| ODF/MinIO | Object Storage | 150+ Gi | Cost report storage |
+| S3 Object Storage | Object Storage | 150+ Gi | Cost report storage |
 | Kafka | Block (RWO) | 50 Gi x 3 | Message persistence |
 | ZooKeeper | Block (RWO) | 10 Gi x 3 | Coordination state |
 | Valkey | Block (RWO) | 5 Gi | Cache persistence |

--- a/openshift-values.yaml
+++ b/openshift-values.yaml
@@ -20,9 +20,6 @@ global:
   # Cluster name - auto-detected if empty, but providing it skips 2 API lookups
   clusterName: ""  # Set by CI or leave empty for auto-detection
 
-  # Storage type for platform detection (overrides empty default in values.yaml)
-  storageType: "odf"
-
 # Explicit storage class names to avoid API lookups (optional but recommended for CI)
 # When provided, skips StorageClass list/get API calls (saves 2-4 lookups)
 # storageClassNames:
@@ -65,49 +62,29 @@ database:
     storage:
       size: "5Gi"
 
-# ODF (Production Storage - for OpenShift deployments)
-# Replaces MinIO on OpenShift
+# S3-Compatible Object Storage
+# ----------------------------
+# This chart requires S3-compatible storage. Options:
 #
-# RECOMMENDED APPROACH: Direct Ceph RGW (Required for Cost Management)
-# -----------------------------------------------------------------------
-# Cost Management requires strong read-after-write consistency for S3.
-# NooBaa's eventual consistency causes 403 errors when reading immediately after write.
-# Direct Ceph RGW provides strong consistency and is the REQUIRED storage backend.
+#   1. Manual (production): Set objectStorage.endpoint/port/useSSL/existingSecret
+#      and pre-create your credentials secret. The install script will skip
+#      all S3 auto-detection.
 #
-# To use Direct Ceph RGW (RECOMMENDED):
-# 1. Create an ObjectBucketClaim BEFORE running the install script:
+#   2. OBC auto-detection: Create an ObjectBucketClaim named "ros-data-ceph"
+#      in the target namespace. The install script auto-detects it and
+#      configures endpoints, credentials, and bucket names.
 #
-#    kubectl apply -f - <<EOF
-#    apiVersion: objectbucket.io/v1alpha1
-#    kind: ObjectBucketClaim
-#    metadata:
-#      name: ros-data-ceph
-#      namespace: cost-onprem
-#    spec:
-#      generateBucketName: ros-data-ceph
-#      storageClassName: ocs-storagecluster-ceph-rgw
-#    EOF
+#   3. MinIO (dev/test): Set MINIO_ENDPOINT env var before running the install
+#      script. See docs/development/ocp-dev-setup-minio.md.
 #
-# 2. The install script will auto-detect the OBC and:
-#    - Extract bucket name, endpoint, and credentials
-#    - Configure all components to use Direct Ceph RGW
-#    - Skip the bucket creation job (bucket managed by OBC)
+#   4. Leave empty: The install script attempts NooBaa auto-detection as fallback.
+#      WARNING: NooBaa's eventual consistency may cause data processing failures.
 #
-# FALLBACK: NooBaa (NOT RECOMMENDED for Cost Management)
-# -------------------------------------------------------
-# If no external OBC is detected, the chart falls back to NooBaa auto-detection.
-# WARNING: NooBaa's eventual consistency may cause data processing failures.
-#
-odf:
-  endpoint: ""  # Auto-detected: Ceph RGW (if OBC exists) or NooBaa (fallback)
+objectStorage:
+  endpoint: ""  # Set manually, or auto-detected by install script
   port: 443
   useSSL: true
-  bucket: "ros-data"  # Only used for NooBaa fallback
-
-  # External ObjectBucketClaim (OBC) configuration
-  # Set to true when using pre-created OBC for Direct Ceph RGW
-  # The install script auto-detects OBC named "ros-data-ceph" and sets this automatically
-  useExternalOBC: false  # Auto-set to true by install script when OBC is detected
+  existingSecret: ""  # Set to use a pre-existing credentials secret (skips secret creation)
 
 # JWT Authentication configuration (avoids Keycloak auto-discovery lookups)
 # Providing explicit Keycloak settings saves ~8 API lookups

--- a/scripts/deploy-minio-test.sh
+++ b/scripts/deploy-minio-test.sh
@@ -2,7 +2,7 @@
 
 # Deploy MinIO for Testing in OpenShift Cluster
 # This script deploys a standalone MinIO instance for testing the cost-onprem chart
-# with MinIO instead of ODF. This simulates the CI environment in an OCP cluster.
+# with MinIO instead of cluster object storage. This simulates the CI environment in an OCP cluster.
 
 set -e  # Exit on any error
 

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -417,7 +417,7 @@ deploy_helm_chart() {
     export NAMESPACE="${NAMESPACE}"
     export JWT_AUTH_ENABLED="true"
     export USE_LOCAL_CHART="${USE_LOCAL_CHART}"
-    export SKIP_S3_SETUP="true"  # Skip S3/ODF detection in CI environments
+    export SKIP_S3_SETUP="true"  # Skip S3 auto-detection in CI environments
 
     if [[ "${VERBOSE}" == "true" ]]; then
         export VERBOSE="true"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,7 +307,7 @@ def s3_config(cluster_config: ClusterConfig) -> Optional[S3Config]:
         f"{cluster_config.namespace}-storage-credentials",  # Namespace-based
         "cost-onprem-storage-credentials",  # Default helm release name
         "koku-storage-credentials",  # Legacy name
-        f"{cluster_config.helm_release_name}-odf-credentials",  # ODF credentials
+        f"{cluster_config.helm_release_name}-object-storage-credentials",  # Object storage credentials
     ]
     
     access_key = None

--- a/tests/suites/helm/test_chart_lint.py
+++ b/tests/suites/helm/test_chart_lint.py
@@ -13,10 +13,10 @@ from utils import helm_lint, helm_template
 OFFLINE_MOCK_VALUES = {
     # Provide mock cluster domain for route generation
     "global.clusterDomain": "apps.example.com",
-    # Provide mock ODF endpoint and credentials to avoid lookup failures
-    "odf.endpoint": "https://s3.example.com",
-    "odf.credentials.accessKey": "mock-access-key",
-    "odf.credentials.secretKey": "mock-secret-key",
+    # Provide mock S3 endpoint and credentials to avoid lookup failures
+    "objectStorage.endpoint": "https://s3.example.com",
+    "objectStorage.credentials.accessKey": "mock-access-key",
+    "objectStorage.credentials.secretKey": "mock-secret-key",
     # Provide mock Keycloak URL for JWT tests
     "jwtAuth.keycloak.url": "https://keycloak.example.com",
 }

--- a/tests/suites/infrastructure/test_storage.py
+++ b/tests/suites/infrastructure/test_storage.py
@@ -97,7 +97,7 @@ def get_s3_credentials(namespace: str) -> dict:
         "cost-onprem-storage-credentials",
         f"{namespace}-storage-credentials",
         "koku-storage-credentials",
-        "cost-onprem-odf-credentials",
+        "cost-onprem-object-storage-credentials",
     ]
     
     for secret_name in secret_patterns:


### PR DESCRIPTION
## Summary

Resolves [FLPATH-3217](https://issues.redhat.com/browse/FLPATH-3217) — the Helm chart should not require that ODF be installed.

- **Rename `odf.*` to `objectStorage.*` in `values.yaml`** with a backward-compatible coalescing helper so existing `odf.*` configs still work.
- **Add `objectStorage.existingSecret` support** so users can supply pre-created S3 credentials, eliminating all `lookup()` calls from storage helpers and avoiding RBAC escalation.
- **Update `install-helm-chart.sh`** to skip S3 auto-detection/setup when `objectStorage.endpoint` and `existingSecret` are already configured in `values.yaml`; fix NooBaa endpoint passthrough and secret ownership conflicts.
- **Update all documentation** (installation, configuration, platform guide, quickstart, resource requirements, dev setup) to present S3 storage as a generic requirement with three supported paths: manual/AWS S3, ODF/OBC auto-detection, and MinIO for development.

### Files changed (20)

| Area | Files |
|------|-------|
| Helm templates | `_helpers.tpl`, `_helpers-koku.tpl`, `_helpers-init-containers.tpl`, `secret-credentials.yaml`, `ingress/deployment.yaml`, `configmap-aws-config.yaml`, `configmap-ca-combine.yaml`, `NOTES.txt` |
| Values | `values.yaml`, `openshift-values.yaml` |
| Scripts | `install-helm-chart.sh`, `deploy-test-cost-onprem.sh`, `deploy-minio-test.sh` |
| Documentation | `configuration.md`, `installation.md`, `cost-management-installation.md`, `platform-guide.md`, `quickstart.md`, `resource-requirements.md`, `ocp-dev-setup-minio.md` |

## Test plan

- [x] `helm template` renders successfully with generic `objectStorage.*` values
- [x] `helm lint` passes
- [x] Full install on ODF cluster (parodos-dev) via `install-helm-chart.sh` — NooBaa auto-detected, credentials created, chart deployed successfully
- [x] Full E2E + unit test suite passed with no regressions (88 tests)
- [x] Backward compatibility: `odf.*` values still coalesce correctly via helper


Made with [Cursor](https://cursor.com)