### PR TITLE
Use RHEL 10 PostgreSQL 16.10.1 for bundled DB and Keycloak

### DIFF
--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -62,7 +62,7 @@ jobs:
               - name: cost-onprem
                 path: ./cost-onprem
           additionalImages:
-            - name: quay.io/insights-onprem/postgresql:16
+            - name: registry.redhat.io/rhel10/postgresql-16:10.1
         EOF
 
         echo "=== Running oc-mirror --dry-run --v2 ==="

--- a/cost-onprem/templates/infrastructure/database/configmap-init.yaml
+++ b/cost-onprem/templates/infrastructure/database/configmap-init.yaml
@@ -14,8 +14,8 @@ metadata:
     "helm.sh/hook-weight": "-15"
 data:
   # PostgreSQL initialization script for all on-prem databases
-  # This script runs automatically on first database initialization
-  # Uses PostgreSQL's /docker-entrypoint-initdb.d/ mechanism
+  # Runs on first start via Red Hat / sclorg image hooks (sourced from
+  # /opt/app-root/src/postgresql-init/*.sh), not docker-entrypoint-initdb.d.
   #
   # Creates databases: costonprem_ros, costonprem_kruize, costonprem_koku
   # Shell script wrapper that passes password environment variables to SQL commands

--- a/cost-onprem/templates/infrastructure/database/database.yaml
+++ b/cost-onprem/templates/infrastructure/database/database.yaml
@@ -29,6 +29,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- include "cost-onprem.securityContext.pod.nonRoot" . | nindent 8 }}
       containers:
         - name: postgres
           image: "{{ .Values.database.server.image.repository }}:{{ .Values.database.server.image.tag }}"
@@ -109,6 +111,8 @@ spec:
             periodSeconds: {{ .Values.probes.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.failureThreshold }}
+          securityContext:
+            {{- include "cost-onprem.securityContext.container" . | nindent 12 }}
           resources:
             {{- toYaml .Values.resources.database | nindent 12 }}
       volumes:

--- a/cost-onprem/templates/infrastructure/database/database.yaml
+++ b/cost-onprem/templates/infrastructure/database/database.yaml
@@ -38,20 +38,21 @@ spec:
               containerPort: {{ .Values.database.server.port }}
               protocol: TCP
           env:
+            # registry.redhat.io/rhel*/postgresql-* (sclorg): requires POSTGRESQL_ADMIN_PASSWORD
+            # or POSTGRESQL_USER+POSTGRESQL_PASSWORD+POSTGRESQL_DATABASE. Admin password path
+            # matches bundled init (superuser role is "postgres").
+            - name: POSTGRESQL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cost-onprem.database.defaultSecretName" . }}
+                  key: postgres-password
+            # Used by init script and probes (must be the PostgreSQL superuser name, typically "postgres")
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cost-onprem.database.defaultSecretName" . }}
                   key: postgres-user
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "cost-onprem.database.defaultSecretName" . }}
-                  key: postgres-password
-            - name: PGDATA
-              value: "/var/lib/postgresql/data/pgdata"
-            # User and password environment variables for database initialization script
-            # These are used by /docker-entrypoint-initdb.d/init-databases.sh
+            # Service users/passwords for bundled init script (sourced from postgresql-init dir)
             - name: ROS_USER
               valueFrom:
                 secretKeyRef:
@@ -84,9 +85,9 @@ spec:
                   key: koku-password
           volumeMounts:
             - name: postgres-storage
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/pgsql/data
             - name: init-scripts
-              mountPath: /docker-entrypoint-initdb.d
+              mountPath: /opt/app-root/src/postgresql-init
               readOnly: true
           livenessProbe:
             exec:

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -591,8 +591,10 @@ database:
   # Unified Database Server Configuration
   server:
     image:
-      repository: quay.io/insights-onprem/postgresql
-      tag: "16"
+      repository: registry.redhat.io/rhel10/postgresql-16
+      tag: "10.1"
+      # Image entrypoint expects POSTGRESQL_* or POSTGRESQL_ADMIN_PASSWORD; chart supplies
+      # the latter. Secret key postgres-user must be the DB superuser name (default: postgres).
 
     storage:
       size: 30Gi  # Total storage for all databases (sum of individual DBs)

--- a/docs/api/keycloak-jwt-authentication-setup.md
+++ b/docs/api/keycloak-jwt-authentication-setup.md
@@ -418,7 +418,7 @@ cd scripts/
 ./deploy-rhbk.sh
 ```
 
-This script automates the operator installation and basic configuration.
+This script automates the operator installation and basic configuration. It also creates a PostgreSQL StatefulSet for the Keycloak database using `registry.redhat.io/rhel10/postgresql-16:10.1`, so the target namespace (or cluster global pull configuration) must be able to pull from `registry.redhat.io`.
 
 ### Post-Installation Verification
 

--- a/docs/operations/disconnected-deployment.md
+++ b/docs/operations/disconnected-deployment.md
@@ -35,7 +35,7 @@ Images marked **additional** are not auto-discovered by `oc-mirror` and
 | `quay.io/insights-onprem/koku:sources` | Cost Management API, MASU, Celery, Listener, Migration | auto |
 | `quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d0b4337` | Kruize optimization engine | auto |
 | `quay.io/insights-onprem/insights-ingress-go:latest` | Ingress service | auto |
-| `quay.io/insights-onprem/postgresql:16` | PostgreSQL database (Helm hook) | **additional** |
+| `registry.redhat.io/rhel10/postgresql-16:10.1` | PostgreSQL database (Helm pre-install/pre-upgrade hook) | **additional** |
 | `registry.redhat.io/rhel10/valkey-8:latest` | Valkey cache | auto |
 | `registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6` | Envoy gateway | auto |
 | `registry.redhat.io/rhceph/oauth2-proxy-rhel9:v7.6.0` | UI OAuth proxy | auto |
@@ -78,7 +78,7 @@ mirror:
   # not rendered during oc-mirror's image discovery pass.
   # Keep in sync with the "Required Container Images" table above.
   additionalImages:
-    - name: quay.io/insights-onprem/postgresql:16
+    - name: registry.redhat.io/rhel10/postgresql-16:10.1
     # Only needed if using install-helm-chart.sh for bucket creation:
     - name: amazon/aws-cli:latest
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,6 +104,7 @@ Deploy Red Hat Build of Keycloak (RHBK) with CoP integration.
 
 **What it creates:**
 - RHBK Operator in target namespace
+- PostgreSQL 16 for Keycloak (`registry.redhat.io/rhel10/postgresql-16:10.1`; requires pull access to `registry.redhat.io`)
 - Keycloak instance with `kubernetes` realm
 - `cost-management-operator` client
 - OpenShift OIDC integration

--- a/scripts/deploy-byoi-infra.sh
+++ b/scripts/deploy-byoi-infra.sh
@@ -134,9 +134,18 @@ spec:
       labels:
         app: postgresql
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: postgresql
         image: registry.redhat.io/rhel10/postgresql-16:10.1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         ports:
         - containerPort: 5432
         env:

--- a/scripts/deploy-byoi-infra.sh
+++ b/scripts/deploy-byoi-infra.sh
@@ -136,27 +136,25 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: quay.io/insights-onprem/postgresql:16
+        image: registry.redhat.io/rhel10/postgresql-16:10.1
         ports:
         - containerPort: 5432
         env:
+        - name: POSTGRESQL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-credentials
+              key: postgres-password
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
               name: postgresql-credentials
               key: postgres-user
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: postgresql-credentials
-              key: postgres-password
-        - name: PGDATA
-          value: /var/lib/postgresql/data/pgdata
         volumeMounts:
         - name: data
-          mountPath: /var/lib/postgresql/data
+          mountPath: /var/lib/pgsql/data
         - name: init-scripts
-          mountPath: /docker-entrypoint-initdb.d
+          mountPath: /opt/app-root/src/postgresql-init
         resources:
           requests:
             memory: "256Mi"

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -353,10 +353,19 @@ spec:
         app: keycloak-db
         component: database
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgres
           image: registry.redhat.io/rhel10/postgresql-16:10.1
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           ports:
             - name: postgres
               containerPort: 5432

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -8,6 +8,10 @@
 #
 # Environment Variables:
 #   LOG_LEVEL - Control output verbosity (ERROR|WARN|INFO|DEBUG, default: WARN)
+#   RHBK_NAMESPACE - Target namespace for operator, Keycloak, and DB (default: keycloak)
+#
+# Keycloak database image (embedded in deploy_postgresql):
+#   registry.redhat.io/rhel10/postgresql-16:10.1
 #
 # Examples:
 #   # Default (clean output)
@@ -351,7 +355,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: registry.redhat.io/rhel9/postgresql-15:latest
+          image: registry.redhat.io/rhel10/postgresql-16:10.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: postgres
@@ -370,8 +374,6 @@ spec:
                 secretKeyRef:
                   name: keycloak-db-secret
                   key: password
-            - name: PGDATA
-              value: "/var/lib/pgsql/data/pgdata"
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/pgsql/data


### PR DESCRIPTION
## Summary
- Switch default bundled PostgreSQL image to `registry.redhat.io/rhel10/postgresql-16:10.1`.
- Align StatefulSet with Red Hat/sclorg image: `POSTGRESQL_ADMIN_PASSWORD`, data volume at `/var/lib/pgsql/data`, init scripts under `/opt/app-root/src/postgresql-init`.
- `deploy-rhbk.sh`: same image for Keycloak DB; drop `PGDATA` override so the image uses its userdata layout.
- `deploy-byoi-infra.sh`: same PostgreSQL env and paths.
- Update disconnected-deployment guide, CI `additionalImages`, scripts README, Keycloak JWT setup note, and values comment.

## Testing
- [ ] `helm template` (local)
- [ ] Install/upgrade on cluster (database pod comes up, migrations run)

## Notes
- Existing PVCs initialized under `/var/lib/postgresql/data` need a one-time data migration or fresh PVC when upgrading to this layout.

Made with [Cursor](https://cursor.com)