### PR TITLE
Update koku image to b5b6fc3 and bump chart to v0.2.20-rc1

### DIFF
--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.19
-appVersion: "0.2.19"
+version: 0.2.20-rc1
+appVersion: "0.2.20-rc1"
 
 keywords:
   - cost-management

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -147,7 +147,7 @@ costManagement:
 
     image:
       repository: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
-      tag: "917373e"
+      tag: "b5b6fc3"
       pullPolicy: Always
 
     replicas: 1


### PR DESCRIPTION
## Summary
- Update koku image tag from 917373e to b5b6fc3
- Bump chart version from 0.2.19 to 0.2.20-rc1 using the bump-version script

## Test plan
- [ ] Verify chart renders correctly with new image tag
- [ ] Deploy and test functionality with updated koku image
- [ ] Validate RC versioning format in Chart.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)