### PR TITLE
Update koku image to 2f5f67f and bump chart version to 0.3.0-rc1

### DIFF
--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.20-rc1
-appVersion: "0.2.20-rc1"
+version: 0.3.0-rc1
+appVersion: "0.3.0-rc1"
 
 keywords:
   - cost-management

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -147,7 +147,7 @@ costManagement:
 
     image:
       repository: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
-      tag: "b5b6fc3"
+      tag: "2f5f67f"
       pullPolicy: Always
 
     replicas: 1


### PR DESCRIPTION
## Summary
- Update koku image tag from `b5b6fc3` to `2f5f67f`
- Bump chart version from `0.2.20-rc1` to `0.3.0-rc1` (minor RC)

## Test plan
- [ ] Verify helm template renders correctly with new image tag
- [ ] Deploy to test cluster and confirm koku pods start with the new image


Made with [Cursor](https://cursor.com)