### PR TITLE
Bump koku image to 917373e and chart version to 0.2.17

### DIFF
--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.16
-appVersion: "0.2.16"
+version: 0.2.17
+appVersion: "0.2.17"
 
 keywords:
   - cost-management

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -147,7 +147,7 @@ costManagement:
 
     image:
       repository: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
-      tag: "b6172dd"
+      tag: "917373e"
       pullPolicy: Always
 
     replicas: 1


### PR DESCRIPTION
## Summary
- Update koku image tag from `b6172dd` to `917373e` to include on-prem notification logging (FLPATH-3483)
- Bump chart version and appVersion from `0.2.16` to `0.2.17`

## Test plan
- [ ] Verify the koku image `917373e` is available in the registry
- [ ] Deploy the updated chart and confirm koku pods start successfully

Made with [Cursor](https://cursor.com)