### PR TITLE
Support Kafka SASL/TLS in non-Clowder (on-prem) mode

### DIFF
--- a/cost-onprem/templates/_helpers-koku.tpl
+++ b/cost-onprem/templates/_helpers-koku.tpl
@@ -324,6 +324,9 @@ Common environment variables for Koku API and Celery
   value: {{ include "cost-onprem.koku.kafka.host" . | quote }}
 - name: INSIGHTS_KAFKA_PORT
   value: {{ include "cost-onprem.koku.kafka.port" . | quote }}
+- name: KAFKA_SECURITY_PROTOCOL
+  value: {{ .Values.kafka.security.protocol | quote }}
+{{- include "cost-onprem.kafka.securityEnv" . }}
 - name: S3_ENDPOINT
   value: {{ include "cost-onprem.storage.endpointWithProtocol" . | quote }}
 - name: REQUESTED_BUCKET
@@ -405,6 +408,7 @@ Includes tmp mount and combined CA bundle
 - name: combined-ca-bundle
   mountPath: /etc/pki/ca-trust/combined
   readOnly: true
+{{- include "cost-onprem.kafka.tls.volumeMount" . }}
 {{- end -}}
 
 {{/*
@@ -429,6 +433,7 @@ Includes tmp volume and CA bundle volumes
     name: {{ include "cost-onprem.fullname" . }}-service-ca
 - name: combined-ca-bundle
   emptyDir: {}
+{{- include "cost-onprem.kafka.tls.volume" . }}
 {{- end -}}
 
 {{/*

--- a/cost-onprem/templates/_helpers.tpl
+++ b/cost-onprem/templates/_helpers.tpl
@@ -409,10 +409,88 @@ Kafka bootstrap servers resolver (supports both internal and external Kafka)
 {{- end }}
 
 {{/*
-Kafka security protocol resolver (supports both internal and external Kafka)
+=============================================================================
+Kafka SASL/TLS Helpers
+=============================================================================
+Reusable helpers for Kafka SASL authentication and TLS encryption.
+Used by Koku, ROS, and Ingress components.
+All values live under kafka.security.* in values.yaml.
 */}}
-{{- define "cost-onprem.kafka.securityProtocol" -}}
-{{- .Values.kafka.securityProtocol | default "PLAINTEXT" -}}
+
+{{/*
+Check if Kafka SASL authentication is enabled.
+Returns "true" when kafka.security.sasl.mechanism is set to a non-empty value.
+*/}}
+{{- define "cost-onprem.kafka.sasl.enabled" -}}
+{{- if and .Values.kafka.security.sasl .Values.kafka.security.sasl.mechanism (ne .Values.kafka.security.sasl.mechanism "") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
+Check if Kafka TLS encryption is enabled.
+Returns "true" when kafka.security.tls.caCertSecret is set to a non-empty value.
+*/}}
+{{- define "cost-onprem.kafka.tls.enabled" -}}
+{{- if and .Values.kafka.security.tls .Values.kafka.security.tls.caCertSecret (ne .Values.kafka.security.tls.caCertSecret "") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
+Kafka SASL/TLS environment variables shared across all Kafka-consuming components.
+Injects SASL credentials from secret and TLS CA cert path when configured.
+Usage: {{ include "cost-onprem.kafka.securityEnv" . | nindent 8 }}
+*/}}
+{{- define "cost-onprem.kafka.securityEnv" -}}
+{{- if eq (include "cost-onprem.kafka.sasl.enabled" .) "true" }}
+- name: KAFKA_SASL_MECHANISM
+  value: {{ .Values.kafka.security.sasl.mechanism | quote }}
+- name: KAFKA_SASL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ required "kafka.security.sasl.existingSecret is required when kafka.security.sasl.mechanism is set" .Values.kafka.security.sasl.existingSecret }}
+      key: username
+- name: KAFKA_SASL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.kafka.security.sasl.existingSecret }}
+      key: password
+{{- end }}
+{{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+- name: KAFKA_SSL_CA_LOCATION
+  value: "/etc/kafka/certs/ca.crt"
+{{- end }}
+{{- end }}
+
+{{/*
+Kafka TLS CA certificate volume.
+Mounts the CA certificate secret as a volume when TLS is enabled.
+Usage: {{ include "cost-onprem.kafka.tls.volume" . | nindent 6 }}
+*/}}
+{{- define "cost-onprem.kafka.tls.volume" -}}
+{{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+- name: kafka-ca-cert
+  secret:
+    secretName: {{ .Values.kafka.security.tls.caCertSecret }}
+{{- end }}
+{{- end }}
+
+{{/*
+Kafka TLS CA certificate volumeMount.
+Mounts the CA certificate at /etc/kafka/certs/ when TLS is enabled.
+Usage: {{ include "cost-onprem.kafka.tls.volumeMount" . | nindent 8 }}
+*/}}
+{{- define "cost-onprem.kafka.tls.volumeMount" -}}
+{{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+- name: kafka-ca-cert
+  mountPath: /etc/kafka/certs
+  readOnly: true
+{{- end }}
 {{- end }}
 
 {{/*

--- a/cost-onprem/templates/ingress/deployment.yaml
+++ b/cost-onprem/templates/ingress/deployment.yaml
@@ -87,6 +87,9 @@ spec:
               value: {{ .Values.ingress.kafka.topic | quote }}
             - name: INGRESS_KAFKAGROUPID
               value: {{ .Values.ingress.kafka.groupId | default "ingress" | quote }}
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: {{ .Values.kafka.security.protocol | quote }}
+            {{- include "cost-onprem.kafka.securityEnv" . | nindent 12 }}
 
             # Authentication configuration
             # JWT is handled by centralized gateway, backend trusts X-Rh-Identity header
@@ -127,6 +130,7 @@ spec:
             - name: ca-bundle
               mountPath: /etc/ssl/certs/ca-bundle
               readOnly: true
+            {{- include "cost-onprem.kafka.tls.volumeMount" . | nindent 12 }}
       volumes:
         - name: aws-config
           configMap:
@@ -144,3 +148,4 @@ spec:
             name: {{ include "cost-onprem.fullname" . }}-service-ca
         - name: ca-bundle
           emptyDir: {}
+        {{- include "cost-onprem.kafka.tls.volume" . | nindent 8 }}

--- a/cost-onprem/templates/ingress/deployment.yaml
+++ b/cost-onprem/templates/ingress/deployment.yaml
@@ -87,9 +87,26 @@ spec:
               value: {{ .Values.ingress.kafka.topic | quote }}
             - name: INGRESS_KAFKAGROUPID
               value: {{ .Values.ingress.kafka.groupId | default "ingress" | quote }}
-            - name: KAFKA_SECURITY_PROTOCOL
+            - name: INGRESS_KAFKASECURITYPROTOCOL
               value: {{ .Values.kafka.security.protocol | quote }}
-            {{- include "cost-onprem.kafka.securityEnv" . | nindent 12 }}
+            {{- if eq (include "cost-onprem.kafka.sasl.enabled" .) "true" }}
+            - name: INGRESS_SASLMECHANISM
+              value: {{ .Values.kafka.security.sasl.mechanism | quote }}
+            - name: INGRESS_KAFKAUSERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "kafka.security.sasl.existingSecret is required when kafka.security.sasl.mechanism is set" .Values.kafka.security.sasl.existingSecret }}
+                  key: username
+            - name: INGRESS_KAFKAPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.kafka.security.sasl.existingSecret }}
+                  key: password
+            {{- end }}
+            {{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+            - name: INGRESS_KAFKACA
+              value: "/etc/kafka/certs/ca.crt"
+            {{- end }}
 
             # Authentication configuration
             # JWT is handled by centralized gateway, backend trusts X-Rh-Identity header

--- a/cost-onprem/templates/kruize/configmap.yaml
+++ b/cost-onprem/templates/kruize/configmap.yaml
@@ -18,17 +18,21 @@ data:
       "kafka": {
         "brokers": [
           {
+            {{- if eq (include "cost-onprem.kafka.sasl.enabled" .) "true" }}
             "authtype": "sasl",
+            {{- else }}
+            "authtype": "",
+            {{- end }}
             "hostname": "{{ include "cost-onprem.kafka.host" . }}",
             "port": {{ include "cost-onprem.kafka.port" . }},
             "sasl": {
               "password": "",
-              "saslMechanism": "PLAIN",
-              "securityProtocol": "SSL",
+              "saslMechanism": {{ (.Values.kafka.security.sasl).mechanism | default "PLAIN" | quote }},
+              "securityProtocol": {{ .Values.kafka.security.protocol | quote }},
               "username": ""
             },
-            "securityProtocol": "SSL",
-            "cacert": "-----BEGIN CERTIFICATE-----\nMIIDvTCCAqWgAwIBAgIUctrqAnBFhUmpF7Yti5AJW7dCnAUwDQYJKoZIhvcNAQEL\nBQAwbTESMBAGA1UEAwwJY2ExLmxvY2FsMRQwEgYDVQQLDAtteS1vcmctdW5pdDEP\nMA0GA1UECgwGbXktb3JnMRAwDgYDVQQHDAdteS1jaXR5MREwDwYDVQQIDAhteS1z\ndGF0ZTELMAkGA1UEBhMCQVUwIBcNMjQwMTAyMDgzNjM4WhgPMjA1MTA1MTkwODM2\nMzhaMG0xEjAQBgNVBAMMCWNhMS5sb2NhbDEUMBIGA1UECwwLbXktb3JnLXVuaXQx\nDzANBgNVBAoMBm15LW9yZzEQMA4GA1UEBwwHbXktY2l0eTERMA8GA1UECAwIbXkt\nc3RhdGUxCzAJBgNVBAYTAkFVMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC\nAQEAs3pAov4jmDyxd+aPQR6KyzACBjHFOQZ/kGk5bZYX1BCTIkCOw802ydzbfdRg\nSCLM1fukn8MyVLM0Lv2JhJe+Ev68ZfbgCTgYiayksyZH1kyOmUAJhsk+mAse/kCW\nP4uxdnNPIWc9Fb+hthYblf7nXUh0h+9rUNItLNay7eiTJe8/pUWZevwJwFL1fgjo\nsNhZAbvBk0yr3j8IlXpa0je8NPFuhoCQtpwHtzeFK8ntGjs9bjV8OjL5nHCwOlWe\naVUr/twGPZLLyYCKGsSejs/gS64gLVOfd9huHf2fZ/loXa4yJT12MSAieGLJ3eNA\n2VXA526y+oof+ePIyOoode5cfwIDAQABo1MwUTAdBgNVHQ4EFgQUzgMMah64ZL1D\n/CKiBYfVeWJ3ttMwHwYDVR0jBBgwFoAUzgMMah64ZL1D/CKiBYfVeWJ3ttMwDwYD\nVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAiuTGQG1nU7Q+cjfVbEjS\nYykiY0Nb0E0EKCnKO3B96s7efw9wOgQ7m5U0Vtz4o67LTIWFYcD5iQIyv5xmWYux\nGSWH+BKIFs9uy5ZEPlLsX/YZEIIy+2nLjP5v5+DJdDZrJPIr8Yb5Mb6YybVjTkgQ\nXqbo0CbdDTRU6Gx5O1GptydzKCtmfJZw+Xh4SCQktzI8R9+iANjXKWEo3oeF/yMv\neMYAwOVauUbncdhV4oE7HewFABYdZfUmW4eWKw0MW6J7rq0/nUBdX3tQkJ2pGl5i\n5wKQJ5X00I9r60u6tOd5uRalnNu6wVywlrC4+YVpOyK7iXnC7MnCKCv/8acpxKW0\njw==\n-----END CERTIFICATE-----"
+            "securityProtocol": {{ .Values.kafka.security.protocol | quote }},
+            "cacert": ""
           }
         ],
         "topics": [

--- a/cost-onprem/templates/ros/api/deployment.yaml
+++ b/cost-onprem/templates/ros/api/deployment.yaml
@@ -85,7 +85,12 @@ spec:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
             - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
+              value: {{ .Values.kafka.security.protocol | quote }}
+            {{- include "cost-onprem.kafka.securityEnv" . | nindent 12 }}
+          {{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+          volumeMounts:
+            {{- include "cost-onprem.kafka.tls.volumeMount" . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /status
@@ -104,3 +109,7 @@ spec:
             failureThreshold: {{ .Values.probes.failureThreshold }}
           resources:
             {{- toYaml .Values.resources.application | nindent 12 }}
+      {{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+      volumes:
+        {{- include "cost-onprem.kafka.tls.volume" . | nindent 8 }}
+      {{- end }}

--- a/cost-onprem/templates/ros/housekeeper/deployment.yaml
+++ b/cost-onprem/templates/ros/housekeeper/deployment.yaml
@@ -79,9 +79,18 @@ spec:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
             - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
+              value: {{ .Values.kafka.security.protocol | quote }}
+            {{- include "cost-onprem.kafka.securityEnv" . | nindent 12 }}
             # Topic for source deletion events from Koku (matches hardcoded topic in Koku)
             - name: SOURCES_EVENT_TOPIC
               value: "platform.sources.event-stream"
+          {{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+          volumeMounts:
+            {{- include "cost-onprem.kafka.tls.volumeMount" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.application | nindent 12 }}
+      {{- if eq (include "cost-onprem.kafka.tls.enabled" .) "true" }}
+      volumes:
+        {{- include "cost-onprem.kafka.tls.volume" . | nindent 8 }}
+      {{- end }}

--- a/cost-onprem/templates/ros/processor/deployment.yaml
+++ b/cost-onprem/templates/ros/processor/deployment.yaml
@@ -58,6 +58,7 @@ spec:
             - name: ca-bundle
               mountPath: /etc/ssl/certs/ca-bundle
               readOnly: true
+            {{- include "cost-onprem.kafka.tls.volumeMount" . | nindent 12 }}
           env:
             - name: CLOWDER_ENABLED
               value: "false"
@@ -82,7 +83,8 @@ spec:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
             - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
+              value: {{ .Values.kafka.security.protocol | quote }}
+            {{- include "cost-onprem.kafka.securityEnv" . | nindent 12 }}
             - name: KAFKA_CONSUMER_GROUP_ID
               value: {{ .Values.ros.processor.kafkaConsumerGroupId | quote }}
             - name: KAFKA_AUTO_COMMIT
@@ -141,3 +143,4 @@ spec:
             name: {{ include "cost-onprem.fullname" . }}-service-ca
         - name: ca-bundle
           emptyDir: {}
+        {{- include "cost-onprem.kafka.tls.volume" . | nindent 8 }}

--- a/cost-onprem/templates/ros/recommendation-poller/deployment.yaml
+++ b/cost-onprem/templates/ros/recommendation-poller/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - name: cdapp-config
               mountPath: /cdapp
               readOnly: true
+            {{- include "cost-onprem.kafka.tls.volumeMount" . | nindent 12 }}
           env:
             - name: CLOWDER_ENABLED
               value: "false"
@@ -83,7 +84,8 @@ spec:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
             - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
+              value: {{ .Values.kafka.security.protocol | quote }}
+            {{- include "cost-onprem.kafka.securityEnv" . | nindent 12 }}
             - name: KAFKA_CONSUMER_GROUP_ID
               value: {{ .Values.ros.recommendationPoller.kafkaConsumerGroupId | quote }}
             - name: KAFKA_AUTO_COMMIT
@@ -115,3 +117,4 @@ spec:
         - name: cdapp-config
           configMap:
             name: {{ include "cost-onprem.fullname" . }}-cdapp-config
+        {{- include "cost-onprem.kafka.tls.volume" . | nindent 8 }}

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -499,7 +499,7 @@ kruize:
 ingress:
   image:
     repository: quay.io/insights-onprem/insights-ingress-go
-    tag: "latest"
+    tag: "kafka-sasl-tls"
     pullPolicy: Always
 
   # Server configuration

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -48,7 +48,7 @@ ros:
   # use the same image
   image:
     repository: quay.io/insights-onprem/ros-ocp-backend
-    tag: "latest"
+    tag: "kafka-sasl-tls"
     pullPolicy: Always
 
   # Service Account
@@ -147,7 +147,7 @@ costManagement:
 
     image:
       repository: quay.io/insights-onprem/koku
-      tag: "sources-3"
+      tag: "kafka-sasl-tls"
       pullPolicy: Always
 
     replicas: 1

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -647,9 +647,55 @@ kafka:
   # This is auto-configured by the install script based on the Kafka cluster it creates
   bootstrapServers: "cost-onprem-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092"
 
-  # Security protocol — only PLAINTEXT is currently supported.
-  # SASL/TLS support requires upstream application changes (see docs/operations/configuration.md).
-  securityProtocol: "PLAINTEXT"
+  # ---------------------------------------------------------------------------
+  # Connection Security
+  # ---------------------------------------------------------------------------
+  # Groups the Kafka security protocol, SASL authentication, and TLS encryption
+  # settings. Mirrors Kafka's native property naming (security.protocol).
+  security:
+    # Security protocol for Kafka connections.
+    # Valid values: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
+    # Must match the listener type on the Kafka broker.
+    protocol: "PLAINTEXT"
+
+    # -------------------------------------------------------------------------
+    # SASL Authentication
+    # -------------------------------------------------------------------------
+    # Configure SASL when connecting to Kafka brokers that require authentication
+    # (e.g., MSK with IAM/SCRAM, Confluent Cloud, AMQ Streams with SCRAM).
+    # Requires protocol set to SASL_PLAINTEXT or SASL_SSL.
+    sasl:
+      # SASL mechanism. Leave empty to disable SASL authentication.
+      # Supported values: SCRAM-SHA-512, SCRAM-SHA-256, PLAIN
+      mechanism: ""
+
+      # Name of an existing Kubernetes Secret containing SASL credentials.
+      # Required when mechanism is set. The secret must contain keys:
+      #   username  - SASL username
+      #   password  - SASL password
+      #
+      # Example:
+      #   kubectl create secret generic kafka-sasl-credentials \
+      #     --from-literal=username=my-user \
+      #     --from-literal=password=my-password
+      existingSecret: ""
+
+    # -------------------------------------------------------------------------
+    # TLS Encryption
+    # -------------------------------------------------------------------------
+    # Configure TLS when connecting to Kafka brokers over encrypted channels.
+    # Requires protocol set to SSL or SASL_SSL.
+    tls:
+      # Name of an existing Kubernetes Secret containing the CA certificate.
+      # When set, the CA certificate is mounted into all Kafka-consuming pods
+      # at /etc/kafka/certs/ca.crt. Leave empty to disable TLS CA mounting.
+      # The secret must contain key:
+      #   ca.crt  - PEM-encoded CA certificate
+      #
+      # Example:
+      #   kubectl create secret generic kafka-ca-cert \
+      #     --from-file=ca.crt=/path/to/ca-certificate.pem
+      caCertSecret: ""
 
 # -----------------------------------------------------------------------------
 # Shared Infrastructure - Cache (Valkey)

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -812,7 +812,8 @@ The Helm chart does **not** deploy Kafka — it only configures applications to 
 ```yaml
 kafka:
   bootstrapServers: "cost-onprem-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092"
-  securityProtocol: "PLAINTEXT"
+  security:
+    protocol: "PLAINTEXT"
 ```
 
 The `install-helm-chart.sh` script auto-detects the bootstrap address from the deployed Kafka cluster. To override (e.g., for an external cluster):
@@ -827,28 +828,102 @@ Or set it in your values file directly.
 
 Use an existing Kafka cluster instead of the bundled AMQ Streams deployment.
 
-> **Known Limitation:** Only **PLAINTEXT** Kafka connections are currently supported. Both Koku and ROS backends do not read SASL/TLS configuration from environment variables in on-prem (non-Clowder) mode. Upstream application changes are required before chart-level SASL/TLS support can be added.
-
 **Prerequisites:**
 
-1. Apache Kafka 3.x or later accessible from the OpenShift cluster with a **PLAINTEXT** listener
+1. Apache Kafka 3.x or later accessible from the OpenShift cluster
 2. All five topics listed above must exist (or `auto.create.topics.enable` must be set to `true`)
 3. Bootstrap servers reachable from the `cost-onprem` namespace over the network
+4. For SASL/TLS: upstream Koku and ROS images with SASL/TLS environment variable support (see note below)
 
-**Configuration:**
+**PLAINTEXT Configuration (default):**
 
 ```yaml
 # values.yaml
 kafka:
   bootstrapServers: "my-kafka-broker1:9092,my-kafka-broker2:9092"
-  securityProtocol: "PLAINTEXT"
+  security:
+    protocol: "PLAINTEXT"
 ```
+
+**SASL_SSL Configuration (enterprise Kafka):**
+
+For Kafka brokers requiring SASL authentication and TLS encryption (e.g., AMQ Streams with SCRAM, Amazon MSK, Confluent Cloud):
+
+```yaml
+# values.yaml
+kafka:
+  bootstrapServers: "my-kafka-broker1:9093,my-kafka-broker2:9093"
+  security:
+    protocol: "SASL_SSL"
+    sasl:
+      mechanism: "SCRAM-SHA-512"        # or SCRAM-SHA-256, PLAIN
+      existingSecret: "kafka-sasl-credentials"
+    tls:
+      caCertSecret: "kafka-ca-cert"
+```
+
+Create the required secrets before installing the chart:
+
+```bash
+# SASL credentials
+kubectl create secret generic kafka-sasl-credentials \
+  --namespace cost-onprem \
+  --from-literal=username=my-kafka-user \
+  --from-literal=password=my-kafka-password
+
+# TLS CA certificate
+kubectl create secret generic kafka-ca-cert \
+  --namespace cost-onprem \
+  --from-file=ca.crt=/path/to/kafka-ca-certificate.pem
+```
+
+**Other security protocol combinations:**
+
+| Protocol | SASL | TLS | Use case |
+|----------|------|-----|----------|
+| `PLAINTEXT` | No | No | Development, internal clusters (default) |
+| `SSL` | No | Yes | Encryption only, no authentication |
+| `SASL_PLAINTEXT` | Yes | No | Authentication only, no encryption |
+| `SASL_SSL` | Yes | Yes | Production — authentication + encryption |
+
+For `SSL` (TLS without SASL):
+```yaml
+kafka:
+  bootstrapServers: "my-kafka-broker1:9093"
+  security:
+    protocol: "SSL"
+    tls:
+      caCertSecret: "kafka-ca-cert"
+```
+
+For `SASL_PLAINTEXT` (SASL without TLS):
+```yaml
+kafka:
+  bootstrapServers: "my-kafka-broker1:9092"
+  security:
+    protocol: "SASL_PLAINTEXT"
+    sasl:
+      mechanism: "SCRAM-SHA-512"
+      existingSecret: "kafka-sasl-credentials"
+```
+
+> **Note on upstream support:** SASL/TLS environment variables (`KAFKA_SASL_MECHANISM`, `KAFKA_SASL_USERNAME`, `KAFKA_SASL_PASSWORD`, `KAFKA_SECURITY_PROTOCOL`, `KAFKA_SSL_CA_LOCATION`) are wired into all Kafka-consuming pods by this chart. However, the upstream Koku and ROS application images must include support for reading these variables in on-prem (non-Clowder) mode. Verify that your Koku and ROS images include SASL/TLS support before enabling these settings.
 
 **Install script behavior:** Setting `KAFKA_BOOTSTRAP_SERVERS` tells the install script to skip AMQ Streams operator verification:
 
 ```bash
-KAFKA_BOOTSTRAP_SERVERS="my-kafka-broker1:9092" ./scripts/install-helm-chart.sh --namespace cost-onprem
+KAFKA_BOOTSTRAP_SERVERS="my-kafka-broker1:9093" ./scripts/install-helm-chart.sh --namespace cost-onprem
 ```
+
+**Environment variables injected into pods:**
+
+| Variable | Condition | Source |
+|----------|-----------|--------|
+| `KAFKA_SECURITY_PROTOCOL` | Always | `kafka.security.protocol` |
+| `KAFKA_SASL_MECHANISM` | When `kafka.security.sasl.mechanism` is set | `kafka.security.sasl.mechanism` |
+| `KAFKA_SASL_USERNAME` | When `kafka.security.sasl.mechanism` is set | Secret: `kafka.security.sasl.existingSecret` key `username` |
+| `KAFKA_SASL_PASSWORD` | When `kafka.security.sasl.mechanism` is set | Secret: `kafka.security.sasl.existingSecret` key `password` |
+| `KAFKA_SSL_CA_LOCATION` | When `kafka.security.tls.caCertSecret` is set | Mounted at `/etc/kafka/certs/ca.crt` |
 
 **Components that use Kafka:**
 


### PR DESCRIPTION
## Summary

- Add `kafka.security.protocol`, `kafka.security.sasl.*`, and `kafka.security.tls.*` to `values.yaml` for configuring secure Kafka connections (SASL_SSL, SSL, SASL_PLAINTEXT)
- Wire SASL credentials (from Kubernetes Secret) and TLS CA certificate (volume mount) into all Kafka-consuming components: Koku, ROS, Ingress, and Kruize
- Add shared Helm helpers (`securityEnv`, `tls.volume`, `tls.volumeMount`) to centralize security config across deployments
- Document all four security protocol combinations with examples in `docs/operations/configuration.md`

## Design decisions

- **SASL**: enabled implicitly when `kafka.security.sasl.mechanism` is set (no `enabled` flag needed)
- **TLS**: enabled implicitly when `kafka.security.tls.caCertSecret` is set (no `enabled` flag needed)
- **Validation**: `helm template` fails with a clear error if `mechanism` is set without `existingSecret`
- **Backward compatible**: default `PLAINTEXT` mode renders identically to before this change

## Depends on

- Koku: https://github.com/project-koku/koku/pull/5929
- ROS: https://github.com/RedHatInsights/ros-ocp-backend/pull/586
- Ingress: https://github.com/RedHatInsights/insights-ingress-go/pull/708

## Test plan

- [ ] `helm lint` passes with default values
- [ ] `helm template` with default values renders no SASL/TLS artifacts
- [ ] `helm template` with SASL_SSL config renders correct env vars, volumes, and mounts
- [ ] Validation rejects missing `existingSecret` when `mechanism` is set
- [ ] Deploy to cluster with PLAINTEXT Kafka — existing behavior unchanged
- [ ] Deploy to cluster with SASL_SSL Kafka — SASL auth and TLS work end-to-end