### PR TITLE
FLPATH-2966: Enable retrieving user info via /api/me endpoint

### DIFF
--- a/cost-onprem/templates/ui/deployment.yaml
+++ b/cost-onprem/templates/ui/deployment.yaml
@@ -58,6 +58,7 @@ spec:
         - --skip-auth-preflight
         - --pass-authorization-header
         - --code-challenge-method=S256
+        - --set-xauthrequest
         - --email-domain=*
         - --cookie-secure=true
         - --cookie-expire={{ .Values.ui.oauthProxy.cookie.expire }}

--- a/cost-onprem/templates/ui/nginx-config.yaml
+++ b/cost-onprem/templates/ui/nginx-config.yaml
@@ -15,6 +15,11 @@ data:
     # - X-Rh-Identity header injection
     # - Path-based routing to backend services (koku, ros, sources, ingress)
     # - Method-based routing for Koku read/write split
+    location /api/me {
+      default_type application/json;
+      return 200 "{\"username\":\"$http_x_auth_request_preferred_username\", \"email\":\"$http_x_forwarded_email\"}";
+    }
+
     location /api/ {
       proxy_pass http://{{ include "cost-onprem.gateway.serviceName" . }}:{{ include "cost-onprem.gateway.servicePort" . }};
       proxy_set_header Host $host;


### PR DESCRIPTION
Adds nginx endpoint /api/me so that UI can retrieve user info forwarded by oauth2-proxy.