### PR TITLE
FLPATH-3371: Fix CMMO parsing error

### DIFF
--- a/cost-onprem/templates/gateway/configmap-envoy.yaml
+++ b/cost-onprem/templates/gateway/configmap-envoy.yaml
@@ -393,29 +393,6 @@ data:
                         end
                       end
 
-              # Compression filter for response optimization
-              - name: envoy.filters.http.compressor
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
-                  response_direction_config:
-                    common_config:
-                      min_content_length: 1024
-                      content_type:
-                      - application/json
-                      - application/javascript
-                      - text/css
-                      - text/html
-                      - text/plain
-                      - text/xml
-                    disable_on_etag_header: true
-                  compressor_library:
-                    name: text_optimized
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
-                      memory_level: 6
-                      window_bits: 12
-                      compression_level: BEST_SPEED
-
               - name: envoy.filters.http.router
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION
[FLPATH-3371](https://issues.redhat.com/browse/FLPATH-3371)
## Motivation

The Cost Management Metrics Operator (CMMO) fails to parse JSON responses from the Koku API with:

```
failed to parse OpenShift source response from Sources API: invalid character '{' after top-level value
```

The Envoy gateway's `envoy.filters.http.compressor` filter strips the `Content-Length` header from proxied responses and switches to `Transfer-Encoding: chunked`. The CMMO's Go HTTP client de-chunks the body transparently but sets `ContentLength = -1`, which causes `httputil.DumpResponse` (used internally by the operator) to re-encode the body in chunked format — prepending hex size markers (e.g., `645\r\n`) to the JSON payload. This breaks `json.Unmarshal`.

## Fix

Remove the gzip compressor filter from the Envoy gateway configuration. Without it, Envoy preserves the upstream `Content-Length` header, and the CMMO parses responses correctly.

The compressor only applied to responses larger than 1024 bytes, so the smaller `/source_types` endpoint (59 bytes) worked fine while the larger `/sources` endpoint (1605 bytes) consistently failed.
