### PR TITLE
[FLPATH-3271] Fix S3 bucket creation in CI after Helm job removal

### DIFF
--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -417,7 +417,7 @@ deploy_helm_chart() {
     export NAMESPACE="${NAMESPACE}"
     export JWT_AUTH_ENABLED="true"
     export USE_LOCAL_CHART="${USE_LOCAL_CHART}"
-    export SKIP_S3_SETUP="true"  # Skip S3 auto-detection in CI environments
+    export SKIP_S3_SETUP="${SKIP_S3_SETUP:-false}"  # Only skip if explicitly set by caller
 
     if [[ "${VERBOSE}" == "true" ]]; then
         export VERBOSE="true"


### PR DESCRIPTION
## Summary

- **Makes `SKIP_S3_SETUP` conditional** instead of hardcoded to `true` in `deploy-test-cost-onprem.sh`
- Fixes regression from PR #89 (FLPATH-3221) which removed the Helm post-install Job (`job-minio-buckets.yaml`) that created S3 buckets, while the deploy script still unconditionally skipped the script-based bucket creation
- With both mechanisms disabled, `koku-bucket` was never created in CI, causing 19 test failures (NoSuchBucket, HTTP 500 on uploads)

## Changes

`SKIP_S3_SETUP` now defaults to `false` (via `${SKIP_S3_SETUP:-false}`), allowing `create_s3_buckets()` in `install-helm-chart.sh` to run and create the required buckets. Callers that manage buckets externally can still set `SKIP_S3_SETUP=true` explicitly.

## Test plan

- [ ] Nightly CI pipeline passes — all 19 previously failing tests recover
- [ ] `test_required_bucket_exists[koku-bucket]` passes
- [ ] `test_03_upload_data_via_ingress` returns 200/202
- [ ] No regressions in the remaining ~144 tests
- [ ] Manual deploy with `SKIP_S3_SETUP=true` still skips bucket creation as expected

Fixes: [FLPATH-3271](https://issues.redhat.com/browse/FLPATH-3271)
Regression from: #89