### PR TITLE
Remove unnecessary hive workarounds from database init

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -19,6 +19,9 @@ jobs:
     name: Validate Chart Version
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout code

--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.13
-appVersion: "0.2.13"
+version: 0.2.14
+appVersion: "0.2.14"
 
 keywords:
   - cost-management

--- a/cost-onprem/templates/cost-management/jobs/migration.yaml
+++ b/cost-onprem/templates/cost-management/jobs/migration.yaml
@@ -39,6 +39,7 @@ spec:
             echo "Timestamp: $(date)"
             echo "Release: {{ .Release.Name }}"
             echo "Namespace: {{ .Release.Namespace }}"
+            echo "ONPREM=${ONPREM:-not set}"
 
             # Wait for database to be ready
             DB_HOST="{{ include "cost-onprem.database.host" . }}"

--- a/cost-onprem/templates/infrastructure/database/configmap-init.yaml
+++ b/cost-onprem/templates/infrastructure/database/configmap-init.yaml
@@ -50,16 +50,11 @@ data:
     END
     \$\$;
 
-    -- Koku User (requires CREATEROLE and CREATEDB for Django migrations)
-    -- CREATEROLE: needed for migrations that create roles like 'hive'
-    -- CREATEDB: needed for migrations that create the 'hive' database
+    -- Koku User
     DO \$\$
     BEGIN
       IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$KOKU_USER') THEN
-        EXECUTE 'CREATE USER $KOKU_USER WITH PASSWORD ' || quote_literal('$KOKU_PASSWORD') || ' CREATEROLE CREATEDB';
-      ELSE
-        -- Ensure privileges are granted if user already exists
-        ALTER USER $KOKU_USER CREATEROLE CREATEDB;
+        EXECUTE 'CREATE USER $KOKU_USER WITH PASSWORD ' || quote_literal('$KOKU_PASSWORD');
       END IF;
     END
     \$\$;
@@ -95,27 +90,7 @@ data:
     GRANT ALL PRIVILEGES ON DATABASE {{ .Values.database.kruize.name }} TO $KRUIZE_USER;
     ALTER DATABASE {{ .Values.database.kruize.name }} OWNER TO $KRUIZE_USER;
 
-    -- ========================================
-    -- Koku Special Configuration
-    -- ========================================
-    -- Koku requires special setup for Trino/Hive integration
-
-    -- Create hive role (used by Trino for table operations)
-    DO \$\$
-    BEGIN
-      IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'hive') THEN
-        CREATE ROLE hive LOGIN;
-      END IF;
-    END
-    \$\$;
-
-    GRANT hive TO $KOKU_USER WITH ADMIN OPTION;
-
-    -- Hive Database (required by Koku migration 0039_create_hive_db)
-    SELECT 'CREATE DATABASE hive OWNER $KOKU_USER'
-    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'hive')
-    \gexec
-
+    -- Koku Database - owned by $KOKU_USER
     GRANT ALL PRIVILEGES ON DATABASE {{ .Values.database.koku.name }} TO $KOKU_USER;
     ALTER DATABASE {{ .Values.database.koku.name }} OWNER TO $KOKU_USER;
 

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -147,7 +147,7 @@ costManagement:
 
     image:
       repository: quay.io/insights-onprem/koku
-      tag: "sources-2"
+      tag: "sources-3"
       pullPolicy: Always
 
     replicas: 1


### PR DESCRIPTION
With the Koku migration now skipping hive creation when ONPREM=True, the database initialization no longer needs to:
- Grant CREATEROLE/CREATEDB privileges to the koku user
- Pre-create the hive role and database

This simplifies the on-prem setup and removes unnecessary privileges.

Requires: project-koku/koku commit that skips migration 0039 for ONPREM
https://github.com/project-koku/koku/pull/5900

Fixes: FLPATH-3265