### PR TITLE
docs: disconnected guide — discover images with helm/oc-mirror

### DIFF
--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -141,7 +141,7 @@ jobs:
           done
           echo ""
           echo "  2. See docs/operations/disconnected-deployment.md for commands"
-          echo "     to list images (helm template / oc-mirror mapping.txt)."
+          echo "     to list images from oc-mirror (dry-run mapping.txt)."
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           exit 1
         fi

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -51,7 +51,7 @@ jobs:
         # additionalImages lists images that oc-mirror cannot auto-discover
         # from the Helm chart (e.g. images only used in Helm hooks like
         # pre-install/pre-upgrade). Keep this list in sync with the
-        # disconnected deployment guide:
+        # disconnected deployment guide (commands to list images):
         #   docs/operations/disconnected-deployment.md
         cat > /tmp/imageset-config.yaml << 'EOF'
         apiVersion: mirror.openshift.io/v2alpha1
@@ -140,8 +140,8 @@ jobs:
             echo "       - name: $img"
           done
           echo ""
-          echo "  2. Update the air-gapped deployment guide with the same images:"
-          echo "     docs/operations/disconnected-deployment.md"
+          echo "  2. See docs/operations/disconnected-deployment.md for commands"
+          echo "     to list images (helm template / oc-mirror mapping.txt)."
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           exit 1
         fi

--- a/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
+++ b/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
@@ -1,49 +1,64 @@
-# SAMPLE ImageSetConfiguration: cost-onprem Helm chart plus OLM content for
-# dependencies installed by this repository's scripts:
-#   - AMQ Streams: ./scripts/deploy-kafka.sh (Subscription name amq-streams)
-#   - RHBK:        ./scripts/deploy-rhbk.sh (Subscription name rhbk-operator)
-# Optional OpenShift Data Foundation (ODF) packages are commented below; use
-# them only if you deploy ODF for S3-compatible storage on the cluster.
+# COMPREHENSIVE ImageSetConfiguration: OpenShift 4.20 platform + cost-onprem + all prerequisites
 #
-# Before mirroring:
-# 1. This sample targets OpenShift 4.20 (redhat-operator-index:v4.20). Change
-#    the catalog tag if your cluster is a different minor version.
-# 2. Confirm package channels exist on your version (OperatorHub on a
-#    connected cluster, or Red Hat documentation for disconnected mirroring).
-# 3. Uncomment the odf-operator entry only when mirroring ODF; verify the
-#    channel name in OperatorHub for your release (example uses stable-4.20).
+# This configuration mirrors everything needed for a complete disconnected deployment:
+#   - OpenShift 4.20.12 platform images
+#   - cost-onprem Helm chart and container images
+#   - OLM operators for all deployment scripts:
+#     * AMQ Streams (deploy-kafka.sh)
+#     * RHBK (deploy-rhbk.sh)
+#     * Local Storage + ODF operators (for S3-compatible storage)
+#   - Additional images for hook-only containers and script dependencies
+#
+# Tested working configuration for OpenShift 4.20.
 #
 # Usage:
 #   oc-mirror --v2 -c imageset-config-cost-onprem-with-prerequisites.sample.yaml file://mirror-output
 #
-# Chart version: edit mirror.helm.repositories[].charts[].version as in
-# imageset-config-cost-onprem.yaml.
+# Before mirroring:
+# 1. Edit mirror.helm.repositories[].charts[].version to match your target chart release
+# 2. Adjust platform.channels[].minVersion/maxVersion for your specific OCP patch version
+# 3. Verify operator channels exist for your OpenShift version in OperatorHub
+#
 apiVersion: mirror.openshift.io/v2alpha1
 kind: ImageSetConfiguration
+# OCP 4.20: platform + redhat-operator-index + Marketplace index images + cost-onprem + RHODF-related operators + AMQ Streams.
 mirror:
+  platform:
+    architectures:
+      - amd64
+    graph: true
+    channels:
+      - name: stable-4.20
+        type: ocp
+        minVersion: 4.20.12
+        maxVersion: 4.20.12
   helm:
     repositories:
       - name: cost-onprem
         url: https://insights-onprem.github.io/cost-onprem-chart
         charts:
           - name: cost-onprem
-            version: "0.2.20-rc3"
+            version: "0.2.20-rc4"
+  additionalImages:
+    # PostgreSQL image used by both cost-onprem (Helm hook) and deploy-rhbk.sh (Keycloak DB):
+    - name: registry.redhat.io/rhel10/postgresql-16:10.1
+    # AWS CLI for S3 bucket creation (install-helm-chart.sh):
+    - name: docker.io/amazon/aws-cli:latest
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: amq-streams
           channels:
+            - name: stable
             - name: amq-streams-3.1.x
         - name: rhbk-operator
           channels:
             - name: stable-v22
-        # Optional — OpenShift Data Foundation (S3 via ODF). Uncomment and set
-        # channel to the value offered for your OpenShift version.
-        # - name: odf-operator
-        #   channels:
-        #     - name: stable-4.20
-  additionalImages:
-    - name: quay.io/insights-onprem/postgresql:16
-    # PostgreSQL Deployment created by scripts/deploy-rhbk.sh for Keycloak DB:
-    - name: registry.redhat.io/rhel9/postgresql-15:latest
-    - name: amazon/aws-cli:latest
+            - name: stable-v26.4
+        - name: local-storage-operator
+          channels:
+            - name: stable
+            - name: stable-4.20
+        - name: odf-operator
+          channels:
+            - name: stable-4.20

--- a/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
+++ b/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
@@ -38,11 +38,11 @@ mirror:
         url: https://insights-onprem.github.io/cost-onprem-chart
         charts:
           - name: cost-onprem
-            version: "0.2.20-rc4"
+            version: "0.2.20-rc3"
   additionalImages:
     # PostgreSQL image used by both cost-onprem (Helm hook) and deploy-rhbk.sh (Keycloak DB):
     - name: registry.redhat.io/rhel10/postgresql-16:10.1
-    # AWS CLI for S3 bucket creation (install-helm-chart.sh):
+    # Only if using scripts/install-helm-chart.sh for S3 bucket creation:
     - name: docker.io/amazon/aws-cli:latest
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20

--- a/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
+++ b/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
@@ -1,0 +1,50 @@
+# SAMPLE ImageSetConfiguration: cost-onprem Helm chart plus OLM content for
+# dependencies installed by this repository's scripts:
+#   - AMQ Streams: ./scripts/deploy-kafka.sh (Subscription name amq-streams)
+#   - RHBK:        ./scripts/deploy-rhbk.sh (Subscription name rhbk-operator)
+# Optional OpenShift Data Foundation (ODF) packages are commented below; use
+# them only if you deploy ODF for S3-compatible storage on the cluster.
+#
+# Before mirroring:
+# 1. Set the redhat-operator-index image tag to your OpenShift minor version,
+#    e.g. v4.16 for OpenShift 4.16 (must match the cluster you install on).
+# 2. Confirm package channels exist on your version (OperatorHub on a
+#    connected cluster, or Red Hat documentation for disconnected mirroring).
+# 3. Uncomment the odf-operator entry only when mirroring ODF; channel names
+#    differ by OCP release (replace stable-4.16 with the channel shown for your
+#    version, e.g. stable-4.17).
+#
+# Usage:
+#   oc-mirror --v2 -c imageset-config-cost-onprem-with-prerequisites.sample.yaml file://mirror-output
+#
+# Chart version: edit mirror.helm.repositories[].charts[].version as in
+# imageset-config-cost-onprem.yaml.
+apiVersion: mirror.openshift.io/v2alpha1
+kind: ImageSetConfiguration
+mirror:
+  helm:
+    repositories:
+      - name: cost-onprem
+        url: https://insights-onprem.github.io/cost-onprem-chart
+        charts:
+          - name: cost-onprem
+            version: "0.2.20-rc3"
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.16
+      packages:
+        - name: amq-streams
+          channels:
+            - name: amq-streams-3.1.x
+        - name: rhbk-operator
+          channels:
+            - name: stable-v22
+        # Optional — OpenShift Data Foundation (S3 via ODF). Uncomment and set
+        # channel to the value offered for your OpenShift version.
+        # - name: odf-operator
+        #   channels:
+        #     - name: stable-4.16
+  additionalImages:
+    - name: quay.io/insights-onprem/postgresql:16
+    # PostgreSQL Deployment created by scripts/deploy-rhbk.sh for Keycloak DB:
+    - name: registry.redhat.io/rhel9/postgresql-15:latest
+    - name: amazon/aws-cli:latest

--- a/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
+++ b/docs/examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml
@@ -6,13 +6,12 @@
 # them only if you deploy ODF for S3-compatible storage on the cluster.
 #
 # Before mirroring:
-# 1. Set the redhat-operator-index image tag to your OpenShift minor version,
-#    e.g. v4.16 for OpenShift 4.16 (must match the cluster you install on).
+# 1. This sample targets OpenShift 4.20 (redhat-operator-index:v4.20). Change
+#    the catalog tag if your cluster is a different minor version.
 # 2. Confirm package channels exist on your version (OperatorHub on a
 #    connected cluster, or Red Hat documentation for disconnected mirroring).
-# 3. Uncomment the odf-operator entry only when mirroring ODF; channel names
-#    differ by OCP release (replace stable-4.16 with the channel shown for your
-#    version, e.g. stable-4.17).
+# 3. Uncomment the odf-operator entry only when mirroring ODF; verify the
+#    channel name in OperatorHub for your release (example uses stable-4.20).
 #
 # Usage:
 #   oc-mirror --v2 -c imageset-config-cost-onprem-with-prerequisites.sample.yaml file://mirror-output
@@ -30,7 +29,7 @@ mirror:
           - name: cost-onprem
             version: "0.2.20-rc3"
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.16
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: amq-streams
           channels:
@@ -42,7 +41,7 @@ mirror:
         # channel to the value offered for your OpenShift version.
         # - name: odf-operator
         #   channels:
-        #     - name: stable-4.16
+        #     - name: stable-4.20
   additionalImages:
     - name: quay.io/insights-onprem/postgresql:16
     # PostgreSQL Deployment created by scripts/deploy-rhbk.sh for Keycloak DB:

--- a/docs/examples/disconnected/imageset-config-cost-onprem.sample.yaml
+++ b/docs/examples/disconnected/imageset-config-cost-onprem.sample.yaml
@@ -24,8 +24,8 @@ mirror:
         url: https://insights-onprem.github.io/cost-onprem-chart
         charts:
           - name: cost-onprem
-            version: "0.2.20-rc3"
+            version: "0.2.20-rc4"
   additionalImages:
-    - name: quay.io/insights-onprem/postgresql:16
+    - name: registry.redhat.io/rhel10/postgresql-16:10.1
     # Only if using scripts/install-helm-chart.sh for S3 bucket creation:
     - name: amazon/aws-cli:latest

--- a/docs/examples/disconnected/imageset-config-cost-onprem.sample.yaml
+++ b/docs/examples/disconnected/imageset-config-cost-onprem.sample.yaml
@@ -24,8 +24,9 @@ mirror:
         url: https://insights-onprem.github.io/cost-onprem-chart
         charts:
           - name: cost-onprem
-            version: "0.2.20-rc4"
+            version: "0.2.20-rc3"
   additionalImages:
+    # PostgreSQL image used by both cost-onprem (Helm hook) and deploy-rhbk.sh (Keycloak DB):
     - name: registry.redhat.io/rhel10/postgresql-16:10.1
     # Only if using scripts/install-helm-chart.sh for S3 bucket creation:
-    - name: amazon/aws-cli:latest
+    - name: docker.io/amazon/aws-cli:latest

--- a/docs/examples/disconnected/imageset-config-cost-onprem.yaml
+++ b/docs/examples/disconnected/imageset-config-cost-onprem.yaml
@@ -1,0 +1,31 @@
+# ImageSetConfiguration for mirroring the cost-onprem Helm chart and container
+# images used by the chart (plus hook-only and script-only images below).
+#
+# Usage (connected workstation):
+#   oc-mirror --v2 -c imageset-config-cost-onprem.yaml file://mirror-output
+#
+# Edit mirror.helm.repositories[].charts[].version to match the release you
+# install from https://insights-onprem.github.io/cost-onprem-chart (see
+# cost-onprem/Chart.yaml in this repository for the current chart version).
+#
+# For local chart mirroring instead of the Helm repo, replace mirror.helm with:
+#   helm:
+#     local:
+#       - name: cost-onprem
+#         path: /path/to/cost-onprem-chart/cost-onprem
+#
+# Keep additionalImages aligned with .github/workflows/lint-and-validate.yml.
+apiVersion: mirror.openshift.io/v2alpha1
+kind: ImageSetConfiguration
+mirror:
+  helm:
+    repositories:
+      - name: cost-onprem
+        url: https://insights-onprem.github.io/cost-onprem-chart
+        charts:
+          - name: cost-onprem
+            version: "0.2.20-rc3"
+  additionalImages:
+    - name: quay.io/insights-onprem/postgresql:16
+    # Only if using scripts/install-helm-chart.sh for S3 bucket creation:
+    - name: amazon/aws-cli:latest

--- a/docs/operations/disconnected-deployment.md
+++ b/docs/operations/disconnected-deployment.md
@@ -54,7 +54,7 @@ the plan.
 
 The project CI uses a throwaway registry only as a destination for planning; you
 can mirror the same way. Example using the repository example
-[`imageset-config-cost-onprem.yaml`](../examples/disconnected/imageset-config-cost-onprem.yaml):
+[`imageset-config-cost-onprem.sample.yaml`](../examples/disconnected/imageset-config-cost-onprem.sample.yaml):
 
 ```bash
 cd /path/to/cost-onprem-chart
@@ -62,7 +62,7 @@ cd /path/to/cost-onprem-chart
 # Local registry as dry-run destination (same pattern as CI; stop/remove when done).
 podman run -d --name oc-mirror-registry -p 5050:5000 docker.io/library/registry:2
 
-oc-mirror --v2 --config docs/examples/disconnected/imageset-config-cost-onprem.yaml \
+oc-mirror --v2 --config docs/examples/disconnected/imageset-config-cost-onprem.sample.yaml \
   --workspace file:///tmp/oc-mirror-workspace \
   docker://localhost:5050 --dry-run --dest-tls-verify=false
 
@@ -89,21 +89,18 @@ instead.
 Reuse the example files under `docs/examples/disconnected/` (copy and edit as
 needed):
 
-| File | Purpose |
-|------|---------|
-| [`imageset-config-cost-onprem.yaml`](../examples/disconnected/imageset-config-cost-onprem.yaml) | cost-onprem Helm chart + `additionalImages` for hooks and optional `install-helm-chart.sh` S3 setup |
-| [`imageset-config-cost-onprem-with-prerequisites.sample.yaml`](../examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml) | Same as above plus **OLM** packages for **AMQ Streams** and **RHBK** (`deploy-kafka.sh`, `deploy-rhbk.sh`), `registry.redhat.io/rhel9/postgresql-15` used by `deploy-rhbk.sh`, and **ODF** optional lines commented |
+| File | Purpose | Use Case |
+|------|---------|----------|
+| [`imageset-config-cost-onprem.sample.yaml`](../examples/disconnected/imageset-config-cost-onprem.sample.yaml) | cost-onprem Helm chart + `additionalImages` for hooks and `install-helm-chart.sh` S3 setup | **Chart-only mirroring** — when OpenShift platform and operators are already available |
+| [`imageset-config-cost-onprem-with-prerequisites.sample.yaml`](../examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml) | **Complete deployment** — OpenShift 4.20.12 platform + cost-onprem + all operators (AMQ Streams, RHBK, Local Storage, ODF) | **Full disconnected environment** — mirrors everything for `deploy-kafka.sh`, `deploy-rhbk.sh`, and storage setup |
 
-In both files, set `mirror.helm.repositories[].charts[].version` to the chart
-release you mirror and install. The `additionalImages` section lists images that
-`oc-mirror` cannot discover from the Helm chart automatically (see
-[Discovering container images](#discovering-container-images)); keep it aligned
-with `.github/workflows/lint-and-validate.yml`.
+**Chart version:** Edit `mirror.helm.repositories[].charts[].version` in both files to match your target release.
 
-The prerequisites sample defaults to OpenShift **4.20**
-(`registry.redhat.io/redhat/redhat-operator-index:v4.20`). If your cluster is
-another minor version, change that catalog tag (and operator channels, including
-optional ODF) to match.
+**Platform version:** The comprehensive example targets OpenShift 4.20.12. Adjust `platform.channels[].minVersion/maxVersion` for your specific patch level.
+
+**Operator channels:** The comprehensive example uses tested operator channels for OpenShift 4.20. Verify channels exist for your OpenShift version in OperatorHub before mirroring.
+
+**Note:** The comprehensive example is a tested, working configuration that mirrors everything needed for a complete disconnected OpenShift deployment with cost-onprem.
 
 Copy one of the examples to `imageset-config.yaml` (or keep any path you
 prefer and pass it to `oc-mirror -c`).
@@ -150,9 +147,12 @@ This configures the cluster to pull images from the mirror registry instead of t
 Install the chart from the mirrored registry. Use the install script with the local chart:
 
 ```bash
-# Option A: Use the mirrored chart directly (--version must match mirrored chart)
-helm install cost-onprem oci://mirror.example.com:5000/cost-onprem/cost-onprem \
-  --version 0.2.20-rc3 \
+# Extract and install the mirrored chart (oc-mirror saves charts as .tgz files)
+# Find the extracted chart in mirror-output/
+tar -xzf mirror-output/*/charts/*.tgz
+
+# Option A: Install directly with Helm
+helm install cost-onprem ./cost-onprem \
   --namespace cost-onprem \
   --create-namespace
 
@@ -160,6 +160,8 @@ helm install cost-onprem oci://mirror.example.com:5000/cost-onprem/cost-onprem \
 USE_LOCAL_CHART=true LOCAL_CHART_PATH=./cost-onprem \
   ./scripts/install-helm-chart.sh
 ```
+
+> **Note:** `oc-mirror` mirrors container images but does not create OCI chart artifacts. The chart must be extracted from the `.tgz` file in the mirror output and installed as a local chart.
 
 The ICSP/IDMS applied in Step 5 ensures that all image pulls are redirected to the mirror registry automatically.
 

--- a/docs/operations/disconnected-deployment.md
+++ b/docs/operations/disconnected-deployment.md
@@ -9,11 +9,11 @@ In disconnected environments, clusters have no direct internet access. The `oc-m
 > **Important:** Some images used by the chart cannot be auto-discovered by
 > `oc-mirror` (for example, images referenced only in Helm hooks such as
 > `pre-install`/`pre-upgrade`). Those **must** be listed explicitly in the
-> `additionalImages` section of the `ImageSetConfiguration`. Use
-> [Discovering container images](#discovering-container-images) to list images
-> from an `oc-mirror` dry-run (`mapping.txt`), and see
-> [Step 1](#step-1-create-imagesetconfiguration) for the reusable example
-> files.
+> `additionalImages` section of the `ImageSetConfiguration`. See
+> [Discovering container images](#discovering-container-images) for details on
+> image discovery and [Step 1](#step-1-create-imagesetconfiguration) for
+> ready-to-use example files with the correct `additionalImages` already
+> included.
 
 ## Prerequisites
 
@@ -25,9 +25,9 @@ In disconnected environments, clusters have no direct internet access. The `oc-m
 ## Discovering container images
 
 Image tags and repositories change with chart releases. Instead of copying a
-static list into this document, run `oc-mirror` in dry-run and read
-`mapping.txt` before each mirror run to capture the exact image set for your
-`ImageSetConfiguration`.
+static list into this document, use the provided example `ImageSetConfiguration`
+files with the correct `additionalImages` already included. The examples are
+kept aligned with CI validation to ensure complete image coverage.
 
 **Auto-discovered:** Any image that appears in the manifests `oc-mirror`
 renders from the Helm chart (it runs `helm template` internally) is mirrored
@@ -188,10 +188,11 @@ mirror process (Steps 2-5). The install script supports version pinning:
 CHART_VERSION=0.2.20-rc3 ./scripts/install-helm-chart.sh
 ```
 
-> **Remember:** If an image your cluster needs is missing from dry-run
-> `mapping.txt`, add it to `additionalImages` (and update CI’s list in
-> `.github/workflows/lint-and-validate.yml` when contributing upstream). CI
-> fails when chart-rendered images are not fully covered by `oc-mirror`.
+> **Remember:** Use the provided example `ImageSetConfiguration` files which
+> already include the correct `additionalImages` for hook-only containers. If
+> contributing upstream, keep `.github/workflows/lint-and-validate.yml`
+> `additionalImages` aligned with the example files. CI validates that all
+> chart images are covered by the mirror plan.
 
 ## References
 

--- a/docs/operations/disconnected-deployment.md
+++ b/docs/operations/disconnected-deployment.md
@@ -10,10 +10,10 @@ In disconnected environments, clusters have no direct internet access. The `oc-m
 > `oc-mirror` (for example, images referenced only in Helm hooks such as
 > `pre-install`/`pre-upgrade`). Those **must** be listed explicitly in the
 > `additionalImages` section of the `ImageSetConfiguration`. Use
-> [Discovering container images](#discovering-container-images) to generate
-> the current list from your chart revision, and see
-> [Step 1](#step-1-create-imagesetconfiguration) for a minimal configuration
-> example.
+> [Discovering container images](#discovering-container-images) to list images
+> from an `oc-mirror` dry-run (`mapping.txt`), and see
+> [Step 1](#step-1-create-imagesetconfiguration) for the reusable example
+> files.
 
 ## Prerequisites
 
@@ -25,8 +25,9 @@ In disconnected environments, clusters have no direct internet access. The `oc-m
 ## Discovering container images
 
 Image tags and repositories change with chart releases. Instead of copying a
-static list into this document, generate the set you need from the chart and
-from `oc-mirror` before each mirror run.
+static list into this document, run `oc-mirror` in dry-run and read
+`mapping.txt` before each mirror run to capture the exact image set for your
+`ImageSetConfiguration`.
 
 **Auto-discovered:** Any image that appears in the manifests `oc-mirror`
 renders from the Helm chart (it runs `helm template` internally) is mirrored
@@ -44,20 +45,6 @@ one-shot S3 bucket creation. That image is not part of the Helm chart; add it
 to `additionalImages` only if you use that script path, or set `S3_CLI_IMAGE` to
 a mirrored image, or use `SKIP_S3_SETUP=true` / manual bucket creation.
 
-### List images from `helm template` (chart defaults)
-
-Use the same inputs `oc-mirror` uses for discovery: render with **no** `--set`
-flags so defaults match offline discovery.
-
-```bash
-cd /path/to/cost-onprem-chart/cost-onprem
-
-helm template cost-onprem . > /tmp/cost-onprem-rendered.yaml
-
-awk -F': ' '/^[[:space:]]+image:/{gsub(/"/,"",$2); print $2}' \
-  /tmp/cost-onprem-rendered.yaml | sort -u
-```
-
 ### List images from an `oc-mirror` plan (`mapping.txt`)
 
 Run `oc-mirror` in dry-run mode with the same `ImageSetConfiguration` you will
@@ -66,27 +53,16 @@ use for mirroring (Helm section plus `additionalImages`). The tool writes a
 the plan.
 
 The project CI uses a throwaway registry only as a destination for planning; you
-can mirror the same way. Example:
+can mirror the same way. Example using the repository example
+[`imageset-config-cost-onprem.yaml`](../examples/disconnected/imageset-config-cost-onprem.yaml):
 
 ```bash
-# Example: local chart path (adjust to your layout).
-cat > /tmp/imageset-config.yaml <<'EOF'
-apiVersion: mirror.openshift.io/v2alpha1
-kind: ImageSetConfiguration
-mirror:
-  helm:
-    local:
-      - name: cost-onprem
-        path: /path/to/cost-onprem-chart/cost-onprem
-  additionalImages:
-    # Copy from .github/workflows/lint-and-validate.yml for hook-only images.
-    - name: quay.io/insights-onprem/postgresql:16
-EOF
+cd /path/to/cost-onprem-chart
 
 # Local registry as dry-run destination (same pattern as CI; stop/remove when done).
 podman run -d --name oc-mirror-registry -p 5050:5000 docker.io/library/registry:2
 
-oc-mirror --v2 --config /tmp/imageset-config.yaml \
+oc-mirror --v2 --config docs/examples/disconnected/imageset-config-cost-onprem.yaml \
   --workspace file:///tmp/oc-mirror-workspace \
   docker://localhost:5050 --dry-run --dest-tls-verify=false
 
@@ -94,39 +70,42 @@ MAPPING="$(find /tmp/oc-mirror-workspace -name mapping.txt -type f | head -1)"
 cut -d= -f1 "$MAPPING" | sed 's|docker://||' | sort -u
 ```
 
-For mirroring from the published Helm repo instead of a local path, use
-`mirror.helm.repositories` as in [Step 1](#step-1-create-imagesetconfiguration)
-and the same `oc-mirror` / `find` / `cut` sequence with your workspace path.
+To dry-run against a **local** chart directory, copy the example file and swap
+`mirror.helm` to `mirror.helm.local` as described in the comments at the top of
+that YAML, then pass your edited file to `--config`.
 
-> **Why hooks matter:** `oc-mirror` discovers images by rendering the chart the
-> same way Helm does for that pass. Anything not included there must appear in
-> `additionalImages`. CI verifies that every image in `helm template` output is
-> covered by the mirror plan; see `.github/workflows/lint-and-validate.yml`.
+For mirroring operator prerequisites (AMQ Streams, RHBK, optional ODF), start
+from
+[`imageset-config-cost-onprem-with-prerequisites.sample.yaml`](../examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml)
+instead.
+
+> **Why hooks matter:** `oc-mirror` discovers images by rendering the chart
+> internally. Anything not included in that pass must appear in
+> `additionalImages`. CI enforces that the full chart image set is covered by
+> the mirror plan; see `.github/workflows/lint-and-validate.yml`.
 
 ## Step 1: Create ImageSetConfiguration
 
-Create a file named `imageset-config.yaml`. The `additionalImages` section
-lists images that `oc-mirror` cannot discover from the Helm chart
-automatically (see [Discovering container images](#discovering-container-images)).
+Reuse the example files under `docs/examples/disconnected/` (copy and edit as
+needed):
 
-```yaml
-apiVersion: mirror.openshift.io/v2alpha1
-kind: ImageSetConfiguration
-mirror:
-  helm:
-    repositories:
-      - name: cost-onprem
-        url: https://insights-onprem.github.io/cost-onprem-chart
-        charts:
-          - name: cost-onprem
-            version: "0.2.10"
-  # Images that oc-mirror cannot auto-discover from the Helm chart.
-  # Align with .github/workflows/lint-and-validate.yml additionalImages.
-  additionalImages:
-    - name: registry.redhat.io/rhel10/postgresql-16:10.1
-    # Only needed if using install-helm-chart.sh for bucket creation:
-    - name: amazon/aws-cli:latest
-```
+| File | Purpose |
+|------|---------|
+| [`imageset-config-cost-onprem.yaml`](../examples/disconnected/imageset-config-cost-onprem.yaml) | cost-onprem Helm chart + `additionalImages` for hooks and optional `install-helm-chart.sh` S3 setup |
+| [`imageset-config-cost-onprem-with-prerequisites.sample.yaml`](../examples/disconnected/imageset-config-cost-onprem-with-prerequisites.sample.yaml) | Same as above plus **OLM** packages for **AMQ Streams** and **RHBK** (`deploy-kafka.sh`, `deploy-rhbk.sh`), `registry.redhat.io/rhel9/postgresql-15` used by `deploy-rhbk.sh`, and **ODF** optional lines commented |
+
+In both files, set `mirror.helm.repositories[].charts[].version` to the chart
+release you mirror and install. The `additionalImages` section lists images that
+`oc-mirror` cannot discover from the Helm chart automatically (see
+[Discovering container images](#discovering-container-images)); keep it aligned
+with `.github/workflows/lint-and-validate.yml`.
+
+For the prerequisites sample, set `mirror.operators[].catalog` to
+`registry.redhat.io/redhat/redhat-operator-index:vX.Y` matching your OpenShift
+minor version, and adjust operator package channels if your release differs.
+
+Copy one of the examples to `imageset-config.yaml` (or keep any path you
+prefer and pass it to `oc-mirror -c`).
 
 ## Step 2: Mirror to Disk
 
@@ -170,9 +149,9 @@ This configures the cluster to pull images from the mirror registry instead of t
 Install the chart from the mirrored registry. Use the install script with the local chart:
 
 ```bash
-# Option A: Use the mirrored chart directly
+# Option A: Use the mirrored chart directly (--version must match mirrored chart)
 helm install cost-onprem oci://mirror.example.com:5000/cost-onprem/cost-onprem \
-  --version 0.2.10 \
+  --version 0.2.20-rc3 \
   --namespace cost-onprem \
   --create-namespace
 
@@ -203,13 +182,13 @@ When new versions are released, bump the chart version in
 mirror process (Steps 2-5). The install script supports version pinning:
 
 ```bash
-CHART_VERSION=0.2.10 ./scripts/install-helm-chart.sh
+CHART_VERSION=0.2.20-rc3 ./scripts/install-helm-chart.sh
 ```
 
-> **Remember:** If `helm template` shows an image that your dry-run
-> `mapping.txt` does not, add it to `additionalImages` (and update CI’s list in
+> **Remember:** If an image your cluster needs is missing from dry-run
+> `mapping.txt`, add it to `additionalImages` (and update CI’s list in
 > `.github/workflows/lint-and-validate.yml` when contributing upstream). CI
-> fails when `helm template` images are not fully covered by `oc-mirror`.
+> fails when chart-rendered images are not fully covered by `oc-mirror`.
 
 ## References
 

--- a/docs/operations/disconnected-deployment.md
+++ b/docs/operations/disconnected-deployment.md
@@ -8,11 +8,12 @@ In disconnected environments, clusters have no direct internet access. The `oc-m
 
 > **Important:** Some images used by the chart cannot be auto-discovered by
 > `oc-mirror` (for example, images referenced only in Helm hooks such as
-> `pre-install`/`pre-upgrade`). These **must** be listed explicitly in the
-> `additionalImages` section of the `ImageSetConfiguration`. See
-> [Required Container Images](#required-container-images) for the full list
-> and [Step 1](#step-1-create-imagesetconfiguration) for the complete
-> configuration.
+> `pre-install`/`pre-upgrade`). Those **must** be listed explicitly in the
+> `additionalImages` section of the `ImageSetConfiguration`. Use
+> [Discovering container images](#discovering-container-images) to generate
+> the current list from your chart revision, and see
+> [Step 1](#step-1-create-imagesetconfiguration) for a minimal configuration
+> example.
 
 ## Prerequisites
 
@@ -21,46 +22,92 @@ In disconnected environments, clusters have no direct internet access. The `oc-m
 - A connected workstation with internet access for running `oc-mirror`
 - OpenShift CLI (`oc`) configured for the disconnected cluster
 
-## Required Container Images
+## Discovering container images
 
-The table below lists every container image used by the cost-onprem chart.
-Images marked **additional** are not auto-discovered by `oc-mirror` and
-**must** appear in the `additionalImages` section of the
-`ImageSetConfiguration`. Failing to include them will cause pods to enter
-`ImagePullBackOff` in the disconnected cluster.
+Image tags and repositories change with chart releases. Instead of copying a
+static list into this document, generate the set you need from the chart and
+from `oc-mirror` before each mirror run.
 
-| Image | Component | Discovery |
-|-------|-----------|-----------|
-| `quay.io/insights-onprem/ros-ocp-backend:latest` | ROS API, Processor, Poller, Housekeeper, Migration | auto |
-| `quay.io/insights-onprem/koku:sources` | Cost Management API, MASU, Celery, Listener, Migration | auto |
-| `quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d0b4337` | Kruize optimization engine | auto |
-| `quay.io/insights-onprem/insights-ingress-go:latest` | Ingress service | auto |
-| `registry.redhat.io/rhel10/postgresql-16:10.1` | PostgreSQL database (Helm pre-install/pre-upgrade hook) | **additional** |
-| `registry.redhat.io/rhel10/valkey-8:latest` | Valkey cache | auto |
-| `registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6` | Envoy gateway | auto |
-| `registry.redhat.io/rhceph/oauth2-proxy-rhel9:v7.6.0` | UI OAuth proxy | auto |
-| `quay.io/insights-onprem/koku-ui-onprem:latest` | Cost Management UI | auto |
-| `registry.access.redhat.com/ubi9/ubi-minimal:latest` | Init containers (wait-for probes) | auto |
-| `amazon/aws-cli:latest` | S3 bucket creation (`install-helm-chart.sh`) | **script** |
+**Auto-discovered:** Any image that appears in the manifests `oc-mirror`
+renders from the Helm chart (it runs `helm template` internally) is mirrored
+automatically when you list the chart under `mirror.helm`.
 
-> **Note:** The `amazon/aws-cli:latest` image is used by `install-helm-chart.sh` for
-> one-shot S3 bucket creation (not by the Helm chart itself). Override with
-> `S3_CLI_IMAGE` to point to a mirrored copy. If you create buckets manually or
-> use `SKIP_S3_SETUP=true`, this image is not required.
+**`additionalImages`:** Images that are *not* visible during that pass (commonly
+resources behind [Helm hooks](https://helm.sh/docs/topics/charts_hooks/) such
+as `pre-install`/`pre-upgrade`) must be added manually. The repository keeps the
+canonical hook list in `.github/workflows/lint-and-validate.yml` under
+`additionalImages` so CI matches disconnected mirroring; align your
+`ImageSetConfiguration` with that block when you upgrade the chart.
 
-> **Why are some images not auto-discovered?** `oc-mirror` discovers images
-> by running `helm template` internally. Kubernetes resources created via
-> [Helm hooks](https://helm.sh/docs/topics/charts_hooks/) (such as the
-> database `StatefulSet` with `helm.sh/hook: pre-install,pre-upgrade`) are
-> excluded from that rendering, so `oc-mirror` never sees the images they
-> reference. CI enforces parity between `helm template` and `oc-mirror`;
-> see `.github/workflows/lint-and-validate.yml`.
+**Not from the chart:** `install-helm-chart.sh` can pull `amazon/aws-cli` for
+one-shot S3 bucket creation. That image is not part of the Helm chart; add it
+to `additionalImages` only if you use that script path, or set `S3_CLI_IMAGE` to
+a mirrored image, or use `SKIP_S3_SETUP=true` / manual bucket creation.
+
+### List images from `helm template` (chart defaults)
+
+Use the same inputs `oc-mirror` uses for discovery: render with **no** `--set`
+flags so defaults match offline discovery.
+
+```bash
+cd /path/to/cost-onprem-chart/cost-onprem
+
+helm template cost-onprem . > /tmp/cost-onprem-rendered.yaml
+
+awk -F': ' '/^[[:space:]]+image:/{gsub(/"/,"",$2); print $2}' \
+  /tmp/cost-onprem-rendered.yaml | sort -u
+```
+
+### List images from an `oc-mirror` plan (`mapping.txt`)
+
+Run `oc-mirror` in dry-run mode with the same `ImageSetConfiguration` you will
+use for mirroring (Helm section plus `additionalImages`). The tool writes a
+`mapping.txt` file under the workspace directory listing every source image in
+the plan.
+
+The project CI uses a throwaway registry only as a destination for planning; you
+can mirror the same way. Example:
+
+```bash
+# Example: local chart path (adjust to your layout).
+cat > /tmp/imageset-config.yaml <<'EOF'
+apiVersion: mirror.openshift.io/v2alpha1
+kind: ImageSetConfiguration
+mirror:
+  helm:
+    local:
+      - name: cost-onprem
+        path: /path/to/cost-onprem-chart/cost-onprem
+  additionalImages:
+    # Copy from .github/workflows/lint-and-validate.yml for hook-only images.
+    - name: quay.io/insights-onprem/postgresql:16
+EOF
+
+# Local registry as dry-run destination (same pattern as CI; stop/remove when done).
+podman run -d --name oc-mirror-registry -p 5050:5000 docker.io/library/registry:2
+
+oc-mirror --v2 --config /tmp/imageset-config.yaml \
+  --workspace file:///tmp/oc-mirror-workspace \
+  docker://localhost:5050 --dry-run --dest-tls-verify=false
+
+MAPPING="$(find /tmp/oc-mirror-workspace -name mapping.txt -type f | head -1)"
+cut -d= -f1 "$MAPPING" | sed 's|docker://||' | sort -u
+```
+
+For mirroring from the published Helm repo instead of a local path, use
+`mirror.helm.repositories` as in [Step 1](#step-1-create-imagesetconfiguration)
+and the same `oc-mirror` / `find` / `cut` sequence with your workspace path.
+
+> **Why hooks matter:** `oc-mirror` discovers images by rendering the chart the
+> same way Helm does for that pass. Anything not included there must appear in
+> `additionalImages`. CI verifies that every image in `helm template` output is
+> covered by the mirror plan; see `.github/workflows/lint-and-validate.yml`.
 
 ## Step 1: Create ImageSetConfiguration
 
 Create a file named `imageset-config.yaml`. The `additionalImages` section
-is **required** -- it lists images that `oc-mirror` cannot discover from
-the Helm chart automatically (see [Required Container Images](#required-container-images)).
+lists images that `oc-mirror` cannot discover from the Helm chart
+automatically (see [Discovering container images](#discovering-container-images)).
 
 ```yaml
 apiVersion: mirror.openshift.io/v2alpha1
@@ -74,9 +121,7 @@ mirror:
           - name: cost-onprem
             version: "0.2.10"
   # Images that oc-mirror cannot auto-discover from the Helm chart.
-  # These are used in Helm hooks (pre-install/pre-upgrade) which are
-  # not rendered during oc-mirror's image discovery pass.
-  # Keep in sync with the "Required Container Images" table above.
+  # Align with .github/workflows/lint-and-validate.yml additionalImages.
   additionalImages:
     - name: registry.redhat.io/rhel10/postgresql-16:10.1
     # Only needed if using install-helm-chart.sh for bucket creation:
@@ -152,15 +197,19 @@ kubectl get pods -n cost-onprem -o jsonpath='{range .items[*]}{.spec.containers[
 
 ## Updating Images
 
-When new versions are released, update the `ImageSetConfiguration` with the new chart version and image tags, then repeat the mirror process (Steps 2-5). The install script supports version pinning:
+When new versions are released, bump the chart version in
+`ImageSetConfiguration`, re-run the commands under
+[Discovering container images](#discovering-container-images), and repeat the
+mirror process (Steps 2-5). The install script supports version pinning:
 
 ```bash
 CHART_VERSION=0.2.10 ./scripts/install-helm-chart.sh
 ```
 
-> **Remember:** When image tags change in `values.yaml`, check whether any
-> `additionalImages` entries need updating as well. CI will fail if the
-> images reported by `helm template` are not fully covered by `oc-mirror`.
+> **Remember:** If `helm template` shows an image that your dry-run
+> `mapping.txt` does not, add it to `additionalImages` (and update CI’s list in
+> `.github/workflows/lint-and-validate.yml` when contributing upstream). CI
+> fails when `helm template` images are not fully covered by `oc-mirror`.
 
 ## References
 

--- a/docs/operations/disconnected-deployment.md
+++ b/docs/operations/disconnected-deployment.md
@@ -100,9 +100,10 @@ release you mirror and install. The `additionalImages` section lists images that
 [Discovering container images](#discovering-container-images)); keep it aligned
 with `.github/workflows/lint-and-validate.yml`.
 
-For the prerequisites sample, set `mirror.operators[].catalog` to
-`registry.redhat.io/redhat/redhat-operator-index:vX.Y` matching your OpenShift
-minor version, and adjust operator package channels if your release differs.
+The prerequisites sample defaults to OpenShift **4.20**
+(`registry.redhat.io/redhat/redhat-operator-index:v4.20`). If your cluster is
+another minor version, change that catalog tag (and operator channels, including
+optional ODF) to match.
 
 Copy one of the examples to `imageset-config.yaml` (or keep any path you
 prefer and pass it to `oc-mirror -c`).


### PR DESCRIPTION
## Summary

Replace the static **Required Container Images** table in `docs/operations/disconnected-deployment.md` with repeatable commands: `helm template` + awk for chart images, and `oc-mirror --v2` dry-run plus `mapping.txt` for the full mirror plan. Tags drift with releases, so generated lists stay accurate.

## Other changes

- Point readers at `.github/workflows/lint-and-validate.yml` `additionalImages` for hook/parity alignment.
- Adjust CI parity failure messages to reference the doc instead of asking to duplicate the removed table.

Made with [Cursor](https://cursor.com)