### PR TITLE
Add architecture diagrams and embed in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,21 @@ docs/
 └── README.md        # This file - documentation index and navigation
 ```
 
+## 📊 Diagrams
+
+Visual overviews of the system architecture, data flows, and key transitions.
+
+| Diagram | Purpose |
+|---------|---------|
+| **[Architecture Overview](cost-onprem-architecture-diagram.svg)** | Component layout of the on-prem deployment |
+| **[SaaS to On-Prem Transition](saas-to-onprem-transition-diagram.svg)** | What changes between SaaS and on-prem |
+| **[Data Processing Flow](data-processing-flow.svg)** | End-to-end data pipeline from operator upload to cost insights |
+| **[Gateway Routing](gateway-routing-diagram.svg)** | Envoy gateway route configuration and request flow |
+| **[UI Login Flow](ui-login-flow.svg)** | OAuth/Keycloak authentication sequence for the UI |
+> **Tip:** These SVGs are also embedded inline in the relevant documentation pages listed below.
+
+---
+
 ## 📚 Documentation Index
 
 Browse documentation by category:

--- a/docs/api/ui-oauth-authentication.md
+++ b/docs/api/ui-oauth-authentication.md
@@ -33,6 +33,8 @@ User → OpenShift Route → OAuth2 Proxy → Keycloak OIDC → Validate
 
 ## Architecture
 
+![UI Login Flow](../ui-login-flow.svg)
+
 ### Deployment Architecture
 
 ```mermaid

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,6 +2,14 @@
 
 System design, component interactions, and technical architecture documentation for Cost Management On-Premise.
 
+## SaaS to On-Prem Transition
+
+![SaaS to On-Prem Transition](../saas-to-onprem-transition-diagram.svg)
+
+## Gateway Routing
+
+![Gateway Routing](../gateway-routing-diagram.svg)
+
 ## Documents
 
 | Document | Description |

--- a/docs/architecture/platform-guide.md
+++ b/docs/architecture/platform-guide.md
@@ -26,6 +26,11 @@ The Cost Management On-Premise Helm chart is designed for OpenShift environments
 
 ### Architecture
 
+![Cost Management On-Prem Architecture](../cost-onprem-architecture-diagram.svg)
+
+<details>
+<summary>Simplified routing diagram (Mermaid)</summary>
+
 ```mermaid
 graph TB
     Client["Client"] --> Router
@@ -56,6 +61,8 @@ graph TB
     style Koku fill:#a5d6a7,stroke:#333,stroke-width:2px,color:#000
     style ROS fill:#a5d6a7,stroke:#333,stroke-width:2px,color:#000
 ```
+
+</details>
 
 ### Networking
 

--- a/docs/cost-onprem-architecture-diagram.svg
+++ b/docs/cost-onprem-architecture-diagram.svg
@@ -1,0 +1,328 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 810" width="1440" height="810">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700&amp;display=swap');
+      text { font-family: 'Red Hat Display', 'Segoe UI', Arial, sans-serif; }
+    </style>
+    <filter id="sh" x="-3%" y="-3%" width="106%" height="106%">
+      <feDropShadow dx="0" dy="1" stdDeviation="3" flood-color="#000" flood-opacity="0.06"/>
+    </filter>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f8f9fa"/>
+      <stop offset="100%" stop-color="#edf0f4"/>
+    </linearGradient>
+    <marker id="ab" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto"><polygon points="0 0,7 2.5,0 5" fill="#1565c0"/></marker>
+    <marker id="ag" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto"><polygon points="0 0,7 2.5,0 5" fill="#2e7d32"/></marker>
+    <marker id="ap" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto"><polygon points="0 0,7 2.5,0 5" fill="#6a1b9a"/></marker>
+    <marker id="ay" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto"><polygon points="0 0,7 2.5,0 5" fill="#455a64"/></marker>
+    <marker id="ar" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto"><polygon points="0 0,7 2.5,0 5" fill="#c62828"/></marker>
+    <marker id="at" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto"><polygon points="0 0,7 2.5,0 5" fill="#00695c"/></marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1440" height="810" rx="16" fill="url(#bg)"/>
+
+  <!-- Title -->
+  <text x="720" y="36" text-anchor="middle" font-size="24" font-weight="700" fill="#1a1a1a">Cost Management On-Premise — Architecture</text>
+  <text x="720" y="54" text-anchor="middle" font-size="12" fill="#868e96">Helm chart deployment on OpenShift — all components running on a single cluster</text>
+
+  <!-- ==================== EXTERNAL ZONE ==================== -->
+  <rect x="30" y="68" width="1380" height="62" rx="14" fill="rgba(21,101,192,0.04)" stroke="#90caf9" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="52" y="90" font-size="9" font-weight="700" fill="#1565c0" letter-spacing="0.8">EXTERNAL</text>
+
+  <!-- Operator -->
+  <g filter="url(#sh)">
+    <rect x="130" y="76" width="220" height="44" rx="8" fill="#fff" stroke="#bbdefb" stroke-width="1.5"/>
+  </g>
+  <rect x="140" y="84" width="28" height="28" rx="7" fill="#1565c0"/>
+  <text x="154" y="103" text-anchor="middle" font-size="14" fill="#fff">&#9881;</text>
+  <text x="176" y="96" font-size="10" font-weight="600" fill="#1a1a1a">Cost Management Metrics Operator</text>
+  <text x="176" y="110" font-size="9" fill="#868e96">Uploads cost data from clusters</text>
+
+  <!-- Browser -->
+  <g filter="url(#sh)">
+    <rect x="380" y="76" width="180" height="44" rx="8" fill="#fff" stroke="#bbdefb" stroke-width="1.5"/>
+  </g>
+  <rect x="390" y="84" width="28" height="28" rx="7" fill="#00695c"/>
+  <text x="404" y="103" text-anchor="middle" font-size="14" fill="#fff">&#9787;</text>
+  <text x="426" y="96" font-size="11" font-weight="600" fill="#1a1a1a">Browser Users</text>
+  <text x="426" y="110" font-size="9" fill="#868e96">Dashboard &amp; APIs</text>
+
+  <!-- OpenShift Routes -->
+  <g filter="url(#sh)">
+    <rect x="590" y="76" width="200" height="44" rx="8" fill="#fff" stroke="#bbdefb" stroke-width="1.5"/>
+  </g>
+  <rect x="600" y="84" width="28" height="28" rx="7" fill="#e65100"/>
+  <text x="614" y="103" text-anchor="middle" font-size="14" fill="#fff">&#9729;</text>
+  <text x="636" y="96" font-size="11" font-weight="600" fill="#1a1a1a">OpenShift Routes</text>
+  <text x="636" y="110" font-size="9" fill="#868e96">HTTPS &amp; TLS termination</text>
+
+  <!-- ==================== AUTH ZONE (left) ==================== -->
+  <rect x="30" y="144" width="188" height="170" rx="14" fill="rgba(198,40,40,0.04)" stroke="#ef9a9a" stroke-width="1.5"/>
+  <text x="48" y="164" font-size="9" font-weight="700" fill="#c62828" letter-spacing="0.8">AUTHENTICATION</text>
+
+  <g filter="url(#sh)">
+    <rect x="42" y="174" width="164" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="52" y="186" width="26" height="26" rx="6" fill="#c62828"/>
+  <text x="65" y="204" text-anchor="middle" font-size="12" fill="#fff">&#128274;</text>
+  <text x="86" y="198" font-size="11" font-weight="600" fill="#1a1a1a">Keycloak</text>
+  <text x="86" y="212" font-size="9" fill="#868e96">OIDC &amp; JWT tokens</text>
+
+  <g filter="url(#sh)">
+    <rect x="42" y="230" width="164" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="52" y="242" width="26" height="26" rx="6" fill="#c62828"/>
+  <text x="65" y="260" text-anchor="middle" font-size="12" fill="#fff">&#9787;</text>
+  <text x="86" y="254" font-size="11" font-weight="600" fill="#1a1a1a">User Mgmt</text>
+  <text x="86" y="268" font-size="9" fill="#868e96">Realm: kubernetes</text>
+
+  <!-- ==================== GATEWAY ZONE (right of auth) ==================== -->
+  <rect x="230" y="144" width="200" height="170" rx="14" fill="rgba(40,53,147,0.05)" stroke="#c5cae9" stroke-width="1.5"/>
+  <text x="248" y="164" font-size="9" font-weight="700" fill="#283593" letter-spacing="0.8">API GATEWAY</text>
+
+  <g filter="url(#sh)">
+    <rect x="242" y="174" width="176" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="252" y="186" width="26" height="26" rx="6" fill="#283593"/>
+  <text x="265" y="204" text-anchor="middle" font-size="12" fill="#fff">&#9741;</text>
+  <text x="286" y="198" font-size="11" font-weight="600" fill="#1a1a1a">Envoy Gateway</text>
+  <text x="286" y="212" font-size="9" fill="#868e96">JWT auth &amp; routing</text>
+
+  <g filter="url(#sh)">
+    <rect x="242" y="230" width="176" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="252" y="242" width="26" height="26" rx="6" fill="#283593"/>
+  <text x="265" y="260" text-anchor="middle" font-size="12" fill="#fff">&#8644;</text>
+  <text x="286" y="254" font-size="11" font-weight="600" fill="#1a1a1a">Path Routing</text>
+  <text x="286" y="268" font-size="9" fill="#868e96">/api/* dispatch</text>
+
+  <!-- ==================== INFRASTRUCTURE ZONE ==================== -->
+  <rect x="442" y="144" width="968" height="110" rx="14" fill="rgba(69,90,100,0.04)" stroke="#b0bec5" stroke-width="1.5"/>
+  <text x="460" y="164" font-size="9" font-weight="700" fill="#455a64" letter-spacing="0.8">INFRASTRUCTURE</text>
+
+  <!-- PostgreSQL -->
+  <g filter="url(#sh)">
+    <rect x="454" y="174" width="210" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="464" y="186" width="26" height="26" rx="6" fill="#1565c0"/>
+  <text x="477" y="203" text-anchor="middle" font-size="11" fill="#fff">DB</text>
+  <text x="498" y="198" font-size="11" font-weight="600" fill="#1a1a1a">PostgreSQL 16</text>
+  <text x="498" y="212" font-size="9" fill="#868e96">3 DBs: koku, ros, kruize</text>
+
+  <!-- S3 -->
+  <g filter="url(#sh)">
+    <rect x="674" y="174" width="180" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="684" y="186" width="26" height="26" rx="6" fill="#e65100"/>
+  <text x="697" y="203" text-anchor="middle" font-size="11" fill="#fff">S3</text>
+  <text x="718" y="198" font-size="11" font-weight="600" fill="#1a1a1a">S3 Storage</text>
+  <text x="718" y="212" font-size="9" fill="#868e96">Upload &amp; data buckets</text>
+
+  <!-- Kafka -->
+  <g filter="url(#sh)">
+    <rect x="864" y="174" width="180" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="874" y="186" width="26" height="26" rx="6" fill="#455a64"/>
+  <text x="887" y="204" text-anchor="middle" font-size="12" fill="#fff">&#9993;</text>
+  <text x="908" y="198" font-size="11" font-weight="600" fill="#1a1a1a">Kafka</text>
+  <text x="908" y="212" font-size="9" fill="#868e96">Event streaming (4 topics)</text>
+
+  <!-- Valkey -->
+  <g filter="url(#sh)">
+    <rect x="1054" y="174" width="180" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="1064" y="186" width="26" height="26" rx="6" fill="#d32f2f"/>
+  <text x="1077" y="204" text-anchor="middle" font-size="12" fill="#fff">&#9776;</text>
+  <text x="1098" y="198" font-size="11" font-weight="600" fill="#1a1a1a">Valkey 8</text>
+  <text x="1098" y="212" font-size="9" fill="#868e96">Task queue &amp; cache</text>
+
+  <!-- ==================== UI ZONE (leftmost) ==================== -->
+  <rect x="30" y="326" width="250" height="290" rx="14" fill="rgba(0,105,92,0.04)" stroke="#80cbc4" stroke-width="1.5"/>
+  <text x="48" y="348" font-size="9" font-weight="700" fill="#00695c" letter-spacing="0.8">USER INTERFACE</text>
+
+  <!-- UI -->
+  <g filter="url(#sh)">
+    <rect x="42" y="358" width="226" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="52" y="370" width="26" height="26" rx="6" fill="#00695c"/>
+  <text x="65" y="388" text-anchor="middle" font-size="11" fill="#fff">&#9633;</text>
+  <text x="86" y="382" font-size="11" font-weight="600" fill="#1a1a1a">Cost Management UI</text>
+  <text x="86" y="396" font-size="9" fill="#868e96">Dashboard, reports &amp; IAM</text>
+
+  <!-- OAuth2 Proxy -->
+  <g filter="url(#sh)">
+    <rect x="42" y="416" width="226" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="52" y="428" width="26" height="26" rx="6" fill="#00897b"/>
+  <text x="65" y="446" text-anchor="middle" font-size="11" fill="#fff">&#9741;</text>
+  <text x="86" y="440" font-size="11" font-weight="600" fill="#1a1a1a">OAuth2 Proxy</text>
+  <text x="86" y="454" font-size="9" fill="#868e96">Keycloak OIDC sidecar</text>
+
+  <!-- Capabilities -->
+  <rect x="42" y="478" width="226" height="100" rx="8" fill="#e0f2f1"/>
+  <text x="54" y="496" font-size="9.5" font-weight="600" fill="#00695c">CAPABILITIES</text>
+  <circle cx="58" cy="514" r="2.5" fill="#00695c"/>
+  <text x="68" y="518" font-size="10" fill="#495057">Cost trends &amp; breakdown</text>
+  <circle cx="58" cy="532" r="2.5" fill="#00695c"/>
+  <text x="68" y="536" font-size="10" fill="#495057">Per-cluster cost allocation</text>
+  <circle cx="58" cy="550" r="2.5" fill="#00695c"/>
+  <text x="68" y="554" font-size="10" fill="#495057">Resource optimization recs</text>
+  <circle cx="58" cy="568" r="2.5" fill="#00695c"/>
+  <text x="68" y="572" font-size="10" fill="#495057">Cost model management</text>
+
+  <!-- ==================== COST MANAGEMENT ZONE ==================== -->
+  <rect x="292" y="326" width="580" height="290" rx="14" fill="rgba(46,125,50,0.04)" stroke="#a5d6a7" stroke-width="1.5"/>
+  <text x="310" y="348" font-size="9" font-weight="700" fill="#2e7d32" letter-spacing="0.8">COST MANAGEMENT (KOKU)</text>
+
+  <!-- Ingress -->
+  <g filter="url(#sh)">
+    <rect x="304" y="358" width="172" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="314" y="370" width="26" height="26" rx="6" fill="#2e7d32"/>
+  <text x="327" y="388" text-anchor="middle" font-size="11" fill="#fff">&#8593;</text>
+  <text x="348" y="382" font-size="11" font-weight="600" fill="#1a1a1a">Ingress</text>
+  <text x="348" y="396" font-size="9" fill="#868e96">Receives uploads, stages to S3</text>
+
+  <!-- Koku API -->
+  <g filter="url(#sh)">
+    <rect x="484" y="358" width="172" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="494" y="370" width="26" height="26" rx="6" fill="#2e7d32"/>
+  <text x="507" y="388" text-anchor="middle" font-size="11" fill="#fff">&#10003;</text>
+  <text x="528" y="382" font-size="11" font-weight="600" fill="#1a1a1a">Koku API</text>
+  <text x="528" y="396" font-size="9" fill="#868e96">REST API &amp; Sources</text>
+
+  <!-- Kafka Listener -->
+  <g filter="url(#sh)">
+    <rect x="664" y="358" width="196" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="674" y="370" width="26" height="26" rx="6" fill="#388e3c"/>
+  <text x="687" y="388" text-anchor="middle" font-size="11" fill="#fff">&#9993;</text>
+  <text x="708" y="382" font-size="11" font-weight="600" fill="#1a1a1a">Kafka Listener</text>
+  <text x="708" y="396" font-size="9" fill="#868e96">Consumes upload events</text>
+
+  <!-- MASU -->
+  <g filter="url(#sh)">
+    <rect x="304" y="416" width="172" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="314" y="428" width="26" height="26" rx="6" fill="#388e3c"/>
+  <text x="327" y="446" text-anchor="middle" font-size="11" fill="#fff">&#9881;</text>
+  <text x="348" y="440" font-size="11" font-weight="600" fill="#1a1a1a">MASU Processor</text>
+  <text x="348" y="454" font-size="9" fill="#868e96">Data processing engine</text>
+
+  <!-- Celery Workers -->
+  <g filter="url(#sh)">
+    <rect x="484" y="416" width="376" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="494" y="428" width="26" height="26" rx="6" fill="#1b5e20"/>
+  <text x="507" y="446" text-anchor="middle" font-size="11" fill="#fff">&#9881;</text>
+  <text x="528" y="440" font-size="11" font-weight="600" fill="#1a1a1a">Celery Workers (5 queues)</text>
+  <text x="528" y="454" font-size="9" fill="#868e96">Default, Priority, OCP, Summary, Cost Model + Scheduler</text>
+
+  <!-- Data flow box -->
+  <rect x="304" y="478" width="556" height="52" rx="8" fill="#f1f8e9" stroke="#c8e6c9" stroke-width="1"/>
+  <text x="314" y="496" font-size="9" font-weight="600" fill="#2e7d32" letter-spacing="0.5">DATA FLOW</text>
+  <text x="314" y="514" font-size="10" fill="#495057">Operator &#8594; Ingress &#8594; S3 + Kafka &#8594; Listener &#8594; Valkey &#8594; Workers &#8594; PostgreSQL &#8594; API</text>
+
+  <!-- ==================== ROS ZONE ==================== -->
+  <rect x="884" y="326" width="526" height="290" rx="14" fill="rgba(106,27,154,0.04)" stroke="#ce93d8" stroke-width="1.5"/>
+  <text x="902" y="348" font-size="9" font-weight="700" fill="#6a1b9a" letter-spacing="0.8">RESOURCE OPTIMIZATION (ROS)</text>
+
+  <!-- ROS API -->
+  <g filter="url(#sh)">
+    <rect x="896" y="358" width="240" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="906" y="370" width="26" height="26" rx="6" fill="#6a1b9a"/>
+  <text x="919" y="388" text-anchor="middle" font-size="11" fill="#fff">&#10003;</text>
+  <text x="940" y="382" font-size="11" font-weight="600" fill="#1a1a1a">ROS API</text>
+  <text x="940" y="396" font-size="9" fill="#868e96">Recommendations endpoint</text>
+
+  <!-- ROS Processor -->
+  <g filter="url(#sh)">
+    <rect x="1148" y="358" width="250" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="1158" y="370" width="26" height="26" rx="6" fill="#6a1b9a"/>
+  <text x="1171" y="388" text-anchor="middle" font-size="11" fill="#fff">&#9881;</text>
+  <text x="1192" y="382" font-size="11" font-weight="600" fill="#1a1a1a">ROS Processor</text>
+  <text x="1192" y="396" font-size="9" fill="#868e96">Processes workload data</text>
+
+  <!-- Recommendation Poller -->
+  <g filter="url(#sh)">
+    <rect x="896" y="416" width="240" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="906" y="428" width="26" height="26" rx="6" fill="#8e24aa"/>
+  <text x="919" y="446" text-anchor="middle" font-size="11" fill="#fff">&#8635;</text>
+  <text x="940" y="440" font-size="11" font-weight="600" fill="#1a1a1a">Rec. Poller</text>
+  <text x="940" y="454" font-size="9" fill="#868e96">Polls Kruize for results</text>
+
+  <!-- Kruize -->
+  <g filter="url(#sh)">
+    <rect x="1148" y="416" width="250" height="50" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="1158" y="428" width="26" height="26" rx="6" fill="#8e24aa"/>
+  <text x="1171" y="446" text-anchor="middle" font-size="11" fill="#fff">&#9733;</text>
+  <text x="1192" y="440" font-size="11" font-weight="600" fill="#1a1a1a">Kruize Engine</text>
+  <text x="1192" y="454" font-size="9" fill="#868e96">Optimization analysis</text>
+
+  <!-- Housekeeper -->
+  <g filter="url(#sh)">
+    <rect x="896" y="478" width="502" height="46" rx="10" fill="#fff" stroke="#e9ecef" stroke-width="1.5"/>
+  </g>
+  <rect x="906" y="488" width="26" height="26" rx="6" fill="#7b1fa2"/>
+  <text x="919" y="506" text-anchor="middle" font-size="11" fill="#fff">&#8962;</text>
+  <text x="940" y="502" font-size="11" font-weight="600" fill="#1a1a1a">Housekeeper</text>
+  <text x="1028" y="502" font-size="9" fill="#868e96">Source monitoring &amp; maintenance</text>
+
+  <!-- ROS Data flow -->
+  <rect x="896" y="532" width="502" height="38" rx="8" fill="#f3e5f5" stroke="#e1bee7" stroke-width="1"/>
+  <text x="906" y="548" font-size="9" font-weight="600" fill="#6a1b9a" letter-spacing="0.5">DATA FLOW</text>
+  <text x="906" y="562" font-size="10" fill="#495057">Kafka &#8594; Processor &#8594; Kruize &#8594; Poller &#8594; PostgreSQL &#8594; ROS API</text>
+
+  <!-- ==================== FLOW ARROWS (zone-to-zone only) ==================== -->
+  <!-- External → Gateway -->
+  <path d="M 240 120 L 330 144" stroke="#1565c0" stroke-width="1.8" fill="none" marker-end="url(#ab)"/>
+  <text x="270" y="126" font-size="8.5" font-weight="600" fill="#1565c0">HTTPS</text>
+
+  <!-- Auth → Gateway (JWT) -->
+  <path d="M 206 200 L 242 200" stroke="#c62828" stroke-width="1.8" fill="none" marker-end="url(#ar)"/>
+  <text x="210" y="194" font-size="8.5" font-weight="600" fill="#c62828">JWT</text>
+
+  <!-- Auth → UI (OIDC) -->
+  <path d="M 124 314 L 155 326" stroke="#c62828" stroke-width="1.5" fill="none" marker-end="url(#ar)" stroke-dasharray="5,3"/>
+  <text x="100" y="310" font-size="8.5" font-weight="600" fill="#c62828">OIDC login</text>
+
+  <!-- UI → Gateway (API calls) -->
+  <path d="M 200 326 L 330 314" stroke="#00695c" stroke-width="1.8" fill="none" marker-end="url(#at)"/>
+  <text x="260" y="316" font-size="8.5" font-weight="600" fill="#00695c">/api/*</text>
+
+  <!-- Gateway → Cost Mgmt -->
+  <path d="M 380 314 C 370 320, 340 328, 310 340" stroke="#283593" stroke-width="1.8" fill="none" marker-end="url(#ab)"/>
+  <text x="350" y="330" font-size="8.5" font-weight="600" fill="#283593">routes</text>
+
+  <!-- Cost Mgmt → Infrastructure -->
+  <path d="M 582 326 L 700 254" stroke="#455a64" stroke-width="1.8" fill="none" marker-end="url(#ay)"/>
+  <text x="610" y="280" font-size="8.5" font-weight="600" fill="#455a64">DB, S3, Kafka, Valkey</text>
+
+  <!-- ROS → Infrastructure -->
+  <path d="M 1100 326 L 1060 254" stroke="#455a64" stroke-width="1.8" fill="none" marker-end="url(#ay)"/>
+
+  <!-- ==================== LEGEND ==================== -->
+  <rect x="30" y="640" width="1380" height="44" rx="10" fill="rgba(255,255,255,0.6)"/>
+  <rect x="50" y="656" width="10" height="10" rx="3" fill="#283593"/>
+  <text x="66" y="665" font-size="9" fill="#868e96">Gateway &amp; Auth</text>
+  <rect x="170" y="656" width="10" height="10" rx="3" fill="#2e7d32"/>
+  <text x="186" y="665" font-size="9" fill="#868e96">Cost Processing</text>
+  <rect x="300" y="656" width="10" height="10" rx="3" fill="#6a1b9a"/>
+  <text x="316" y="665" font-size="9" fill="#868e96">Resource Optimization</text>
+  <rect x="460" y="656" width="10" height="10" rx="3" fill="#455a64"/>
+  <text x="476" y="665" font-size="9" fill="#868e96">Infrastructure</text>
+  <rect x="580" y="656" width="10" height="10" rx="3" fill="#00695c"/>
+  <text x="596" y="665" font-size="9" fill="#868e96">UI</text>
+  <rect x="640" y="656" width="10" height="10" rx="3" fill="#c62828"/>
+  <text x="656" y="665" font-size="9" fill="#868e96">Authentication</text>
+
+  <!-- Footer -->
+  <text x="1410" y="796" text-anchor="end" font-size="9" fill="#adb5bd">Cost Management On-Premise &#8226; Helm Chart Architecture</text>
+  <text x="30" y="796" font-size="9" fill="#adb5bd">OpenShift 4.x</text>
+</svg>

--- a/docs/data-processing-flow.svg
+++ b/docs/data-processing-flow.svg
@@ -1,0 +1,234 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 920" font-family="Segoe UI, Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arwBlue" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2B6CB0"/>
+    </marker>
+    <marker id="arwGreen" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#276749"/>
+    </marker>
+    <marker id="arwPurple" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B46C1"/>
+    </marker>
+    <marker id="arwOrange" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#C05621"/>
+    </marker>
+    <marker id="arwRed" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9B2C2C"/>
+    </marker>
+    <marker id="arwGray" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#718096"/>
+    </marker>
+    <filter id="shd" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="1" dy="1" stdDeviation="2" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="920" rx="8" fill="#F7FAFC"/>
+
+  <text x="600" y="36" text-anchor="middle" font-size="20" font-weight="700" fill="#1A202C">Cost Management On-Premise &#8212; Data Processing Flow</text>
+  <text x="600" y="56" text-anchor="middle" font-size="12" fill="#718096">CMMO Upload &#8594; Ingress &#8594; Koku Processing &#8594; Database (with JWT Authentication)</text>
+
+  <rect x="20" y="75" width="210" height="250" rx="6" fill="#EBF8FF" stroke="#BEE3F8" stroke-width="1.5"/>
+  <text x="125" y="96" text-anchor="middle" font-size="11" font-weight="600" fill="#2B6CB0">OpenShift Cluster (Operator)</text>
+
+  <rect x="40" y="115" width="170" height="60" rx="8" fill="#fff" stroke="#2B6CB0" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="125" y="139" text-anchor="middle" font-size="13" font-weight="600" fill="#2B6CB0">CMMO</text>
+  <text x="125" y="156" text-anchor="middle" font-size="9.5" fill="#4A5568">Cost Management</text>
+  <text x="125" y="168" text-anchor="middle" font-size="9.5" fill="#4A5568">Metrics Operator</text>
+
+  <rect x="35" y="200" width="180" height="50" rx="6" fill="#EBF4FF" stroke="#BEE3F8" stroke-width="1"/>
+  <text x="125" y="218" text-anchor="middle" font-size="10" fill="#2B6CB0" font-weight="600">Upload Payload</text>
+  <text x="125" y="232" text-anchor="middle" font-size="9" fill="#4A5568">.tgz (manifest.json + CSVs)</text>
+  <text x="125" y="244" text-anchor="middle" font-size="9" fill="#4A5568">Content-Type: hccm+tgz</text>
+
+  <rect x="35" y="262" width="180" height="48" rx="6" fill="#FFF5F5" stroke="#FED7D7" stroke-width="1"/>
+  <text x="125" y="280" text-anchor="middle" font-size="10" fill="#9B2C2C" font-weight="600">JWT Authentication</text>
+  <text x="125" y="294" text-anchor="middle" font-size="9" fill="#4A5568">Client: cost-management-operator</text>
+
+  <rect x="250" y="75" width="930" height="830" rx="6" fill="#F0FFF4" stroke="#C6F6D5" stroke-width="1.5"/>
+  <text x="715" y="96" text-anchor="middle" font-size="11" font-weight="600" fill="#276749">OpenShift Cluster &#8212; cost-onprem Namespace</text>
+
+  <rect x="510" y="115" width="160" height="54" rx="8" fill="#fff" stroke="#9B2C2C" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="590" y="139" text-anchor="middle" font-size="13" font-weight="600" fill="#9B2C2C">Keycloak (RHBK)</text>
+  <text x="590" y="156" text-anchor="middle" font-size="10" fill="#4A5568">OIDC / JWKS Provider</text>
+
+  <rect x="280" y="200" width="160" height="54" rx="8" fill="#fff" stroke="#276749" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="360" y="224" text-anchor="middle" font-size="13" font-weight="600" fill="#276749">OpenShift Route</text>
+  <text x="360" y="241" text-anchor="middle" font-size="10" fill="#4A5568">/api &#8594; Gateway</text>
+
+  <rect x="510" y="200" width="190" height="54" rx="8" fill="#fff" stroke="#276749" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="605" y="224" text-anchor="middle" font-size="13" font-weight="600" fill="#276749">Envoy Gateway</text>
+  <text x="605" y="241" text-anchor="middle" font-size="10" fill="#4A5568">JWT Validation + X-Rh-Identity</text>
+
+  <rect x="510" y="300" width="190" height="54" rx="8" fill="#fff" stroke="#6B46C1" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="605" y="324" text-anchor="middle" font-size="13" font-weight="600" fill="#6B46C1">Ingress Service</text>
+  <text x="605" y="341" text-anchor="middle" font-size="10" fill="#4A5568">insights-ingress-go</text>
+
+  <rect x="800" y="300" width="160" height="54" rx="8" fill="#fff" stroke="#C05621" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="880" y="324" text-anchor="middle" font-size="13" font-weight="600" fill="#C05621">S3 Storage</text>
+  <text x="880" y="341" text-anchor="middle" font-size="10" fill="#4A5568">NooBaa / ODF / MinIO</text>
+
+  <rect x="1000" y="290" width="155" height="72" rx="6" fill="#FFFAF0" stroke="#FEEBC8" stroke-width="1"/>
+  <text x="1077" y="308" text-anchor="middle" font-size="10" fill="#C05621" font-weight="600">Buckets</text>
+  <text x="1077" y="323" text-anchor="middle" font-size="9" fill="#4A5568">insights-upload-perma</text>
+  <text x="1077" y="337" text-anchor="middle" font-size="9" fill="#4A5568">koku-bucket</text>
+  <text x="1077" y="351" text-anchor="middle" font-size="9" fill="#4A5568">ros-data</text>
+
+  <rect x="510" y="400" width="190" height="54" rx="8" fill="#fff" stroke="#D69E2E" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="605" y="424" text-anchor="middle" font-size="13" font-weight="600" fill="#975A16">Kafka (AMQ Streams)</text>
+  <text x="605" y="441" text-anchor="middle" font-size="10" fill="#4A5568">Message Broker</text>
+
+  <rect x="750" y="390" width="210" height="72" rx="6" fill="#FFFFF0" stroke="#FEFCBF" stroke-width="1"/>
+  <text x="855" y="408" text-anchor="middle" font-size="10" fill="#975A16" font-weight="600">Topics</text>
+  <text x="855" y="423" text-anchor="middle" font-size="9" fill="#4A5568">platform.upload.announce</text>
+  <text x="855" y="437" text-anchor="middle" font-size="9" fill="#4A5568">hccm.ros.events</text>
+  <text x="855" y="451" text-anchor="middle" font-size="9" fill="#4A5568">rosocp.kruize.recommendations</text>
+
+  <rect x="270" y="490" width="710" height="80" rx="6" fill="#EBF4FF" stroke="#BEE3F8" stroke-width="1.2" stroke-dasharray="6,3"/>
+  <text x="625" y="510" text-anchor="middle" font-size="11" font-weight="600" fill="#2B6CB0">Koku Processing Pipeline</text>
+
+  <rect x="290" y="520" width="140" height="40" rx="8" fill="#fff" stroke="#2B6CB0" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="360" y="545" text-anchor="middle" font-size="12" font-weight="600" fill="#2B6CB0">Koku Listener</text>
+
+  <rect x="470" y="520" width="140" height="40" rx="8" fill="#fff" stroke="#2B6CB0" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="540" y="545" text-anchor="middle" font-size="12" font-weight="600" fill="#2B6CB0">MASU Processor</text>
+
+  <rect x="650" y="520" width="140" height="40" rx="8" fill="#fff" stroke="#2B6CB0" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="720" y="545" text-anchor="middle" font-size="12" font-weight="600" fill="#2B6CB0">Celery Workers</text>
+
+  <rect x="830" y="520" width="130" height="40" rx="8" fill="#fff" stroke="#718096" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="895" y="539" text-anchor="middle" font-size="11" font-weight="600" fill="#718096">Celery Beat</text>
+  <text x="895" y="553" text-anchor="middle" font-size="9.5" fill="#718096">+ Valkey (broker)</text>
+
+  <rect x="420" y="610" width="190" height="68" rx="8" fill="#fff" stroke="#276749" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="515" y="632" text-anchor="middle" font-size="13" font-weight="600" fill="#276749">PostgreSQL</text>
+  <text x="515" y="648" text-anchor="middle" font-size="10" fill="#4A5568">costonprem_koku</text>
+  <text x="515" y="662" text-anchor="middle" font-size="10" fill="#4A5568">costonprem_ros / costonprem_kruize</text>
+
+  <rect x="270" y="700" width="570" height="80" rx="6" fill="#FAF5FF" stroke="#E9D8FD" stroke-width="1.2" stroke-dasharray="6,3"/>
+  <text x="555" y="720" text-anchor="middle" font-size="11" font-weight="600" fill="#6B46C1">ROS (Resource Optimization) Pipeline</text>
+
+  <rect x="290" y="730" width="150" height="40" rx="8" fill="#fff" stroke="#6B46C1" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="365" y="755" text-anchor="middle" font-size="12" font-weight="600" fill="#6B46C1">ROS Processor</text>
+
+  <rect x="490" y="730" width="140" height="40" rx="8" fill="#fff" stroke="#6B46C1" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="560" y="755" text-anchor="middle" font-size="12" font-weight="600" fill="#6B46C1">Kruize</text>
+
+  <rect x="680" y="730" width="140" height="40" rx="8" fill="#fff" stroke="#6B46C1" stroke-width="1.5" filter="url(#shd)"/>
+  <text x="750" y="755" text-anchor="middle" font-size="12" font-weight="600" fill="#6B46C1">ROS API</text>
+
+
+  <!-- A: CMMO -> Keycloak (get JWT) -->
+  <path d="M 160 115 Q 160 80 350 80 Q 508 80 508 120" fill="none" stroke="#9B2C2C" stroke-width="1.6" marker-end="url(#arwRed)" stroke-dasharray="5,3"/>
+  <rect x="310" y="68" width="16" height="15" rx="7" fill="#9B2C2C"/>
+  <text x="318" y="79" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">A</text>
+  <text x="340" y="79" font-size="9" fill="#9B2C2C" font-weight="600">Get JWT</text>
+
+  <!-- 1: CMMO -> Route (upload, routed right of Upload Payload box) -->
+  <path d="M 210 145 L 232 145 L 232 227 L 278 227" fill="none" stroke="#2B6CB0" stroke-width="1.8" marker-end="url(#arwBlue)"/>
+  <rect x="238" y="183" width="16" height="15" rx="7" fill="#2B6CB0"/>
+  <text x="246" y="194" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">1</text>
+  <text x="264" y="194" font-size="9" fill="#2B6CB0" font-weight="600">POST /api/ingress/v1/upload</text>
+
+  <!-- 2: Route -> Gateway -->
+  <line x1="440" y1="227" x2="508" y2="227" stroke="#276749" stroke-width="1.8" marker-end="url(#arwGreen)"/>
+  <rect x="460" y="215" width="16" height="15" rx="7" fill="#276749"/>
+  <text x="468" y="226" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">2</text>
+
+  <!-- B: Gateway -> Keycloak (JWKS) -->
+  <path d="M 605 200 L 605 169" fill="none" stroke="#718096" stroke-width="1.3" marker-end="url(#arwGray)" stroke-dasharray="4,3"/>
+  <rect x="610" y="178" width="16" height="15" rx="7" fill="#718096"/>
+  <text x="618" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">B</text>
+  <text x="641" y="189" font-size="9" fill="#718096">JWKS</text>
+
+  <!-- 3: Gateway -> Ingress -->
+  <line x1="605" y1="254" x2="605" y2="298" stroke="#276749" stroke-width="1.8" marker-end="url(#arwGreen)"/>
+  <rect x="610" y="268" width="16" height="15" rx="7" fill="#276749"/>
+  <text x="618" y="279" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">3</text>
+  <text x="641" y="279" font-size="9" fill="#276749" font-weight="600">+ X-Rh-Identity</text>
+
+  <!-- 4: Ingress -> S3 (store) -->
+  <line x1="700" y1="327" x2="798" y2="327" stroke="#C05621" stroke-width="1.8" marker-end="url(#arwOrange)"/>
+  <rect x="735" y="315" width="16" height="15" rx="7" fill="#C05621"/>
+  <text x="743" y="326" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">4</text>
+  <text x="743" y="311" text-anchor="middle" font-size="9" fill="#C05621" font-weight="600">Store tarball</text>
+
+  <!-- 5: Ingress -> Kafka (announce) -->
+  <line x1="605" y1="354" x2="605" y2="398" stroke="#975A16" stroke-width="1.8" marker-end="url(#arwOrange)"/>
+  <rect x="610" y="368" width="16" height="15" rx="7" fill="#975A16"/>
+  <text x="618" y="379" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">5</text>
+  <text x="641" y="379" font-size="9" fill="#975A16" font-weight="600">Announce upload</text>
+
+  <!-- 6: Kafka -> Listener (consume, routed left to avoid crossing arrow 10) -->
+  <path d="M 510 450 Q 420 475 360 518" fill="none" stroke="#2B6CB0" stroke-width="1.8" marker-end="url(#arwBlue)"/>
+  <rect x="408" y="468" width="16" height="15" rx="7" fill="#2B6CB0"/>
+  <text x="416" y="479" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">6</text>
+  <text x="390" y="464" font-size="9" fill="#2B6CB0" font-weight="600">Consume announce</text>
+
+  <!-- 7: Listener -> MASU -->
+  <line x1="430" y1="540" x2="468" y2="540" stroke="#2B6CB0" stroke-width="1.8" marker-end="url(#arwBlue)"/>
+  <rect x="440" y="528" width="16" height="15" rx="7" fill="#2B6CB0"/>
+  <text x="448" y="539" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">7</text>
+
+  <!-- 8: MASU -> Workers -->
+  <line x1="610" y1="540" x2="648" y2="540" stroke="#2B6CB0" stroke-width="1.8" marker-end="url(#arwBlue)"/>
+  <rect x="620" y="528" width="16" height="15" rx="7" fill="#2B6CB0"/>
+  <text x="628" y="539" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">8</text>
+
+  <!-- Pipelines -> S3 (read data, single arrow for both Koku and ROS pipelines) -->
+  <path d="M 980 510 Q 1010 430 960 354" fill="none" stroke="#C05621" stroke-width="1.3" marker-end="url(#arwOrange)" stroke-dasharray="4,3"/>
+  <text x="1015" y="440" font-size="9" fill="#C05621">Read data</text>
+  <text x="1015" y="452" font-size="8" fill="#718096">(both pipelines)</text>
+
+  <!-- 9: Workers -> Database -->
+  <path d="M 720 560 L 720 600 Q 720 620 612 630" fill="none" stroke="#276749" stroke-width="1.8" marker-end="url(#arwGreen)"/>
+  <rect x="700" y="580" width="16" height="15" rx="7" fill="#276749"/>
+  <text x="708" y="591" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">9</text>
+  <text x="730" y="591" font-size="9" fill="#276749" font-weight="600">Store processed data</text>
+
+  <!-- 10: MASU -> Kafka (ROS events, from MASU left corner) -->
+  <path d="M 470 520 Q 480 487 520 454" fill="none" stroke="#6B46C1" stroke-width="1.6" marker-end="url(#arwPurple)"/>
+  <rect x="448" y="478" width="22" height="15" rx="7" fill="#6B46C1"/>
+  <text x="459" y="489" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">10</text>
+  <text x="435" y="474" font-size="9" fill="#6B46C1" font-weight="600" text-anchor="end">ROS events</text>
+
+  <!-- 11: Kafka -> ROS Processor (via left margin, rounded corners) -->
+  <path d="M 510 440 L 283 440 Q 268 440 268 455 L 268 735 Q 268 750 283 750 L 290 750" fill="none" stroke="#6B46C1" stroke-width="1.6" marker-end="url(#arwPurple)"/>
+  <rect x="330" y="425" width="22" height="15" rx="7" fill="#6B46C1"/>
+  <text x="341" y="436" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">11</text>
+
+  <!-- 12: ROS Processor -> Kruize -->
+  <line x1="440" y1="750" x2="488" y2="750" stroke="#6B46C1" stroke-width="1.6" marker-end="url(#arwPurple)"/>
+  <rect x="450" y="738" width="22" height="15" rx="7" fill="#6B46C1"/>
+  <text x="461" y="749" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">12</text>
+
+  <!-- 13: Kruize -> ROS API -->
+  <line x1="630" y1="750" x2="678" y2="750" stroke="#6B46C1" stroke-width="1.6" marker-end="url(#arwPurple)"/>
+  <rect x="642" y="738" width="22" height="15" rx="7" fill="#6B46C1"/>
+  <text x="653" y="749" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">13</text>
+
+  <!-- ROS -> PostgreSQL (same DB instance serves all databases) -->
+  <path d="M 750 730 Q 680 695 610 672" fill="none" stroke="#718096" stroke-width="1.3" marker-end="url(#arwGray)" stroke-dasharray="4,3"/>
+
+  <!-- Legend -->
+  <rect x="20" y="830" width="1160" height="78" rx="6" fill="#fff" stroke="#E2E8F0" stroke-width="1"/>
+  <text x="600" y="852" text-anchor="middle" font-size="13" font-weight="700" fill="#1A202C">Flow Summary</text>
+
+  <rect x="40" y="862" width="12" height="12" rx="2" fill="#9B2C2C"/>
+  <text x="58" y="873" font-size="10" fill="#4A5568">A: CMMO gets JWT from Keycloak</text>
+
+  <rect x="240" y="862" width="12" height="12" rx="2" fill="#2B6CB0"/>
+  <text x="258" y="873" font-size="10" fill="#4A5568">1-3: Upload via Route &#8594; Envoy (JWT validated) &#8594; Ingress</text>
+
+  <rect x="555" y="862" width="12" height="12" rx="2" fill="#C05621"/>
+  <text x="573" y="873" font-size="10" fill="#4A5568">4-5: Store to S3 + announce to Kafka</text>
+
+  <rect x="40" y="882" width="12" height="12" rx="2" fill="#2B6CB0"/>
+  <text x="58" y="893" font-size="10" fill="#4A5568">6-9: Listener &#8594; MASU &#8594; Celery Workers &#8594; PostgreSQL</text>
+
+  <rect x="380" y="882" width="12" height="12" rx="2" fill="#6B46C1"/>
+  <text x="398" y="893" font-size="10" fill="#4A5568">10-13: ROS pipeline &#8212; MASU emits events &#8594; ROS Processor &#8594; Kruize &#8594; ROS API</text>
+
+  <rect x="830" y="862" width="12" height="12" rx="2" fill="#276749"/>
+  <text x="848" y="873" font-size="10" fill="#4A5568">Envoy injects X-Rh-Identity header; backends trust gateway auth</text>
+</svg>

--- a/docs/gateway-routing-diagram.svg
+++ b/docs/gateway-routing-diagram.svg
@@ -1,0 +1,194 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 880" font-family="Segoe UI, Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aPink" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0,8 3,0 6" fill="#c2185b"/>
+    </marker>
+    <marker id="aPurple" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0,8 3,0 6" fill="#7b1fa2"/>
+    </marker>
+    <marker id="aBlue" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0,8 3,0 6" fill="#01579b"/>
+    </marker>
+    <marker id="aOrange" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0,8 3,0 6" fill="#ef6c00"/>
+    </marker>
+    <marker id="aGreen" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0,8 3,0 6" fill="#2e7d32"/>
+    </marker>
+    <marker id="aGray" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0,8 3,0 6" fill="#546e7a"/>
+    </marker>
+    <filter id="sh" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="1" dy="1" stdDeviation="2" flood-opacity="0.1"/>
+    </filter>
+  </defs>
+
+  <rect width="1300" height="880" rx="8" fill="#f8f9fa"/>
+
+  <text x="650" y="32" text-anchor="middle" font-size="20" font-weight="700" fill="#1a1a1a">Cost Management On-Premise &#8212; Gateway Routing</text>
+  <text x="650" y="50" text-anchor="middle" font-size="11" fill="#868e96">Request flow from external clients through Envoy gateway to backend services</text>
+
+  <!-- ==================== EXTERNAL TRAFFIC ==================== -->
+  <!-- Arranged left-to-right by target: API+Operator -> RouteAPI (left), Browser -> RouteUI (right) -->
+  <rect x="40" y="65" width="880" height="80" rx="10" fill="#fce4ec" stroke="#c2185b" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="58" y="82" font-size="9" font-weight="700" fill="#c2185b" letter-spacing="0.8">EXTERNAL TRAFFIC</text>
+
+  <rect x="60" y="90" width="180" height="44" rx="8" fill="#fff" stroke="#c2185b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="150" y="110" text-anchor="middle" font-size="12" font-weight="600" fill="#1a1a1a">API Client</text>
+  <text x="150" y="124" text-anchor="middle" font-size="9" fill="#868e96">curl, scripts</text>
+
+  <rect x="270" y="90" width="310" height="44" rx="8" fill="#fff" stroke="#c2185b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="425" y="110" text-anchor="middle" font-size="12" font-weight="600" fill="#1a1a1a">Cost Management Metrics Operator</text>
+  <text x="425" y="124" text-anchor="middle" font-size="9" fill="#868e96">/api/cost-management/*, /api/ingress/*</text>
+
+  <rect x="620" y="90" width="280" height="44" rx="8" fill="#fff" stroke="#c2185b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="760" y="110" text-anchor="middle" font-size="12" font-weight="600" fill="#1a1a1a">Browser</text>
+  <text x="760" y="124" text-anchor="middle" font-size="9" fill="#868e96">UI access (dashboard, reports)</text>
+
+  <!-- ==================== OPENSHIFT ROUTER ==================== -->
+  <rect x="80" y="180" width="780" height="75" rx="10" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="98" y="197" font-size="9" font-weight="700" fill="#7b1fa2" letter-spacing="0.8">OPENSHIFT ROUTER</text>
+
+  <rect x="100" y="205" width="300" height="40" rx="8" fill="#fff" stroke="#7b1fa2" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="250" y="222" text-anchor="middle" font-size="11" font-weight="600" fill="#1a1a1a">Route: /api/* &#8594; gateway:80</text>
+  <text x="250" y="236" text-anchor="middle" font-size="9" fill="#868e96">API traffic</text>
+
+  <rect x="530" y="205" width="300" height="40" rx="8" fill="#fff" stroke="#7b1fa2" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="680" y="222" text-anchor="middle" font-size="11" font-weight="600" fill="#1a1a1a">Route: / &#8594; ui:443</text>
+  <text x="680" y="236" text-anchor="middle" font-size="9" fill="#868e96">UI traffic (TLS reencrypt)</text>
+
+  <!-- ==================== ENVOY GATEWAY POD ==================== -->
+  <rect x="40" y="295" width="590" height="265" rx="10" fill="#e1f5fe" stroke="#01579b" stroke-width="1.5"/>
+  <text x="58" y="315" font-size="9" font-weight="700" fill="#01579b" letter-spacing="0.8">ENVOY GATEWAY POD</text>
+
+  <rect x="60" y="325" width="260" height="40" rx="8" fill="#fff" stroke="#01579b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="190" y="342" text-anchor="middle" font-size="12" font-weight="600" fill="#01579b">Envoy Proxy :9080</text>
+  <text x="190" y="356" text-anchor="middle" font-size="9" fill="#868e96">Main listener</text>
+
+  <rect x="340" y="325" width="270" height="40" rx="8" fill="#fff" stroke="#01579b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="475" y="342" text-anchor="middle" font-size="12" font-weight="600" fill="#01579b">Admin :9901</text>
+  <text x="475" y="356" text-anchor="middle" font-size="9" fill="#868e96">/stats/prometheus</text>
+
+  <!-- Filters subgroup -->
+  <rect x="60" y="380" width="550" height="165" rx="8" fill="rgba(1,87,155,0.06)" stroke="#01579b" stroke-width="1" stroke-dasharray="5,3"/>
+  <text x="78" y="398" font-size="9" font-weight="700" fill="#01579b" letter-spacing="0.6">HTTP FILTER CHAIN</text>
+
+  <rect x="80" y="415" width="155" height="55" rx="8" fill="#fff" stroke="#01579b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="157" y="436" text-anchor="middle" font-size="11" font-weight="600" fill="#01579b">JWT Auth Filter</text>
+  <text x="157" y="452" text-anchor="middle" font-size="9" fill="#868e96">Keycloak validation</text>
+
+  <rect x="260" y="415" width="155" height="55" rx="8" fill="#fff" stroke="#01579b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="337" y="436" text-anchor="middle" font-size="11" font-weight="600" fill="#01579b">Lua Filter</text>
+  <text x="337" y="452" text-anchor="middle" font-size="9" fill="#868e96">X-Rh-Identity injection</text>
+
+  <rect x="440" y="415" width="155" height="55" rx="8" fill="#fff" stroke="#01579b" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="517" y="436" text-anchor="middle" font-size="11" font-weight="600" fill="#01579b">Router Filter</text>
+  <text x="517" y="452" text-anchor="middle" font-size="9" fill="#868e96">Path + method routing</text>
+
+  <!-- Filter chain arrows -->
+  <line x1="235" y1="442" x2="258" y2="442" stroke="#01579b" stroke-width="1.8" marker-end="url(#aBlue)"/>
+  <line x1="415" y1="442" x2="438" y2="442" stroke="#01579b" stroke-width="1.8" marker-end="url(#aBlue)"/>
+
+  <text x="335" y="496" text-anchor="middle" font-size="10" fill="#01579b" font-style="italic">Validate &#8594; Enrich &#8594; Route</text>
+
+  <!-- Gateway routing summary -->
+  <text x="78" y="514" font-size="9" fill="#546e7a">Routes: /api/cost-management/* | /api/ingress/* | /api/.../recommendations/openshift</text>
+  <text x="78" y="530" font-size="9" fill="#546e7a">Koku API handles cost-management + sources; read/write split via Envoy route match</text>
+
+  <!-- ==================== UI POD ==================== -->
+  <rect x="670" y="295" width="310" height="220" rx="10" fill="#fff3e0" stroke="#ef6c00" stroke-width="1.5"/>
+  <text x="688" y="315" font-size="9" font-weight="700" fill="#ef6c00" letter-spacing="0.8">UI POD</text>
+
+  <rect x="690" y="325" width="270" height="40" rx="8" fill="#fff" stroke="#ef6c00" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="825" y="342" text-anchor="middle" font-size="12" font-weight="600" fill="#ef6c00">oauth2-proxy :4180</text>
+  <text x="825" y="356" text-anchor="middle" font-size="9" fill="#868e96">Keycloak OIDC sidecar</text>
+
+  <rect x="690" y="385" width="270" height="40" rx="8" fill="#fff" stroke="#ef6c00" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="825" y="402" text-anchor="middle" font-size="12" font-weight="600" fill="#ef6c00">nginx :8080</text>
+  <text x="825" y="416" text-anchor="middle" font-size="9" fill="#868e96">Reverse proxy + static server</text>
+
+  <rect x="690" y="445" width="270" height="40" rx="8" fill="#fff" stroke="#ef6c00" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="825" y="462" text-anchor="middle" font-size="12" font-weight="600" fill="#ef6c00">Static Files</text>
+  <text x="825" y="476" text-anchor="middle" font-size="9" fill="#868e96">/opt/app-root/src/</text>
+
+  <!-- ==================== KEYCLOAK (below UI Pod) ==================== -->
+  <rect x="790" y="530" width="250" height="95" rx="10" fill="#ffebee" stroke="#c62828" stroke-width="1.5"/>
+  <text x="808" y="550" font-size="9" font-weight="700" fill="#c62828" letter-spacing="0.8">RHBK / KEYCLOAK</text>
+
+  <rect x="810" y="568" width="210" height="44" rx="8" fill="#fff" stroke="#c62828" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="915" y="587" text-anchor="middle" font-size="11" font-weight="600" fill="#c62828">JWKS Endpoint</text>
+  <text x="915" y="601" text-anchor="middle" font-size="9" fill="#868e96">/realms/.../certs</text>
+
+  <!-- ==================== BACKEND SERVICES ==================== -->
+  <rect x="40" y="605" width="720" height="105" rx="10" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5"/>
+  <text x="58" y="625" font-size="9" font-weight="700" fill="#2e7d32" letter-spacing="0.8">BACKEND SERVICES</text>
+
+  <rect x="60" y="635" width="250" height="60" rx="8" fill="#fff" stroke="#2e7d32" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="185" y="656" text-anchor="middle" font-size="12" font-weight="600" fill="#2e7d32">koku-api :8000</text>
+  <text x="185" y="672" text-anchor="middle" font-size="9" fill="#868e96">Cost management + sources (all methods)</text>
+  <text x="185" y="686" text-anchor="middle" font-size="9" fill="#546e7a">/api/cost-management/* | /api/sources/*</text>
+
+  <rect x="330" y="635" width="200" height="60" rx="8" fill="#fff" stroke="#2e7d32" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="430" y="656" text-anchor="middle" font-size="12" font-weight="600" fill="#2e7d32">ingress :8081</text>
+  <text x="430" y="672" text-anchor="middle" font-size="9" fill="#868e96">File upload</text>
+  <text x="430" y="686" text-anchor="middle" font-size="9" fill="#546e7a">/api/ingress/*</text>
+
+  <rect x="550" y="635" width="195" height="60" rx="8" fill="#fff" stroke="#2e7d32" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="647" y="656" text-anchor="middle" font-size="12" font-weight="600" fill="#2e7d32">ros-api :8000</text>
+  <text x="647" y="672" text-anchor="middle" font-size="9" fill="#868e96">Recommendations</text>
+  <text x="647" y="686" text-anchor="middle" font-size="9" fill="#546e7a">/api/.../recommendations/*</text>
+
+  <!-- ==================== FLOW ARROWS ==================== -->
+
+  <!-- External -> Router (no crossings: left clients -> left route, right client -> right route) -->
+  <line x1="150" y1="134" x2="200" y2="203" stroke="#c2185b" stroke-width="1.6" marker-end="url(#aPink)"/>
+  <line x1="425" y1="134" x2="310" y2="203" stroke="#c2185b" stroke-width="1.6" marker-end="url(#aPink)"/>
+  <line x1="760" y1="134" x2="700" y2="203" stroke="#c2185b" stroke-width="1.6" marker-end="url(#aPink)"/>
+
+  <!-- Router -> Gateway / UI (no crossings) -->
+  <line x1="250" y1="245" x2="190" y2="323" stroke="#7b1fa2" stroke-width="1.6" marker-end="url(#aPurple)"/>
+  <line x1="680" y1="245" x2="780" y2="323" stroke="#7b1fa2" stroke-width="1.6" marker-end="url(#aPurple)"/>
+
+  <!-- UI internal flow -->
+  <line x1="825" y1="365" x2="825" y2="383" stroke="#ef6c00" stroke-width="1.5" marker-end="url(#aOrange)"/>
+  <line x1="825" y1="425" x2="825" y2="443" stroke="#ef6c00" stroke-width="1.5" marker-end="url(#aOrange)"/>
+  <text x="838" y="438" font-size="8" fill="#ef6c00">/*</text>
+
+  <!-- Nginx -> Gateway (/api/*) -->
+  <path d="M 690 405 L 632 405" fill="none" stroke="#ef6c00" stroke-width="1.5" marker-end="url(#aOrange)"/>
+  <text x="645" y="398" font-size="8" fill="#ef6c00">/api/*</text>
+
+  <!-- Gateway -> Backends (3 arrows fanning out without crossings) -->
+  <line x1="185" y1="560" x2="185" y2="633" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#aGreen)"/>
+  <line x1="335" y1="560" x2="430" y2="633" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#aGreen)"/>
+  <line x1="480" y1="560" x2="647" y2="633" stroke="#2e7d32" stroke-width="1.5" marker-end="url(#aGreen)"/>
+
+  <!-- Gateway -> Keycloak (dashed, short hop to the right) -->
+  <path d="M 632 555 L 788 555" fill="none" stroke="#c62828" stroke-width="1.5" marker-end="url(#aGray)" stroke-dasharray="6,3"/>
+  <text x="640" y="548" font-size="9" fill="#c62828" font-weight="600">Validate JWT (JWKS)</text>
+
+  <!-- ==================== LEGEND ==================== -->
+  <rect x="40" y="740" width="1230" height="55" rx="8" fill="#fff" stroke="#dee2e6" stroke-width="1"/>
+  <text x="650" y="760" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">Legend</text>
+
+  <rect x="70" y="774" width="14" height="14" rx="3" fill="#fce4ec" stroke="#c2185b" stroke-width="1"/>
+  <text x="92" y="786" font-size="10" fill="#546e7a">External Traffic</text>
+
+  <rect x="220" y="774" width="14" height="14" rx="3" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="1"/>
+  <text x="242" y="786" font-size="10" fill="#546e7a">OpenShift Router</text>
+
+  <rect x="380" y="774" width="14" height="14" rx="3" fill="#e1f5fe" stroke="#01579b" stroke-width="1"/>
+  <text x="402" y="786" font-size="10" fill="#546e7a">Envoy Gateway</text>
+
+  <rect x="530" y="774" width="14" height="14" rx="3" fill="#fff3e0" stroke="#ef6c00" stroke-width="1"/>
+  <text x="552" y="786" font-size="10" fill="#546e7a">UI Pod</text>
+
+  <rect x="630" y="774" width="14" height="14" rx="3" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1"/>
+  <text x="652" y="786" font-size="10" fill="#546e7a">Backend Services</text>
+
+  <rect x="800" y="774" width="14" height="14" rx="3" fill="#ffebee" stroke="#c62828" stroke-width="1"/>
+  <text x="822" y="786" font-size="10" fill="#546e7a">Keycloak (RHBK)</text>
+
+  <line x1="960" y1="781" x2="1000" y2="781" stroke="#546e7a" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="1010" y="786" font-size="10" fill="#546e7a">JWT validation</text>
+</svg>

--- a/docs/operations/cost-management-data-sources.md
+++ b/docs/operations/cost-management-data-sources.md
@@ -231,6 +231,8 @@ oc get namespace my-app-namespace --show-labels | grep cost_management_optimizat
 
 ## Data Upload Process
 
+![Data Processing Flow](../data-processing-flow.svg)
+
 ### Upload Workflow
 
 ```

--- a/docs/saas-to-onprem-transition-diagram.svg
+++ b/docs/saas-to-onprem-transition-diagram.svg
@@ -1,0 +1,205 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 774" width="1200" height="774">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700;800&amp;display=swap');
+      text { font-family: 'Red Hat Display', 'Segoe UI', Arial, sans-serif; }
+    </style>
+    <filter id="ts" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.06"/>
+    </filter>
+    <clipPath id="tc">
+      <rect x="40" y="86" width="1120" height="612" rx="8"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="774" fill="#f8f9fa"/>
+
+  <!-- Title -->
+  <text x="600" y="30" text-anchor="middle" font-size="22" font-weight="700" fill="#1a1a1a">Cost Management &#8212; What Changes</text>
+  <text x="600" y="48" text-anchor="middle" font-size="11" fill="#868e96">SaaS &#8594; On-Prem transition: only the components that differ (10 services remain unchanged)</text>
+
+  <!-- Legend -->
+  <g transform="translate(280,58)">
+    <rect width="10" height="10" rx="2" fill="#e65100"/>
+    <text x="16" y="9" font-size="9" fill="#495057">Replaced</text>
+    <rect x="85" width="10" height="10" rx="2" fill="#c62828"/>
+    <text x="101" y="9" font-size="9" fill="#495057">Removed</text>
+    <rect x="170" width="10" height="10" rx="2" fill="#283593"/>
+    <text x="186" y="9" font-size="9" fill="#495057">Merged</text>
+    <rect x="245" width="10" height="10" rx="2" fill="#1565c0"/>
+    <text x="261" y="9" font-size="9" fill="#495057">Kept (upgrade planned)</text>
+  </g>
+
+  <!-- Table shadow -->
+  <rect x="40" y="86" width="1120" height="612" rx="8" fill="#fff" filter="url(#ts)"/>
+
+  <!-- Table content (clipped to rounded rect) -->
+  <g clip-path="url(#tc)">
+    <rect x="40" y="86" width="1120" height="612" fill="#fff"/>
+
+    <!-- Column headers -->
+    <rect x="40" y="86" width="560" height="32" fill="#ffcdd2"/>
+    <text x="310" y="107" text-anchor="middle" font-size="13" font-weight="700" fill="#c62828">SaaS (console.redhat.com)</text>
+    <rect x="600" y="86" width="560" height="32" fill="#c8e6c9"/>
+    <text x="880" y="107" text-anchor="middle" font-size="13" font-weight="700" fill="#2e7d32">On-Prem (OpenShift)</text>
+
+    <!-- ===== FRONTEND & ENTRY ===== -->
+    <rect x="40" y="118" width="1120" height="22" fill="#f1f3f5"/>
+    <text x="56" y="133" font-size="8" font-weight="700" fill="#495057" letter-spacing="0.8">FRONTEND &amp; ENTRY</text>
+
+    <rect x="40" y="140" width="1120" height="32" fill="#fff3e0"/>
+    <rect x="40" y="140" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="161" font-size="11" font-weight="500" fill="#1a1a1a">console.redhat.com</text>
+    <text x="616" y="161" font-size="11" font-weight="500" fill="#1a1a1a">Cost Management UI + IAM</text>
+    <rect x="1092" y="149" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="159" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <rect x="40" y="172" width="1120" height="32" fill="#fff8f0"/>
+    <rect x="40" y="172" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="193" font-size="11" font-weight="500" fill="#1a1a1a">Akamai CDN</text>
+    <text x="616" y="193" font-size="11" font-weight="500" fill="#1a1a1a">OpenShift Routes</text>
+    <rect x="1092" y="181" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="191" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <rect x="40" y="204" width="1120" height="32" fill="#fff3e0"/>
+    <rect x="40" y="204" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="225" font-size="11" font-weight="500" fill="#1a1a1a">3scale API Gateway</text>
+    <text x="616" y="225" font-size="11" font-weight="500" fill="#1a1a1a">Envoy Gateway</text>
+    <rect x="1092" y="213" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="223" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <!-- ===== AUTH & IDENTITY ===== -->
+    <rect x="40" y="236" width="1120" height="22" fill="#f1f3f5"/>
+    <text x="56" y="251" font-size="8" font-weight="700" fill="#495057" letter-spacing="0.8">AUTH &amp; IDENTITY</text>
+
+    <rect x="40" y="258" width="1120" height="32" fill="#fff3e0"/>
+    <rect x="40" y="258" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="279" font-size="11" font-weight="500" fill="#1a1a1a">sso.redhat.com</text>
+    <text x="616" y="279" font-size="11" font-weight="500" fill="#1a1a1a">Keycloak (RHBK)</text>
+    <rect x="1092" y="267" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="277" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <rect x="40" y="290" width="1120" height="32" fill="#e3f2fd"/>
+    <rect x="40" y="290" width="4" height="32" fill="#1565c0"/>
+    <text x="60" y="311" font-size="11" font-weight="500" fill="#1a1a1a">RBAC Service</text>
+    <text x="616" y="307" font-size="11" font-weight="500" fill="#1a1a1a">RBAC Service (reused as-is)</text>
+    <text x="616" y="319" font-size="8" fill="#78909c" font-style="italic">planned upgrade to newer solution</text>
+    <rect x="1068" y="299" width="80" height="14" rx="4" fill="#1565c0"/>
+    <text x="1108" y="309" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">KEPT (for now)</text>
+
+    <!-- ===== CORE SERVICES ===== -->
+    <rect x="40" y="322" width="1120" height="22" fill="#f1f3f5"/>
+    <text x="56" y="337" font-size="8" font-weight="700" fill="#495057" letter-spacing="0.8">CORE SERVICES</text>
+
+    <rect x="40" y="344" width="1120" height="32" fill="#e8eaf6"/>
+    <rect x="40" y="344" width="4" height="32" fill="#283593"/>
+    <text x="60" y="365" font-size="11" font-weight="500" fill="#1a1a1a">Sources API (standalone)</text>
+    <text x="616" y="365" font-size="11" font-weight="500" fill="#283593" font-style="italic">Merged into Koku API</text>
+    <rect x="1092" y="353" width="56" height="14" rx="4" fill="#283593"/>
+    <text x="1120" y="363" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">MERGED</text>
+
+    <rect x="40" y="376" width="1120" height="32" fill="#ffebee"/>
+    <rect x="40" y="376" width="4" height="32" fill="#c62828"/>
+    <text x="60" y="397" font-size="11" font-weight="500" fill="#1a1a1a">Notifications</text>
+    <text x="616" y="397" font-size="11" fill="#adb5bd" font-style="italic">&#8212;</text>
+    <rect x="1092" y="385" width="56" height="14" rx="4" fill="#c62828"/>
+    <text x="1120" y="395" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REMOVED</text>
+
+    <!-- ===== DATA & QUERY LAYER ===== -->
+    <rect x="40" y="408" width="1120" height="22" fill="#f1f3f5"/>
+    <text x="56" y="423" font-size="8" font-weight="700" fill="#495057" letter-spacing="0.8">DATA &amp; QUERY LAYER</text>
+
+    <rect x="40" y="430" width="1120" height="32" fill="#fff3e0"/>
+    <rect x="40" y="430" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="451" font-size="11" font-weight="500" fill="#1a1a1a">Trino + Hive Metastore</text>
+    <text x="616" y="451" font-size="11" font-weight="500" fill="#1a1a1a">Direct PostgreSQL queries</text>
+    <rect x="1092" y="439" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="449" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <!-- ===== INFRASTRUCTURE ===== -->
+    <rect x="40" y="462" width="1120" height="22" fill="#f1f3f5"/>
+    <text x="56" y="477" font-size="8" font-weight="700" fill="#495057" letter-spacing="0.8">INFRASTRUCTURE</text>
+
+    <rect x="40" y="484" width="1120" height="32" fill="#fff3e0"/>
+    <rect x="40" y="484" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="505" font-size="11" font-weight="500" fill="#1a1a1a">RDS PostgreSQL</text>
+    <text x="616" y="505" font-size="11" font-weight="500" fill="#1a1a1a">PostgreSQL 16 (StatefulSet)</text>
+    <rect x="1092" y="493" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="503" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <rect x="40" y="516" width="1120" height="32" fill="#fff8f0"/>
+    <rect x="40" y="516" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="537" font-size="11" font-weight="500" fill="#1a1a1a">AWS S3</text>
+    <text x="616" y="537" font-size="11" font-weight="500" fill="#1a1a1a">ODF / NooBaa (S3-compatible)</text>
+    <rect x="1092" y="525" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="535" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <rect x="40" y="548" width="1120" height="32" fill="#fff3e0"/>
+    <rect x="40" y="548" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="569" font-size="11" font-weight="500" fill="#1a1a1a">MSK (Kafka)</text>
+    <text x="616" y="569" font-size="11" font-weight="500" fill="#1a1a1a">AMQ Streams (Kafka)</text>
+    <rect x="1092" y="557" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="567" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <rect x="40" y="580" width="1120" height="32" fill="#fff8f0"/>
+    <rect x="40" y="580" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="601" font-size="11" font-weight="500" fill="#1a1a1a">ElastiCache</text>
+    <text x="616" y="601" font-size="11" font-weight="500" fill="#1a1a1a">Valkey 8</text>
+    <rect x="1092" y="589" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="599" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <!-- ===== DEPLOYMENT ===== -->
+    <rect x="40" y="612" width="1120" height="22" fill="#f1f3f5"/>
+    <text x="56" y="627" font-size="8" font-weight="700" fill="#495057" letter-spacing="0.8">DEPLOYMENT</text>
+
+    <rect x="40" y="634" width="1120" height="32" fill="#fff3e0"/>
+    <rect x="40" y="634" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="655" font-size="11" font-weight="500" fill="#1a1a1a">Clowder Operator</text>
+    <text x="616" y="655" font-size="11" font-weight="500" fill="#1a1a1a">Helm Chart</text>
+    <rect x="1092" y="643" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="653" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <rect x="40" y="666" width="1120" height="32" fill="#fff8f0"/>
+    <rect x="40" y="666" width="4" height="32" fill="#e65100"/>
+    <text x="60" y="687" font-size="11" font-weight="500" fill="#1a1a1a">app-interface / AppSRE</text>
+    <text x="616" y="687" font-size="11" font-weight="500" fill="#1a1a1a">OpenShift 4.x (customer cluster)</text>
+    <rect x="1092" y="675" width="56" height="14" rx="4" fill="#e65100"/>
+    <text x="1120" y="685" text-anchor="middle" font-size="7" font-weight="700" fill="#fff">REPLACED</text>
+
+    <!-- Column divider -->
+    <line x1="600" y1="118" x2="600" y2="698" stroke="#dee2e6" stroke-width="1"/>
+
+    <!-- Subtle row separators -->
+    <line x1="40" y1="172" x2="1160" y2="172" stroke="rgba(0,0,0,0.04)" stroke-width="0.5"/>
+    <line x1="40" y1="204" x2="1160" y2="204" stroke="rgba(0,0,0,0.04)" stroke-width="0.5"/>
+    <line x1="40" y1="290" x2="1160" y2="290" stroke="rgba(0,0,0,0.04)" stroke-width="0.5"/>
+    <line x1="40" y1="516" x2="1160" y2="516" stroke="rgba(0,0,0,0.04)" stroke-width="0.5"/>
+    <line x1="40" y1="548" x2="1160" y2="548" stroke="rgba(0,0,0,0.04)" stroke-width="0.5"/>
+    <line x1="40" y1="580" x2="1160" y2="580" stroke="rgba(0,0,0,0.04)" stroke-width="0.5"/>
+    <line x1="40" y1="666" x2="1160" y2="666" stroke="rgba(0,0,0,0.04)" stroke-width="0.5"/>
+  </g>
+
+  <!-- Table border -->
+  <rect x="40" y="86" width="1120" height="612" rx="8" fill="none" stroke="#dee2e6" stroke-width="1.5"/>
+
+  <!-- Unchanged components note -->
+  <text x="600" y="722" text-anchor="middle" font-size="10" fill="#868e96"><tspan font-weight="600" fill="#495057">Unchanged (10):</tspan> Ingress, Koku API, MASU, Celery Workers, Kafka Listener, ROS API, ROS Processor, Kruize, ROS Poller, ROS Housekeeper</text>
+
+  <!-- Stats summary -->
+  <g transform="translate(230,738)">
+    <rect width="8" height="8" rx="2" fill="#e65100"/>
+    <text x="14" y="8" font-size="9" fill="#495057"><tspan font-weight="700">11</tspan> replaced</text>
+    <rect x="95" width="8" height="8" rx="2" fill="#c62828"/>
+    <text x="109" y="8" font-size="9" fill="#495057"><tspan font-weight="700">1</tspan> removed</text>
+    <rect x="170" width="8" height="8" rx="2" fill="#283593"/>
+    <text x="184" y="8" font-size="9" fill="#495057"><tspan font-weight="700">1</tspan> merged</text>
+    <rect x="248" width="8" height="8" rx="2" fill="#1565c0"/>
+    <text x="262" y="8" font-size="9" fill="#495057"><tspan font-weight="700">1</tspan> kept (upgrade planned)</text>
+    <rect x="400" width="8" height="8" rx="2" fill="#90a4ae"/>
+    <text x="414" y="8" font-size="9" fill="#495057"><tspan font-weight="700">10</tspan> unchanged</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="1160" y="766" text-anchor="end" font-size="8" fill="#adb5bd">Cost Management &#8226; SaaS &#8594; On-Prem Transition</text>
+</svg>

--- a/docs/ui-login-flow.svg
+++ b/docs/ui-login-flow.svg
@@ -1,0 +1,174 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 820" font-family="Segoe UI, Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2B6CB0"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#276749"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#C05621"/>
+    </marker>
+    <marker id="arrowGray" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#718096"/>
+    </marker>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="1" dy="1" stdDeviation="2" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+
+  <rect width="1100" height="820" rx="8" fill="#F7FAFC"/>
+
+  <text x="550" y="38" text-anchor="middle" font-size="20" font-weight="700" fill="#1A202C">Cost Management On-Premise &#8212; UI Login Flow</text>
+  <text x="550" y="58" text-anchor="middle" font-size="12" fill="#718096">OAuth2 Proxy + Keycloak OIDC Authentication</text>
+
+  <!-- External Zone -->
+  <rect x="20" y="75" width="200" height="720" rx="6" fill="#EBF8FF" stroke="#BEE3F8" stroke-width="1.5"/>
+  <text x="120" y="96" text-anchor="middle" font-size="11" font-weight="600" fill="#2B6CB0">External</text>
+
+  <rect x="45" y="115" width="150" height="54" rx="8" fill="#fff" stroke="#2B6CB0" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="120" y="139" text-anchor="middle" font-size="13" font-weight="600" fill="#2B6CB0">Browser</text>
+  <text x="120" y="156" text-anchor="middle" font-size="10" fill="#4A5568">End User</text>
+
+  <!-- OpenShift Cluster Zone -->
+  <rect x="240" y="75" width="840" height="720" rx="6" fill="#F0FFF4" stroke="#C6F6D5" stroke-width="1.5"/>
+  <text x="660" y="96" text-anchor="middle" font-size="11" font-weight="600" fill="#276749">OpenShift Cluster</text>
+
+  <rect x="280" y="115" width="160" height="54" rx="8" fill="#fff" stroke="#276749" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="360" y="139" text-anchor="middle" font-size="13" font-weight="600" fill="#276749">OpenShift Route</text>
+  <text x="360" y="156" text-anchor="middle" font-size="10" fill="#4A5568">TLS Termination</text>
+
+  <!-- UI Pod box -->
+  <rect x="270" y="200" width="380" height="200" rx="6" fill="#FEFCBF" stroke="#ECC94B" stroke-width="1.2" stroke-dasharray="6,3"/>
+  <text x="460" y="220" text-anchor="middle" font-size="11" font-weight="600" fill="#975A16">UI Pod</text>
+
+  <rect x="290" y="235" width="160" height="54" rx="8" fill="#fff" stroke="#D69E2E" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="370" y="259" text-anchor="middle" font-size="13" font-weight="600" fill="#975A16">OAuth2 Proxy</text>
+  <text x="370" y="276" text-anchor="middle" font-size="10" fill="#4A5568">OIDC + Session Cookie</text>
+
+  <rect x="290" y="320" width="160" height="54" rx="8" fill="#fff" stroke="#D69E2E" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="370" y="344" text-anchor="middle" font-size="13" font-weight="600" fill="#975A16">Nginx</text>
+  <text x="370" y="361" text-anchor="middle" font-size="10" fill="#4A5568">Static UI + /api/ proxy</text>
+
+  <rect x="700" y="115" width="160" height="54" rx="8" fill="#fff" stroke="#9B2C2C" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="780" y="139" text-anchor="middle" font-size="13" font-weight="600" fill="#9B2C2C">Keycloak (RHBK)</text>
+  <text x="780" y="156" text-anchor="middle" font-size="10" fill="#4A5568">OIDC Provider / JWKS</text>
+
+  <rect x="560" y="320" width="180" height="54" rx="8" fill="#fff" stroke="#276749" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="650" y="344" text-anchor="middle" font-size="13" font-weight="600" fill="#276749">Envoy Gateway</text>
+  <text x="650" y="361" text-anchor="middle" font-size="10" fill="#4A5568">JWT Validation + Lua</text>
+
+  <rect x="490" y="450" width="160" height="54" rx="8" fill="#fff" stroke="#276749" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="570" y="474" text-anchor="middle" font-size="13" font-weight="600" fill="#276749">Koku API</text>
+  <text x="570" y="491" text-anchor="middle" font-size="10" fill="#4A5568">Cost Management API</text>
+
+  <rect x="700" y="450" width="160" height="54" rx="8" fill="#fff" stroke="#276749" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="780" y="474" text-anchor="middle" font-size="13" font-weight="600" fill="#276749">ROS API</text>
+  <text x="780" y="491" text-anchor="middle" font-size="10" fill="#4A5568">Resource Optimization</text>
+
+  <!-- Step 1: Browser -> Route -->
+  <line x1="195" y1="142" x2="278" y2="142" stroke="#2B6CB0" stroke-width="1.8" marker-end="url(#arrowBlue)"/>
+  <rect x="208" y="122" width="18" height="16" rx="8" fill="#2B6CB0"/>
+  <text x="217" y="134" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">1</text>
+
+  <!-- Step 2: Route -> OAuth2 Proxy -->
+  <line x1="360" y1="169" x2="360" y2="233" stroke="#276749" stroke-width="1.8" marker-end="url(#arrowGreen)"/>
+  <rect x="365" y="186" width="18" height="16" rx="8" fill="#276749"/>
+  <text x="374" y="198" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">2</text>
+
+  <!-- Step 3: OAuth2 Proxy -> Keycloak (redirect) -->
+  <path d="M 450 250 Q 580 200 698 142" fill="none" stroke="#C05621" stroke-width="1.8" marker-end="url(#arrowOrange)" stroke-dasharray="6,3"/>
+  <rect x="558" y="199" width="18" height="16" rx="8" fill="#C05621"/>
+  <text x="567" y="211" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">3</text>
+
+  <!-- Step 4: Keycloak -> Browser (auth code redirect, routed above Route) -->
+  <path d="M 700 125 Q 400 68 120 113" fill="none" stroke="#C05621" stroke-width="1.8" marker-end="url(#arrowOrange)" stroke-dasharray="6,3"/>
+  <rect x="400" y="64" width="18" height="16" rx="8" fill="#C05621"/>
+  <text x="409" y="76" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">4</text>
+
+  <!-- Step 5: Browser -> OAuth2 Proxy (callback) -->
+  <path d="M 170 169 L 170 262 L 288 262" fill="none" stroke="#2B6CB0" stroke-width="1.8" marker-end="url(#arrowBlue)"/>
+  <rect x="148" y="212" width="18" height="16" rx="8" fill="#2B6CB0"/>
+  <text x="157" y="224" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">5</text>
+
+  <!-- Step 6: OAuth2 Proxy -> Keycloak (token exchange, ends at left edge) -->
+  <path d="M 450 262 L 550 262 Q 670 245 700 145" fill="none" stroke="#C05621" stroke-width="1.8" marker-end="url(#arrowOrange)"/>
+  <rect x="600" y="236" width="18" height="16" rx="8" fill="#C05621"/>
+  <text x="609" y="248" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">6</text>
+
+  <!-- Step 7: OAuth2 Proxy -> Nginx (authenticated) -->
+  <line x1="370" y1="289" x2="370" y2="318" stroke="#276749" stroke-width="1.8" marker-end="url(#arrowGreen)"/>
+  <rect x="375" y="296" width="18" height="16" rx="8" fill="#276749"/>
+  <text x="384" y="308" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">7</text>
+
+  <!-- Step 8: Nginx -> Gateway (/api/ proxy) -->
+  <line x1="450" y1="347" x2="558" y2="347" stroke="#276749" stroke-width="1.8" marker-end="url(#arrowGreen)"/>
+  <rect x="490" y="330" width="18" height="16" rx="8" fill="#276749"/>
+  <text x="499" y="342" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">8</text>
+
+  <!-- Step 9: Gateway -> Keycloak (JWKS fetch) -->
+  <path d="M 740 340 L 780 340 L 780 171" fill="none" stroke="#718096" stroke-width="1.3" marker-end="url(#arrowGray)" stroke-dasharray="4,3"/>
+  <rect x="785" y="250" width="18" height="16" rx="8" fill="#718096"/>
+  <text x="794" y="262" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">9</text>
+
+  <!-- Step 10: Gateway -> Backend services -->
+  <line x1="620" y1="374" x2="580" y2="448" stroke="#276749" stroke-width="1.8" marker-end="url(#arrowGreen)"/>
+  <line x1="680" y1="374" x2="770" y2="448" stroke="#276749" stroke-width="1.8" marker-end="url(#arrowGreen)"/>
+  <rect x="594" y="405" width="22" height="16" rx="8" fill="#276749"/>
+  <text x="605" y="417" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">10</text>
+
+  <!-- Step Legend -->
+  <rect x="30" y="540" width="1040" height="245" rx="6" fill="#fff" stroke="#E2E8F0" stroke-width="1"/>
+  <text x="550" y="565" text-anchor="middle" font-size="14" font-weight="700" fill="#1A202C">Flow Steps</text>
+
+  <!-- OIDC Login Phase -->
+  <rect x="50" y="580" width="490" height="190" rx="4" fill="#FFF5F5" stroke="#FED7D7" stroke-width="1"/>
+  <text x="295" y="600" text-anchor="middle" font-size="12" font-weight="600" fill="#9B2C2C">OIDC Authorization Code Flow (Initial Login)</text>
+
+  <rect x="62" y="614" width="18" height="16" rx="8" fill="#2B6CB0"/>
+  <text x="71" y="626" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">1</text>
+  <text x="88" y="626" font-size="11" fill="#2D3748">Browser requests UI (HTTPS to OpenShift Route)</text>
+
+  <rect x="62" y="636" width="18" height="16" rx="8" fill="#276749"/>
+  <text x="71" y="648" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">2</text>
+  <text x="88" y="648" font-size="11" fill="#2D3748">Route forwards to OAuth2 Proxy (TLS reencrypt)</text>
+
+  <rect x="62" y="658" width="18" height="16" rx="8" fill="#C05621"/>
+  <text x="71" y="670" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">3</text>
+  <text x="88" y="670" font-size="11" fill="#2D3748">No session &#8594; 302 redirect to Keycloak authorize endpoint</text>
+
+  <rect x="62" y="680" width="18" height="16" rx="8" fill="#C05621"/>
+  <text x="71" y="692" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">4</text>
+  <text x="88" y="692" font-size="11" fill="#2D3748">User authenticates; Keycloak redirects back with auth code</text>
+
+  <rect x="62" y="702" width="18" height="16" rx="8" fill="#2B6CB0"/>
+  <text x="71" y="714" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">5</text>
+  <text x="88" y="714" font-size="11" fill="#2D3748">Browser sends callback to OAuth2 Proxy (/oauth2/callback)</text>
+
+  <rect x="62" y="724" width="18" height="16" rx="8" fill="#C05621"/>
+  <text x="71" y="736" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">6</text>
+  <text x="88" y="736" font-size="11" fill="#2D3748">OAuth2 Proxy exchanges code for JWT tokens (ID + Access)</text>
+
+  <!-- Authenticated API Phase -->
+  <rect x="560" y="580" width="490" height="190" rx="4" fill="#F0FFF4" stroke="#C6F6D5" stroke-width="1"/>
+  <text x="805" y="600" text-anchor="middle" font-size="12" font-weight="600" fill="#276749">Authenticated Session (API Requests)</text>
+
+  <rect x="572" y="614" width="18" height="16" rx="8" fill="#276749"/>
+  <text x="581" y="626" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">7</text>
+  <text x="598" y="626" font-size="11" fill="#2D3748">Session cookie set; requests forwarded to Nginx</text>
+
+  <rect x="572" y="636" width="18" height="16" rx="8" fill="#276749"/>
+  <text x="581" y="648" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">8</text>
+  <text x="598" y="648" font-size="11" fill="#2D3748">Nginx proxies /api/ to Envoy Gateway (with Bearer token)</text>
+
+  <rect x="572" y="658" width="18" height="16" rx="8" fill="#718096"/>
+  <text x="581" y="670" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">9</text>
+  <text x="598" y="670" font-size="11" fill="#2D3748">Envoy validates JWT via Keycloak JWKS endpoint</text>
+
+  <rect x="572" y="680" width="22" height="16" rx="8" fill="#276749"/>
+  <text x="583" y="692" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">10</text>
+  <text x="602" y="692" font-size="11" fill="#2D3748">Lua injects X-Rh-Identity + X-Bearer-Token headers;</text>
+  <text x="602" y="706" font-size="11" fill="#2D3748">routes to Koku API or ROS API based on path</text>
+
+  <text x="602" y="740" font-size="10" fill="#718096" font-style="italic">Session cookie = edge auth; JWT = gateway auth for backends</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add 5 SVG diagrams: architecture overview, SaaS-to-on-prem transition, data processing flow, gateway routing, and UI login flow
- Add a central "Diagrams" index table to `docs/README.md` for quick navigation
- Embed each SVG inline in the most relevant documentation page:
  - `architecture/platform-guide.md` — architecture overview
  - `architecture/README.md` — SaaS-to-on-prem transition + gateway routing
  - `api/ui-oauth-authentication.md` — UI login flow
  - `operations/cost-management-data-sources.md` — data processing flow

## Test plan

- [ ] Verify SVGs render in GitHub markdown preview on the PR's file changes
- [ ] Verify relative paths resolve correctly from each subdirectory (`../diagram.svg`)
- [ ] Confirm no ACM-related content is included (WIP, excluded intentionally)


Made with [Cursor](https://cursor.com)