### PR TITLE
FLPATH-3886 Add RC (release candidate) versioning support

### DIFF
--- a/.cursor/prompts/release-chart.md
+++ b/.cursor/prompts/release-chart.md
@@ -16,11 +16,19 @@ Ask the user which version bump to apply:
 - **patch** - Bug fixes, config changes, image tag updates (e.g., 0.2.9 -> 0.2.10)
 - **minor** - New features, backward-compatible values.yaml changes (e.g., 0.2.9 -> 0.3.0)
 - **major** - Breaking changes to values.yaml contract or upgrade path (e.g., 0.2.9 -> 1.0.0)
+- **rc** - Release candidate for CI/QE validation before stable release
 
 ### 2. Bump the Version
 
 ```bash
+# Stable releases
 ./scripts/bump-version.sh --<type>
+
+# Release candidates
+./scripts/bump-version.sh --rc              # patch-scope RC (e.g., 0.2.19 -> 0.2.20-rc1)
+./scripts/bump-version.sh --rc --minor      # minor-scope RC (e.g., 0.2.19 -> 0.3.0-rc1)
+./scripts/bump-version.sh --rc --major      # major-scope RC (e.g., 0.2.19 -> 1.0.0-rc1)
+./scripts/bump-version.sh --rc              # iterate RC    (e.g., 0.2.20-rc1 -> 0.2.20-rc2)
 ```
 
 Verify the change:
@@ -48,4 +56,41 @@ gh pr create \
 
 This PR triggers the chart-releaser workflow on merge to main,
 which publishes the chart to the GitHub Pages Helm repository."
+```
+
+## RC Workflow
+
+Release candidates allow CI/QE validation before promoting to a stable customer-visible release.
+
+### Lifecycle
+
+```
+0.2.19 (stable, current)
+  -> 0.2.20-rc1 (dev/QE)       ./scripts/bump-version.sh --rc
+  -> 0.2.20-rc2 (dev/QE)       ./scripts/bump-version.sh --rc
+  -> 0.2.20 (stable, promoted)  ./scripts/bump-version.sh --patch
+```
+
+### RC Behavior
+
+- RC releases are marked as **pre-release** on GitHub
+- They do **not** appear as the "latest" release
+- Helm users must use `--devel` to see them: `helm search repo --devel cost-onprem`
+- OCI registry pushes work normally — the tag includes the `-rcN` suffix
+
+### Promoting an RC to Stable
+
+When QE approves an RC, promote it by stripping the RC suffix:
+
+```bash
+./scripts/bump-version.sh --patch    # 0.2.20-rc3 -> 0.2.20
+git add cost-onprem/Chart.yaml
+git commit -s -m "chore: release cost-onprem v0.2.20"
+```
+
+You can also skip directly to a minor or major bump if needed:
+
+```bash
+./scripts/bump-version.sh --minor    # 0.2.20-rc3 -> 0.3.0
+./scripts/bump-version.sh --major    # 0.2.20-rc3 -> 1.0.0
 ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       version: ${{ steps.chart.outputs.version }}
       changed: ${{ steps.check.outputs.changed }}
+      is_rc: ${{ steps.rc_check.outputs.is_rc }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,6 +27,18 @@ jobs:
         run: |
           VERSION=$(grep '^version:' cost-onprem/Chart.yaml | awk '{print $2}')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if version is RC
+        id: rc_check
+        run: |
+          VERSION="${{ steps.chart.outputs.version }}"
+          if echo "$VERSION" | grep -qE '\-rc[0-9]+$'; then
+            echo "is_rc=true" >> $GITHUB_OUTPUT
+            echo "Version $VERSION is a release candidate"
+          else
+            echo "is_rc=false" >> $GITHUB_OUTPUT
+            echo "Version $VERSION is a stable release"
+          fi
 
       - name: Check if release already exists
         id: check
@@ -64,8 +77,17 @@ jobs:
         with:
           charts_dir: .
           config: .github/cr.yaml
+          mark_as_latest: ${{ needs.check-version.outputs.is_rc != 'true' }}
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Mark RC release as pre-release
+        if: needs.check-version.outputs.is_rc == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="cost-onprem-${{ needs.check-version.outputs.version }}"
+          gh release edit "$TAG" --prerelease
 
   release-oci:
     needs: check-version

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -49,6 +49,14 @@ jobs:
           fi
           echo "Current version '$CURRENT_VERSION' is valid semantic version"
 
+          PREREL=$(semver get prerel "$CURRENT_VERSION")
+          if [ -n "$PREREL" ]; then
+            echo "is_rc=true" >> $GITHUB_OUTPUT
+            echo "Version has pre-release component: $PREREL"
+          else
+            echo "is_rc=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get latest release version
         id: latest_release
         run: |
@@ -76,11 +84,13 @@ jobs:
           CURRENT_VERSION="${{ steps.current_version.outputs.version }}"
           LATEST_VERSION="${{ steps.latest_release.outputs.version }}"
           IS_FIRST_RELEASE="${{ steps.latest_release.outputs.is_first_release }}"
+          IS_RC="${{ steps.current_version.outputs.is_rc }}"
 
           echo "=== Version Comparison ==="
           echo "Current version: $CURRENT_VERSION"
           echo "Latest release:  $LATEST_VERSION"
           echo "First release:   $IS_FIRST_RELEASE"
+          echo "Is RC:           $IS_RC"
           echo ""
 
           if [ "$IS_FIRST_RELEASE" = "true" ]; then
@@ -105,20 +115,26 @@ jobs:
             1)
               echo "Version bumped: $LATEST_VERSION -> $CURRENT_VERSION"
               echo "result=new_version" >> $GITHUB_OUTPUT
-              echo "message=Version bumped from $LATEST_VERSION to $CURRENT_VERSION - a release will be created on merge" >> $GITHUB_OUTPUT
               echo "will_release=true" >> $GITHUB_OUTPUT
 
-              NEXT_MAJOR=$(semver bump major "$LATEST_VERSION")
-              NEXT_MINOR=$(semver bump minor "$LATEST_VERSION")
-              NEXT_PATCH=$(semver bump patch "$LATEST_VERSION")
-              if [ "$(semver compare "$CURRENT_VERSION" "$NEXT_MAJOR")" -eq 0 ]; then
-                echo "bump_type=major" >> $GITHUB_OUTPUT
-              elif [ "$(semver compare "$CURRENT_VERSION" "$NEXT_MINOR")" -eq 0 ]; then
-                echo "bump_type=minor" >> $GITHUB_OUTPUT
-              elif [ "$(semver compare "$CURRENT_VERSION" "$NEXT_PATCH")" -eq 0 ]; then
-                echo "bump_type=patch" >> $GITHUB_OUTPUT
+              if [ "$IS_RC" = "true" ]; then
+                echo "bump_type=rc" >> $GITHUB_OUTPUT
+                echo "message=RC version $CURRENT_VERSION (pre-release from $LATEST_VERSION) - an RC release will be created on merge" >> $GITHUB_OUTPUT
               else
-                echo "bump_type=custom" >> $GITHUB_OUTPUT
+                echo "message=Version bumped from $LATEST_VERSION to $CURRENT_VERSION - a release will be created on merge" >> $GITHUB_OUTPUT
+
+                NEXT_MAJOR=$(semver bump major "$LATEST_VERSION")
+                NEXT_MINOR=$(semver bump minor "$LATEST_VERSION")
+                NEXT_PATCH=$(semver bump patch "$LATEST_VERSION")
+                if [ "$(semver compare "$CURRENT_VERSION" "$NEXT_MAJOR")" -eq 0 ]; then
+                  echo "bump_type=major" >> $GITHUB_OUTPUT
+                elif [ "$(semver compare "$CURRENT_VERSION" "$NEXT_MINOR")" -eq 0 ]; then
+                  echo "bump_type=minor" >> $GITHUB_OUTPUT
+                elif [ "$(semver compare "$CURRENT_VERSION" "$NEXT_PATCH")" -eq 0 ]; then
+                  echo "bump_type=patch" >> $GITHUB_OUTPUT
+                else
+                  echo "bump_type=custom" >> $GITHUB_OUTPUT
+                fi
               fi
               ;;
             0)
@@ -147,6 +163,7 @@ jobs:
             echo "  Patch: $(semver bump patch $LATEST_VERSION)"
             echo "  Minor: $(semver bump minor $LATEST_VERSION)"
             echo "  Major: $(semver bump major $LATEST_VERSION)"
+            echo "  RC:    $(semver bump patch $LATEST_VERSION)-rc1"
             echo ""
             echo "Update cost-onprem/Chart.yaml:"
             echo "  version: $(semver bump patch $LATEST_VERSION)"
@@ -159,6 +176,7 @@ jobs:
           MESSAGE="${{ steps.version_check.outputs.message }}"
           BUMP_TYPE="${{ steps.version_check.outputs.bump_type }}"
           WILL_RELEASE="${{ steps.version_check.outputs.will_release }}"
+          IS_RC="${{ steps.current_version.outputs.is_rc }}"
 
           echo "## Version Check Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -199,6 +217,7 @@ jobs:
           echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Current Chart Version | \`${{ steps.current_version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Latest Release | \`${{ steps.latest_release.outputs.version || 'None' }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Is RC | $IS_RC |" >> $GITHUB_STEP_SUMMARY
           echo "| Will Release | $WILL_RELEASE |" >> $GITHUB_STEP_SUMMARY
 
       - name: Comment on PR (version regression)
@@ -221,7 +240,8 @@ jobs:
             The chart version must be **>=** the latest release. Suggested fixes:
             - \`$(semver bump patch ${{ steps.latest_release.outputs.version }})\` for bug fixes
             - \`$(semver bump minor ${{ steps.latest_release.outputs.version }})\` for new features
-            - \`$(semver bump major ${{ steps.latest_release.outputs.version }})\` for breaking changes`;
+            - \`$(semver bump major ${{ steps.latest_release.outputs.version }})\` for breaking changes
+            - \`$(semver bump patch ${{ steps.latest_release.outputs.version }})-rc1\` for release candidates`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -230,11 +250,43 @@ jobs:
               body: message
             });
 
-      - name: Comment on PR (release note)
+      - name: Comment on PR (RC release note)
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.version_check.outputs.result == 'new_version'
+          steps.version_check.outputs.result == 'new_version' &&
+          steps.current_version.outputs.is_rc == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const message = `## RC Release Pending
+
+            This PR creates a **release candidate** version.
+
+            | | Version |
+            |---|---------|
+            | **Latest stable release** | \`${{ steps.latest_release.outputs.version || 'None' }}\` |
+            | **This PR (RC)** | \`${{ steps.current_version.outputs.version }}\` |
+
+            On merge, release **cost-onprem-${{ steps.current_version.outputs.version }}** will be created as a **pre-release**.
+
+            - It will **not** appear as the latest release
+            - Helm users must use \`--devel\` to see it: \`helm search repo --devel cost-onprem\`
+            - Promote to stable with: \`./scripts/bump-version.sh --patch\``;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });
+
+      - name: Comment on PR (stable release note)
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.version_check.outputs.result == 'new_version' &&
+          steps.current_version.outputs.is_rc != 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,32 +1,12 @@
 #!/bin/bash
 
-# Bump Cost-Onprem Chart Version
-# Bumps the Helm chart version according to semantic versioning.
-# Updates both 'version' and 'appVersion' fields in Chart.yaml.
-#
-# Usage:
-#   ./bump-version.sh --patch
-#   ./bump-version.sh --minor
-#   ./bump-version.sh --major
-#
-# Examples:
-#   # Bump patch: 0.2.9 -> 0.2.10
-#   ./scripts/bump-version.sh --patch
-#
-#   # Bump minor: 0.2.9 -> 0.3.0
-#   ./scripts/bump-version.sh --minor
-#
-#   # Bump major: 0.2.9 -> 1.0.0
-#   ./scripts/bump-version.sh --major
+set -e
 
-set -e  # Exit on any error
-
-# Color codes for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
 echo_info() {
     echo -e "${BLUE}[INFO]${NC} $1"
@@ -42,52 +22,76 @@ echo_error() {
 
 usage() {
     echo "Usage: $0 --patch | --minor | --major"
+    echo "       $0 --rc [--patch|--minor|--major]   (from stable: start RC cycle, default: --patch)"
+    echo "       $0 --rc                             (from RC: increment RC number)"
     echo ""
     echo "Bump the cost-onprem Helm chart version according to semver."
     echo ""
     echo "Options:"
     echo "  --patch   Bump patch version (e.g., 0.2.9 -> 0.2.10)"
+    echo "            From RC: promotes to stable (e.g., 0.2.10-rc3 -> 0.2.10)"
     echo "  --minor   Bump minor version (e.g., 0.2.9 -> 0.3.0)"
     echo "  --major   Bump major version (e.g., 0.2.9 -> 1.0.0)"
+    echo "  --rc      Create or increment release candidate"
+    echo "            From stable: start RC cycle (default scope: patch)"
+    echo "              --rc           0.2.9 -> 0.2.10-rc1"
+    echo "              --rc --patch   0.2.9 -> 0.2.10-rc1"
+    echo "              --rc --minor   0.2.9 -> 0.3.0-rc1"
+    echo "              --rc --major   0.2.9 -> 1.0.0-rc1"
+    echo "            From RC: increment RC number (scope qualifiers not allowed)"
+    echo "              --rc           0.2.10-rc1 -> 0.2.10-rc2"
     echo "  --help    Show this help message"
 }
 
-# Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_FILE="$SCRIPT_DIR/../cost-onprem/Chart.yaml"
 
-# Parse arguments
-BUMP_TYPE=""
+RC_MODE=false
+SCOPE=""
 
-case "${1:-}" in
-    --patch)
-        BUMP_TYPE="patch"
-        ;;
-    --minor)
-        BUMP_TYPE="minor"
-        ;;
-    --major)
-        BUMP_TYPE="major"
-        ;;
-    --help|-h)
-        usage
-        exit 0
-        ;;
-    *)
-        echo_error "Exactly one of --patch, --minor, or --major is required"
-        echo ""
-        usage
-        exit 1
-        ;;
-esac
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --patch)
+            SCOPE="patch"
+            shift
+            ;;
+        --minor)
+            SCOPE="minor"
+            shift
+            ;;
+        --major)
+            SCOPE="major"
+            shift
+            ;;
+        --rc)
+            RC_MODE=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo_error "Unknown argument: $1"
+            echo ""
+            usage
+            exit 1
+            ;;
+    esac
+done
 
-# Validate Chart.yaml exists
+if [ "$RC_MODE" = false ] && [ -z "$SCOPE" ]; then
+    echo_error "Exactly one of --patch, --minor, --major, or --rc is required"
+    echo ""
+    usage
+    exit 1
+fi
+
 if [ ! -f "$CHART_FILE" ]; then
     echo_error "Chart.yaml not found: $CHART_FILE"
     exit 1
 fi
 
-# Extract current version
 CURRENT_VERSION=$(grep '^version:' "$CHART_FILE" | awk '{print $2}')
 
 if [ -z "$CURRENT_VERSION" ]; then
@@ -95,38 +99,83 @@ if [ -z "$CURRENT_VERSION" ]; then
     exit 1
 fi
 
-# Validate MAJOR.MINOR.PATCH format
-if ! echo "$CURRENT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-    echo_error "Version '$CURRENT_VERSION' is not valid semver (expected MAJOR.MINOR.PATCH)"
+VERSION_REGEX='^([0-9]+)\.([0-9]+)\.([0-9]+)(-rc([0-9]+))?$'
+if ! [[ "$CURRENT_VERSION" =~ $VERSION_REGEX ]]; then
+    echo_error "Version '$CURRENT_VERSION' is not valid semver (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-rcN)"
     exit 1
 fi
 
-# Parse version components
-IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+PATCH="${BASH_REMATCH[3]}"
+RC_SUFFIX="${BASH_REMATCH[4]}"
+RC_NUM="${BASH_REMATCH[5]}"
 
-# Compute new version
-case "$BUMP_TYPE" in
-    patch)
-        PATCH=$((PATCH + 1))
-        ;;
-    minor)
-        MINOR=$((MINOR + 1))
-        PATCH=0
-        ;;
-    major)
-        MAJOR=$((MAJOR + 1))
-        MINOR=0
-        PATCH=0
-        ;;
-esac
+IS_RC=false
+if [ -n "$RC_SUFFIX" ]; then
+    IS_RC=true
+fi
 
-NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+if [ "$RC_MODE" = true ]; then
+    if [ "$IS_RC" = true ]; then
+        if [ -n "$SCOPE" ]; then
+            echo_error "Cannot use --$SCOPE with --rc when already on an RC version ($CURRENT_VERSION). The target version is already set — use --rc alone to increment the RC number."
+            exit 1
+        fi
+        NEW_RC=$((RC_NUM + 1))
+        NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-rc${NEW_RC}"
+    else
+        if [ -z "$SCOPE" ]; then
+            SCOPE="patch"
+        fi
+        case "$SCOPE" in
+            patch)
+                PATCH=$((PATCH + 1))
+                ;;
+            minor)
+                MINOR=$((MINOR + 1))
+                PATCH=0
+                ;;
+            major)
+                MAJOR=$((MAJOR + 1))
+                MINOR=0
+                PATCH=0
+                ;;
+        esac
+        NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-rc1"
+    fi
+else
+    case "$SCOPE" in
+        patch)
+            if [ "$IS_RC" = true ]; then
+                NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            else
+                PATCH=$((PATCH + 1))
+                NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            fi
+            ;;
+        minor)
+            MINOR=$((MINOR + 1))
+            PATCH=0
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            ;;
+        major)
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            ;;
+    esac
+fi
 
 echo_info "Chart: $CHART_FILE"
 echo_info "Current version: $CURRENT_VERSION"
-echo_info "Bump type: $BUMP_TYPE"
+if [ "$RC_MODE" = true ]; then
+    echo_info "Bump type: rc"
+else
+    echo_info "Bump type: $SCOPE"
+fi
 
-# Update Chart.yaml (portable sed: -i.bak works on both macOS and Linux)
 sed -i.bak "s/^version: .*/version: $NEW_VERSION/" "$CHART_FILE"
 sed -i.bak "s/^appVersion: .*/appVersion: \"$NEW_VERSION\"/" "$CHART_FILE"
 rm -f "$CHART_FILE.bak"


### PR DESCRIPTION
## Summary

- **bump-version.sh**: Add `--rc` flag with optional `--minor`/`--major` scope qualifiers for creating pre-release versions (e.g., `0.2.20-rc1`). Supports RC increment and promotion to stable via `--patch`.
- **release.yml**: Detect RC versions, mark GitHub releases as pre-release, prevent RC from being marked as latest.
- **version-check.yml**: Detect RC bump type, differentiate PR comments for RC vs stable, add RC suggestion on version regression.
- **release-chart.md**: Document RC workflow lifecycle and promotion steps.

### RC Lifecycle

```
0.2.19 (stable, current)
  → 0.2.20-rc1 (dev/QE)        ./scripts/bump-version.sh --rc
  → 0.2.20-rc2 (dev/QE)        ./scripts/bump-version.sh --rc
  → 0.2.20 (stable, promoted)  ./scripts/bump-version.sh --patch
```

Helm 3 hides pre-release versions from `helm search repo` by default. Users must use `--devel` to see them.

## Test plan

- [x] `--rc` from stable → `0.2.20-rc1`
- [x] `--rc` from RC → `0.2.20-rc2`
- [x] `--rc --minor` from stable → `0.3.0-rc1`
- [x] `--rc --major` from stable → `1.0.0-rc1`
- [x] `--rc --minor` from RC → error (correct)
- [x] `--patch` from RC → `0.2.20` (promote)
- [x] `--minor` from RC → `0.3.0`
- [x] `--major` from RC → `1.0.0`
- [x] `--patch` from stable → `0.2.20` (unchanged behavior)
- [ ] Verify release.yml marks RC as pre-release after merge
- [ ] Verify version-check.yml shows "RC Release Pending" comment on RC PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)