### PR TITLE
Bump chart version to 0.2.10

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -61,8 +61,9 @@ jobs:
             echo "version=" >> $GITHUB_OUTPUT
             echo "is_first_release=true" >> $GITHUB_OUTPUT
           else
-            # Remove 'v' prefix if present
-            LATEST_VERSION=${LATEST_RELEASE#v}
+            # Remove 'cost-onprem-' or 'v' prefix if present
+            LATEST_VERSION=${LATEST_RELEASE#cost-onprem-}
+            LATEST_VERSION=${LATEST_VERSION#v}
             echo "Latest release version: $LATEST_VERSION"
             echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
             echo "is_first_release=false" >> $GITHUB_OUTPUT

--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.9
-appVersion: "0.2.9"
+version: 0.2.10
+appVersion: "0.2.10"
 
 keywords:
   - cost-management


### PR DESCRIPTION
## Summary
- Bump chart version from 0.2.9 to 0.2.10
- Prepare for release v0.2.10

## Test plan
- [ ] CI passes
- [ ] Chart can be installed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)