### PR TITLE
[FLPATH-3420] Update koku image to 2f5f67f and bump chart to 0.2.21-rc1

### DIFF
--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.21-rc1
-appVersion: "0.2.21-rc1"
+version: 0.2.20-rc2
+appVersion: "0.2.20-rc2"
 
 keywords:
   - cost-management

--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.20-rc1
-appVersion: "0.2.20-rc1"
+version: 0.2.21-rc1
+appVersion: "0.2.21-rc1"
 
 keywords:
   - cost-management

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -147,7 +147,7 @@ costManagement:
 
     image:
       repository: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
-      tag: "b5b6fc3"
+      tag: "2f5f67f"
       pullPolicy: Always
 
     replicas: 1


### PR DESCRIPTION
## Summary
- [FLPATH-3420](https://redhat.atlassian.net/browse/FLPATH-3420) — Add `updated_timestamp` to Sources model and API
- Update koku image tag from `b5b6fc3` to `2f5f67f` (picks up [project-koku/koku#5994](https://github.com/project-koku/koku/pull/5994))
- Bump chart version from `0.2.20-rc1` to `0.2.20-rc2`

## Test plan
- [ ] Verify helm template renders correctly with new image tag
- [ ] Deploy to test cluster and confirm koku pods start with the new image


Made with [Cursor](https://cursor.com)