### PR TITLE
FLPATH-3438 Enable source CRUD tests, add Kafka config, add Sources tests, update IQE profiles

### DIFF
--- a/.cursor/prompts/validate-iqe-changes.md
+++ b/.cursor/prompts/validate-iqe-changes.md
@@ -1,0 +1,112 @@
+# Validate IQE Plugin Changes
+
+Use this guide when validating changes to `iqe-cost-management-plugin` against the on-prem deployment.
+
+## Prerequisites
+
+- OpenShift cluster access configured (`oc login`)
+- `NAMESPACE` environment variable set (default: `cost-onprem`)
+- Local `iqe-cost-management-plugin` repo at `../iqe-cost-management-plugin`
+
+## Quick Validation
+
+For simple changes, run a targeted test:
+
+```bash
+# Single test
+NAMESPACE=cost-onprem ./scripts/run-iqe-tests-local.sh --filter "test_name_here"
+
+# Test category
+NAMESPACE=cost-onprem ./scripts/run-iqe-tests-local.sh --filter "test_api_ocp_compute"
+```
+
+## Loop Testing for Stability
+
+When validating changes that could introduce flakiness, use the loop runner:
+
+```bash
+# Run 5 iterations (default)
+./scripts/qe/run-iqe-loop.sh --filter "test_api_ocp_compute_deltas_percentages"
+
+# Run 12 iterations for thorough validation
+./scripts/qe/run-iqe-loop.sh --iterations 12 --filter "test_api_ocp_compute_deltas_percentages"
+
+# Verbose output to see full test logs
+./scripts/qe/run-iqe-loop.sh --iterations 3 --filter "test_name" --verbose
+```
+
+## Cleanup Stale Sources
+
+If tests fail with "duplicate accounts" errors, clean up stale test sources:
+
+```bash
+# Cleanup only
+./scripts/qe/run-iqe-loop.sh --cleanup-only
+
+# Or manually via API
+KEYCLOAK_SECRET=$(kubectl get secret -n keycloak keycloak-client-secret-cost-management-operator -o jsonpath='{.data.CLIENT_SECRET}' | base64 -d)
+TOKEN=$(curl -sk -X POST "https://$(kubectl get route -n keycloak keycloak -o jsonpath='{.spec.host}')/realms/kubernetes/protocol/openid-connect/token" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=cost-management-operator" \
+  -d "client_secret=$KEYCLOAK_SECRET" | jq -r '.access_token')
+
+# List sources
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  "https://$(kubectl get route -n cost-onprem cost-onprem-gateway -o jsonpath='{.spec.host}')/api/cost-management/v1/sources/" | jq '.data[] | {uuid, name}'
+
+# Delete a specific source
+curl -sk -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://$(kubectl get route -n cost-onprem cost-onprem-gateway -o jsonpath='{.spec.host}')/api/cost-management/v1/sources/UUID_HERE/"
+```
+
+## Common Test Patterns
+
+### Delta/Percentage Tests
+Tests that calculate deltas between metrics (usage vs limit, request vs capacity):
+
+```bash
+./scripts/qe/run-iqe-loop.sh --iterations 5 --filter "deltas_percentages"
+```
+
+**Known behavior**: Many OpenShift system namespaces have `limit=0` (no resource limits set), which causes `ZeroDivisionError` when calculating `usage_v_limit`. The helper function `validate_delta_percentage()` handles this gracefully by logging a warning and continuing.
+
+### Volume Tests  
+Tests for persistent volume reports:
+
+```bash
+./scripts/qe/run-iqe-loop.sh --iterations 5 --filter "test_api_ocp_volume"
+```
+
+**Known behavior**: Claimless PVs and certain cloud integrations produce resources with `No-node`, `No-project`, etc. naming patterns that legitimately have zero values.
+
+## Interpreting Results
+
+| Status | Meaning |
+|--------|---------|
+| PASSED | Test executed successfully |
+| FAILED | Test assertion failed |
+| ERROR | Test crashed (exception) |
+| XFAIL | Expected failure (fixture issue, usually stale source) |
+
+**XFAIL with "Source fixture failed"** indicates a stale test source exists. Run cleanup:
+```bash
+./scripts/qe/run-iqe-loop.sh --cleanup-only
+```
+
+## Validating ZeroDivisionError Handling
+
+After changes to delta percentage handling, verify:
+
+1. Tests that previously crashed with `ZeroDivisionError` now pass
+2. Warnings are logged for zero denominator cases
+3. No variance across multiple runs
+
+```bash
+# Run the specific tests that triggered ZeroDivisionError in CI
+./scripts/qe/run-iqe-loop.sh --iterations 10 --filter "test_api_ocp_compute_deltas_percentages or test_api_ocp_memory_deltas_percentages"
+```
+
+Expected output should show:
+- All iterations PASSED
+- Warnings logged for `limit=0` resources
+- Consistent results across all iterations

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ version_info.json
 reports/junit.xml
 **/*.json.gz
 debug-exports/**/*
-docs/development/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ version_info.json
 reports/junit.xml
 **/*.json.gz
 debug-exports/**/*
+docs/development/*.md

--- a/docs/development/skipped-iqe-tests.md
+++ b/docs/development/skipped-iqe-tests.md
@@ -49,7 +49,7 @@ A curated set of source and cost model tests that pass reliably. Good for quick 
 ```
 
 Includes:
-- Source CRUD operations (except update)
+- Source CRUD operations (including update — FLPATH-3423 resolved)
 - Cost model creation and application
 - Basic API validation
 
@@ -107,7 +107,7 @@ comment on each test identifies the Jira ticket.
 | COST-7179: GPU/MIG schema mismatch | ~27 functions | bucketing, cost reports, volume, VM, forecasting, currency, cost model, resource types, data ingest, source |
 | COST-7179: `completed_datetime` timeout | ~3 functions | cost model (tag rates), order-by, cost distribution |
 | COST-7179: GPU/MIG data in `last-90-days` param | 2 param-level | `api_params.py` |
-| FLPATH-3423: Source CRUD update | 1 function | `test__i_source.py` |
+| ~~FLPATH-3423: Source CRUD update~~ | ~~1 function~~ | ~~`test__i_source.py`~~ — **RESOLVED** |
 | Kafka consumer: external TLS access unsupported by `BrokerConfig` | 1 function | `test_ros.py` — [details](#kafka-consumer-test-limitation) |
 
 ### Markers Not Added
@@ -201,15 +201,18 @@ handled in seconds rather than 8+ hours.
 
 ---
 
-### Source CRUD Update (`SKIP_SOURCE_CRUD_TESTS`)
+### Source CRUD Update (`SKIP_SOURCE_CRUD_TESTS`) — RESOLVED
 
 **Jira**: [FLPATH-3423](https://redhat.atlassian.net/browse/FLPATH-3423)
-**Status**: Blocked — requires IQE plugin and backend fixes
-**Impact**: 1 test
+**Status**: ✅ Fixed — Koku PR #5968, chart PR #151, IQE plugin fix
+**Impact**: 1 test — now included in smoke profile
 
-**Problem**: Wrong API client in plugin + backend PATCH endpoint returns 500.
+**Resolution**: Backend `AdminSourcesSerializer` fixed to gate create-only validation
+on `not self.instance`; `SourcesViewSet` passes `partial=True` on PATCH. IQE plugin
+fixed to use `sources_client.sources_api.update_source` with `authentication=data`
+instead of the broken `integrations_api` path.
 
-**Filter**: `test_api_ocp_source_crud`
+**Filter**: `test_api_ocp_source_crud` (no longer skipped)
 
 ---
 
@@ -341,7 +344,7 @@ These groups were validated and are now included in profiles above `smoke`.
 |--------|-------|--------|--------|
 | [COST-7179](https://issues.redhat.com/browse/COST-7179) | GPU/MIG schema mismatch (`mig_instance_uuid`) | ~90 direct + ~100 cascade (order-by, cost-dist, unstable, data-intensive, 90-day) | Open — backend fix needed |
 | [FLPATH-3429](https://redhat.atlassian.net/browse/FLPATH-3429) | NISE GPU data feature flag for on-prem | Would unblock COST-7179 tests by gating GPU data generation | Open — proposed resolution |
-| [FLPATH-3423](https://redhat.atlassian.net/browse/FLPATH-3423) | Source CRUD update: wrong API client + backend 500 | 1 test | Open |
+| [FLPATH-3423](https://redhat.atlassian.net/browse/FLPATH-3423) | Source CRUD update: wrong API client + backend 500 | 1 test | ✅ Resolved (2026-04-29) |
 | [FLPATH-3369](https://redhat.atlassian.net/browse/FLPATH-3369) | IQE plugin updates for on-prem (fail-fast, fixtures, markers) | All on-prem tests benefit | In progress — branch active |
 | [FLPATH-2689](https://redhat.atlassian.net/browse/FLPATH-2689) | IQE unstable test investigation | ~20 tests — now reclassified as deterministic (COST-7179) | Resolved (2026-03-25) |
 

--- a/scripts/lib/iqe-filters.sh
+++ b/scripts/lib/iqe-filters.sh
@@ -62,9 +62,15 @@ apply_profile() {
             SKIP_FLAKY_TESTS=false
             ;;
         full)
-            # Release validation (~3324 tests, 2-3 hours)
-            # All cost_ocp_on_prem tests, no skip filters
-            SKIP_FILTER_BUILD=true
+            # Release validation (~3200 tests, ~90 min)
+            # All cost_ocp_on_prem tests except 90-day date range tests
+            # These tests actually can pass with some changes (FLPATH-4131).
+            # They do take roughly 1hr to run, so we will create a separate profile for them.
+            SKIP_DATE_RANGE_TESTS=true
+            SKIP_INFRA_TESTS=false
+            SKIP_SLOW_TESTS=false
+            SKIP_DELTA_TESTS=false
+            SKIP_FLAKY_TESTS=false
             ;;
         *)
             # Default: same as stable (all validated groups)
@@ -97,8 +103,9 @@ SKIP_ROS_TESTS="${SKIP_ROS_TESTS:-true}"
 FILTER_ROS="test_api_ocp_ros"
 
 # --- Date Range Tests (Insufficient Historical Data) ---
-# On-prem generates ~60 days of data; 90-day queries and random date ranges fail
-# ~50 tests affected
+# On-prem generates ~60 days of data; 90-day queries fail with 400 errors
+# ~120 tests affected (hardcoded last-90-days params)
+# Jira: COST-7253 (retention config), COST-573 (>90 days epic)
 # Note: Use underscores in patterns - pytest -k treats hyphens as "and not"
 SKIP_DATE_RANGE_TESTS="${SKIP_DATE_RANGE_TESTS:-true}"
 FILTER_DATE_RANGE="(last and 90 and days) or random_date_range or random_daily_time_filter"

--- a/scripts/lib/iqe-filters.sh
+++ b/scripts/lib/iqe-filters.sh
@@ -34,10 +34,9 @@ TEST_PROFILE="${TEST_PROFILE:-}"
 apply_profile() {
     case "${TEST_PROFILE}" in
         smoke)
-            # Quick validation (~43 tests, ~17 min)
+            # Quick validation (~44 tests, ~17 min)
             # Uses positive -k filter to select source + cost model tests
-            # Excludes test_api_ocp_source_crud (backend 500 error on update)
-            SMOKE_FILTER="(test_api_ocp_source and not test_api_ocp_source_crud) or test_api_cost_model_ocp"
+            SMOKE_FILTER="test_api_ocp_source or test_api_cost_model_ocp"
             # Skip all optional groups for fastest run
             SKIP_INFRA_TESTS=true
             SKIP_SLOW_TESTS=true
@@ -126,7 +125,7 @@ FILTER_COST_DISTRIBUTION="test_api_cost_model_ocp_cost_distribution"
 # --- Source CRUD Update Test (Backend Bug) ---
 # Backend PATCH endpoint returns 500 error
 # 1 test affected
-SKIP_SOURCE_CRUD_TESTS="${SKIP_SOURCE_CRUD_TESTS:-true}"
+SKIP_SOURCE_CRUD_TESTS="${SKIP_SOURCE_CRUD_TESTS:-false}"
 FILTER_SOURCE_CRUD="test_api_ocp_source_crud"
 
 # --- Tag-Based Rates Update Test (COST-7179 related) ---

--- a/scripts/lib/iqe-filters.sh
+++ b/scripts/lib/iqe-filters.sh
@@ -62,10 +62,9 @@ apply_profile() {
             SKIP_FLAKY_TESTS=false
             ;;
         full)
-            # Release validation (~3200 tests, ~90 min)
-            # All cost_ocp_on_prem tests except 90-day date range tests
-            # These tests actually can pass with some changes (FLPATH-4131).
-            # They do take roughly 1hr to run, so we will create a separate profile for them.
+            # Release validation (~2350 tests, ~55 min)
+            # All cost_ocp_on_prem tests except 90-day date range tests (~120 tests)
+            # 90-day tests require RETAIN_NUM_MONTHS=4 in chart (FLPATH-4131, COST-7253)
             SKIP_DATE_RANGE_TESTS=true
             SKIP_INFRA_TESTS=false
             SKIP_SLOW_TESTS=false

--- a/scripts/qe/run-iqe-loop.sh
+++ b/scripts/qe/run-iqe-loop.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+# run-iqe-loop.sh - Run IQE tests in a loop with proper cleanup between iterations. This has no CI use; it is only for local testing and putting tests through their paces.
+#
+# Usage:
+#   ./scripts/qe/run-iqe-loop.sh [OPTIONS]
+#
+# Options:
+#   --iterations N      Number of iterations (default: 5)
+#   --filter EXPR       Pytest filter expression
+#   --cleanup-only      Only run cleanup, don't run tests
+#   --no-cleanup        Skip cleanup between iterations
+#   --verbose           Show full test output
+#   --help              Show this help message
+#
+# Examples:
+#   # Run delta tests 10 times
+#   ./scripts/qe/run-iqe-loop.sh --iterations 10 --filter "test_api_ocp_compute_deltas_percentages"
+#
+#   # Clean up stale test sources
+#   ./scripts/qe/run-iqe-loop.sh --cleanup-only
+#
+#   # Run smoke tests 3 times with verbose output
+#   ./scripts/qe/run-iqe-loop.sh --iterations 3 --filter "smoke" --verbose
+
+set -euo pipefail
+
+# Defaults
+ITERATIONS=5
+FILTER=""
+CLEANUP_ONLY=false
+NO_CLEANUP=false
+VERBOSE=false
+NAMESPACE="${NAMESPACE:-cost-onprem}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+usage() {
+    grep '^#' "$0" | grep -v '#!/bin/bash' | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_success() { echo -e "${GREEN}[PASS]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[FAIL]${NC} $*"; }
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --iterations)
+            ITERATIONS="$2"
+            shift 2
+            ;;
+        --filter)
+            FILTER="$2"
+            shift 2
+            ;;
+        --cleanup-only)
+            CLEANUP_ONLY=true
+            shift
+            ;;
+        --no-cleanup)
+            NO_CLEANUP=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Get Keycloak token for API calls
+get_token() {
+    local keycloak_secret
+    keycloak_secret=$(kubectl get secret -n keycloak keycloak-client-secret-cost-management-operator \
+        -o jsonpath='{.data.CLIENT_SECRET}' 2>/dev/null | base64 -d)
+    
+    if [[ -z "$keycloak_secret" ]]; then
+        log_error "Could not get Keycloak secret"
+        return 1
+    fi
+    
+    local keycloak_host
+    keycloak_host=$(kubectl get route -n keycloak keycloak -o jsonpath='{.spec.host}' 2>/dev/null)
+    
+    curl -sk -X POST "https://${keycloak_host}/realms/kubernetes/protocol/openid-connect/token" \
+        -d "grant_type=client_credentials" \
+        -d "client_id=cost-management-operator" \
+        -d "client_secret=$keycloak_secret" | jq -r '.access_token'
+}
+
+# Get API gateway URL
+get_gateway_url() {
+    local route
+    # Try common route names
+    route=$(kubectl get route -n "$NAMESPACE" cost-onprem-api -o jsonpath='{.spec.host}' 2>/dev/null) || \
+    route=$(kubectl get route -n "$NAMESPACE" cost-onprem-gateway -o jsonpath='{.spec.host}' 2>/dev/null) || \
+    route=$(kubectl get route -n "$NAMESPACE" -l app.kubernetes.io/component=ingress -o jsonpath='{.items[0].spec.host}' 2>/dev/null)
+    
+    if [[ -z "$route" ]]; then
+        log_error "Could not find API gateway route"
+        return 1
+    fi
+    echo "https://${route}"
+}
+
+# List all test sources (sources with names starting with test_cost_)
+list_test_sources() {
+    local token gateway_url
+    token=$(get_token)
+    gateway_url=$(get_gateway_url)
+    
+    curl -sk -H "Authorization: Bearer $token" \
+        "${gateway_url}/api/cost-management/v1/sources/" | \
+        jq -r '.data[] | select(.name | startswith("test_cost_")) | "\(.uuid)\t\(.name)"'
+}
+
+# Delete a source by UUID
+delete_source() {
+    local uuid="$1"
+    local token gateway_url
+    token=$(get_token)
+    gateway_url=$(get_gateway_url)
+    
+    curl -sk -X DELETE -H "Authorization: Bearer $token" \
+        "${gateway_url}/api/cost-management/v1/sources/${uuid}/" >/dev/null
+}
+
+# Clean up all test sources
+cleanup_test_sources() {
+    log_info "Checking for stale test sources..."
+    
+    local sources
+    sources=$(list_test_sources)
+    
+    if [[ -z "$sources" ]]; then
+        log_info "No test sources found"
+        return 0
+    fi
+    
+    local count=0
+    while IFS=$'\t' read -r uuid name; do
+        if [[ -n "$uuid" ]]; then
+            log_warn "Deleting stale source: $name ($uuid)"
+            delete_source "$uuid"
+            ((count++))
+        fi
+    done <<< "$sources"
+    
+    if [[ $count -gt 0 ]]; then
+        log_info "Deleted $count stale test source(s)"
+        # Wait a moment for deletion to propagate
+        sleep 2
+    fi
+}
+
+# Run a single test iteration
+run_test_iteration() {
+    local iteration="$1"
+    local filter_args=""
+    
+    if [[ -n "$FILTER" ]]; then
+        filter_args="--filter \"$FILTER\""
+    fi
+    
+    local start_time end_time duration
+    start_time=$(date +%s)
+    
+    local output
+    local exit_code=0
+    
+    if [[ "$VERBOSE" == "true" ]]; then
+        NAMESPACE="$NAMESPACE" ./scripts/run-iqe-tests-local.sh $filter_args || exit_code=$?
+    else
+        output=$(NAMESPACE="$NAMESPACE" ./scripts/run-iqe-tests-local.sh $filter_args 2>&1) || exit_code=$?
+    fi
+    
+    end_time=$(date +%s)
+    duration=$((end_time - start_time))
+    
+    # Extract results from output
+    local passed failed errors xfailed
+    if [[ "$VERBOSE" != "true" ]]; then
+        passed=$(echo "$output" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' || echo "0")
+        failed=$(echo "$output" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' || echo "0")
+        errors=$(echo "$output" | grep -oE '[0-9]+ error' | grep -oE '[0-9]+' || echo "0")
+        xfailed=$(echo "$output" | grep -oE '[0-9]+ xfailed' | grep -oE '[0-9]+' || echo "0")
+    fi
+    
+    # Return results
+    echo "${exit_code}|${duration}|${passed:-?}|${failed:-?}|${errors:-?}|${xfailed:-?}"
+}
+
+# Main execution
+main() {
+    log_info "IQE Test Loop Runner"
+    log_info "Namespace: $NAMESPACE"
+    log_info "Iterations: $ITERATIONS"
+    [[ -n "$FILTER" ]] && log_info "Filter: $FILTER"
+    echo ""
+    
+    # Cleanup only mode
+    if [[ "$CLEANUP_ONLY" == "true" ]]; then
+        cleanup_test_sources
+        exit 0
+    fi
+    
+    # Initial cleanup
+    if [[ "$NO_CLEANUP" != "true" ]]; then
+        cleanup_test_sources
+    fi
+    
+    # Track results
+    declare -a results
+    local total_passed=0
+    local total_failed=0
+    local total_errors=0
+    
+    # Run iterations
+    for i in $(seq 1 "$ITERATIONS"); do
+        echo ""
+        log_info "========== Iteration $i/$ITERATIONS =========="
+        
+        # Cleanup before each iteration (except first, already done)
+        if [[ "$NO_CLEANUP" != "true" && $i -gt 1 ]]; then
+            cleanup_test_sources
+        fi
+        
+        # Run tests
+        local result
+        result=$(run_test_iteration "$i")
+        results+=("$result")
+        
+        # Parse result
+        IFS='|' read -r exit_code duration passed failed errors xfailed <<< "$result"
+        
+        # Display result
+        if [[ "$exit_code" -eq 0 ]]; then
+            log_success "Iteration $i: PASSED (${duration}s) - passed=$passed failed=$failed errors=$errors xfailed=$xfailed"
+            ((total_passed++))
+        else
+            log_error "Iteration $i: FAILED (${duration}s) - passed=$passed failed=$failed errors=$errors xfailed=$xfailed"
+            ((total_failed++))
+        fi
+    done
+    
+    # Summary
+    echo ""
+    echo "=========================================="
+    log_info "SUMMARY"
+    echo "=========================================="
+    echo "Total iterations: $ITERATIONS"
+    log_success "Passed: $total_passed"
+    [[ $total_failed -gt 0 ]] && log_error "Failed: $total_failed"
+    echo ""
+    
+    # Detailed results table
+    echo "Iteration | Status | Duration | Passed | Failed | Errors | XFailed"
+    echo "----------|--------|----------|--------|--------|--------|--------"
+    for i in "${!results[@]}"; do
+        IFS='|' read -r exit_code duration passed failed errors xfailed <<< "${results[$i]}"
+        local status="PASS"
+        [[ "$exit_code" -ne 0 ]] && status="FAIL"
+        printf "    %d     | %s  |   %3ds   |   %s   |   %s   |   %s   |   %s\n" \
+            $((i+1)) "$status" "$duration" "$passed" "$failed" "$errors" "$xfailed"
+    done
+    
+    # Final cleanup
+    if [[ "$NO_CLEANUP" != "true" ]]; then
+        echo ""
+        cleanup_test_sources
+    fi
+    
+    # Exit with failure if any iteration failed
+    [[ $total_failed -gt 0 ]] && exit 1
+    exit 0
+}
+
+main

--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -295,6 +295,18 @@ else
     S3_USE_SSL="true"
 fi
 
+# Get Kafka bootstrap servers from Kafka CR (Strimzi)
+# The container runs inside the cluster so it can use the internal service name
+KAFKA_NAMESPACE=${KAFKA_NAMESPACE:-kafka}
+KAFKA_BOOTSTRAP=$(kubectl get kafka -n "$KAFKA_NAMESPACE" -o jsonpath='{.items[0].status.listeners[?(@.name=="plain")].bootstrapServers}' 2>/dev/null || echo "")
+if [ -z "$KAFKA_BOOTSTRAP" ]; then
+    # Fallback to service name
+    KAFKA_BOOTSTRAP="cost-onprem-kafka-kafka-bootstrap.${KAFKA_NAMESPACE}.svc:9092"
+fi
+# Parse hostname and port
+KAFKA_HOSTNAME="${KAFKA_BOOTSTRAP%%:*}"
+KAFKA_PORT="${KAFKA_BOOTSTRAP##*:}"
+
 # Get Keycloak credentials from the auth secret
 # Try uppercase keys first (keycloak-client-secret-*), then lowercase (cost-management-auth-secret)
 KEYCLOAK_CLIENT_ID=$(kubectl get secret "$KEYCLOAK_SECRET_NAME" -n "$KEYCLOAK_SECRET_NS" -o jsonpath='{.data.CLIENT_ID}' 2>/dev/null | base64 -d || \
@@ -349,6 +361,7 @@ echo "  MASU (in-cluster): ${MASU_HOSTNAME}:${MASU_PORT}"
 echo "  S3 Endpoint: ${S3_ENDPOINT}"
 echo "  S3 Port: ${S3_PORT} (SSL: ${S3_USE_SSL})"
 echo "  S3 Buckets: koku=${S3_BUCKET_NAME}, ros=${S3_ROS_BUCKET}"
+echo "  Kafka: ${KAFKA_BOOTSTRAP}"
 echo "  OAuth URL: ${OAUTH_URL}"
 echo "  Keycloak Client ID: ${KEYCLOAK_CLIENT_ID}"
 
@@ -615,6 +628,7 @@ spec:
           -k "\${IQE_FILTER}" \
           -vv \
           --junitxml=/results/junit.xml \
+          -o junit_suite_name=iqe-cost-management-onprem \
           2>&1 | tee /results/test-output.log
       else
         iqe tests plugin cost_management \
@@ -622,6 +636,7 @@ spec:
           -m "${IQE_MARKER}" \
           -vv \
           --junitxml=/results/junit.xml \
+          -o junit_suite_name=iqe-cost-management-onprem \
           2>&1 | tee /results/test-output.log
       fi
       
@@ -752,6 +767,16 @@ spec:
       value: "${S3_BUCKET_NAME}"
     - name: S3_ROS_BUCKET
       value: "${S3_ROS_BUCKET}"
+
+    # Kafka Configuration (for MQ plugin - ROS Kafka tests)
+    # DYNACONF reads these env vars to configure the broker for cost_onprem environment
+    # Note: lowercase after DYNACONF_BROKER__ preserves case in the config dict
+    - name: DYNACONF_BROKER__hostname
+      value: "${KAFKA_HOSTNAME}"
+    - name: DYNACONF_BROKER__port
+      value: "${KAFKA_PORT}"
+    - name: DYNACONF_BROKER__securityProtocol
+      value: "PLAINTEXT"
 ${NISE_VERSION_ENV}
     imagePullPolicy: Always
     resources:

--- a/tests/suites/sources/test_sources_api.py
+++ b/tests/suites/sources/test_sources_api.py
@@ -768,3 +768,233 @@ class TestSourceStatus:
             print(f"Source status: {source['status']}")
         else:
             print(f"Source structure: {list(source.keys())}")
+
+
+# =============================================================================
+# P4 - Source Pause/Resume (FLPATH-3486)
+# =============================================================================
+
+
+@pytest.mark.sources
+@pytest.mark.api
+@pytest.mark.integration
+class TestSourcesPauseResume:
+    """External API tests for source pause/resume via gateway (FLPATH-3486)."""
+
+    def test_pause_and_resume_source(
+        self, gateway_url: str, authenticated_session: requests.Session
+    ):
+        """Verify PATCH pause/resume works via external gateway.
+
+        Validates FLPATH-3423 (PATCH IntegrityError) and FLPATH-3486
+        (paused field not accepted).
+        """
+        ocp_source_type_id = get_ocp_source_type_id(gateway_url, authenticated_session)
+
+        source_name = f"pause-test-{uuid.uuid4().hex[:8]}"
+        cluster_id = f"pause-cluster-{uuid.uuid4().hex[:8]}"
+
+        # Create source
+        create_resp = authenticated_session.post(
+            f"{gateway_url}/cost-management/v1/sources",
+            json={
+                "name": source_name,
+                "source_type_id": ocp_source_type_id,
+                "source_ref": cluster_id,
+            },
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        assert create_resp.status_code == 201, (
+            f"Source creation failed: {create_resp.status_code} - {create_resp.text[:200]}"
+        )
+
+        source_data = create_resp.json()
+        source_id = source_data.get("id")
+        source_uuid = source_data.get("uuid")
+        assert source_id or source_uuid, "Source ID/UUID not returned"
+
+        # Use UUID for PATCH if available, otherwise ID
+        patch_id = source_uuid or source_id
+
+        try:
+            # Pause
+            pause_resp = authenticated_session.patch(
+                f"{gateway_url}/cost-management/v1/sources/{patch_id}/",
+                json={"paused": True},
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            assert pause_resp.status_code == 200, (
+                f"Pause PATCH failed: {pause_resp.status_code} - {pause_resp.text[:200]}"
+            )
+
+            # Verify paused
+            get_resp = authenticated_session.get(
+                f"{gateway_url}/cost-management/v1/sources/{patch_id}/",
+                timeout=30,
+            )
+            assert get_resp.status_code == 200
+            assert get_resp.json().get("paused") is True, (
+                f"Source not paused after PATCH: {get_resp.json()}"
+            )
+
+            # Resume
+            resume_resp = authenticated_session.patch(
+                f"{gateway_url}/cost-management/v1/sources/{patch_id}/",
+                json={"paused": False},
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            assert resume_resp.status_code == 200, (
+                f"Resume PATCH failed: {resume_resp.status_code} - {resume_resp.text[:200]}"
+            )
+
+            # Verify resumed
+            get_resp2 = authenticated_session.get(
+                f"{gateway_url}/cost-management/v1/sources/{patch_id}/",
+                timeout=30,
+            )
+            assert get_resp2.status_code == 200
+            assert get_resp2.json().get("paused") is False, (
+                f"Source not resumed after PATCH: {get_resp2.json()}"
+            )
+
+        finally:
+            authenticated_session.delete(
+                f"{gateway_url}/cost-management/v1/sources/{patch_id}/",
+                timeout=30,
+            )
+
+
+# =============================================================================
+# P5 - Source Timestamps (FLPATH-3420)
+# =============================================================================
+
+
+@pytest.mark.sources
+@pytest.mark.api
+@pytest.mark.integration
+class TestSourcesTimestamps:
+    """External API tests for source timestamp fields (FLPATH-3420)."""
+
+    def test_source_has_updated_timestamp(
+        self, gateway_url: str, authenticated_session: requests.Session
+    ):
+        """Verify GET source response includes updated_timestamp field."""
+        ocp_source_type_id = get_ocp_source_type_id(gateway_url, authenticated_session)
+
+        source_name = f"ts-test-{uuid.uuid4().hex[:8]}"
+        cluster_id = f"ts-cluster-{uuid.uuid4().hex[:8]}"
+
+        create_resp = authenticated_session.post(
+            f"{gateway_url}/cost-management/v1/sources",
+            json={
+                "name": source_name,
+                "source_type_id": ocp_source_type_id,
+                "source_ref": cluster_id,
+            },
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        assert create_resp.status_code == 201
+        source_data = create_resp.json()
+        source_id = source_data.get("uuid") or source_data.get("id")
+
+        try:
+            # Verify field exists on detail GET
+            get_resp = authenticated_session.get(
+                f"{gateway_url}/cost-management/v1/sources/{source_id}/",
+                timeout=30,
+            )
+            assert get_resp.status_code == 200
+            detail = get_resp.json()
+            assert "updated_timestamp" in detail, (
+                f"updated_timestamp missing from source response. Keys: {list(detail.keys())}"
+            )
+            assert detail["updated_timestamp"] is not None, (
+                "updated_timestamp should not be null for a newly created source"
+            )
+
+            # Verify field exists in list response
+            list_resp = authenticated_session.get(
+                f"{gateway_url}/cost-management/v1/sources",
+                params={"name": source_name},
+                timeout=30,
+            )
+            assert list_resp.status_code == 200
+            sources = list_resp.json().get("data", [])
+            assert len(sources) > 0
+            assert "updated_timestamp" in sources[0], (
+                f"updated_timestamp missing from list response. Keys: {list(sources[0].keys())}"
+            )
+
+        finally:
+            authenticated_session.delete(
+                f"{gateway_url}/cost-management/v1/sources/{source_id}/",
+                timeout=30,
+            )
+
+    def test_updated_timestamp_advances_on_patch(
+        self, gateway_url: str, authenticated_session: requests.Session
+    ):
+        """Verify updated_timestamp increases after a PATCH.
+
+        Exercises both FLPATH-3420 (timestamp) and FLPATH-3423 (PATCH works).
+        """
+        import time
+
+        ocp_source_type_id = get_ocp_source_type_id(gateway_url, authenticated_session)
+
+        source_name = f"ts-patch-{uuid.uuid4().hex[:8]}"
+        cluster_id = f"ts-patch-cluster-{uuid.uuid4().hex[:8]}"
+
+        create_resp = authenticated_session.post(
+            f"{gateway_url}/cost-management/v1/sources",
+            json={
+                "name": source_name,
+                "source_type_id": ocp_source_type_id,
+                "source_ref": cluster_id,
+            },
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        assert create_resp.status_code == 201
+        source_id = create_resp.json().get("uuid") or create_resp.json().get("id")
+
+        try:
+            # Record initial timestamp
+            get1 = authenticated_session.get(
+                f"{gateway_url}/cost-management/v1/sources/{source_id}/",
+                timeout=30,
+            )
+            ts1 = get1.json().get("updated_timestamp")
+            assert ts1 is not None
+
+            time.sleep(1)  # ensure wall-clock difference
+
+            # PATCH to trigger update
+            patch_resp = authenticated_session.patch(
+                f"{gateway_url}/cost-management/v1/sources/{source_id}/",
+                json={"paused": True},
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            assert patch_resp.status_code == 200
+
+            # Verify timestamp advanced
+            get2 = authenticated_session.get(
+                f"{gateway_url}/cost-management/v1/sources/{source_id}/",
+                timeout=30,
+            )
+            ts2 = get2.json().get("updated_timestamp")
+            assert ts2 is not None
+            assert ts2 > ts1, (
+                f"updated_timestamp did not advance after PATCH: {ts1} -> {ts2}"
+            )
+
+        finally:
+            authenticated_session.delete(
+                f"{gateway_url}/cost-management/v1/sources/{source_id}/",
+                timeout=30,
+            )


### PR DESCRIPTION
This updates IQE test infrastructure to enable newly-fixed tests and improve containerized test execution:

#### 1. Enable Source CRUD Tests

**Background:** FLPATH-3423 (backend PATCH 500 error) has been fixed in Koku.

**Changes:**
- Set `SKIP_SOURCE_CRUD_TESTS=false` in `iqe-filters.sh`
- Update smoke profile filter to include `test_api_ocp_source_crud`
- Update documentation to mark FLPATH-3423 as resolved

#### 2. Kafka Configuration for IQE Container

**Problem:** `test_api_ocp_ros_kafka_content` requires Kafka broker configuration, which wasn't available in containerized runs.

**Fix:** In `run-iqe-tests.sh`:
- Extract Kafka bootstrap server from Strimzi CR
- Pass `DYNACONF_BROKER__hostname`, `DYNACONF_BROKER__port`, `DYNACONF_BROKER__securityProtocol` to IQE pod
- Enables ROS Kafka test to run in CI

#### 3. Update Full IQE Profile

**Problem:** 90-day date range tests fail with HTTP 400 due to `RETAIN_NUM_MONTHS=3` in the chart.

**Change:** Skip these tests in the `full` profile until COST-7253/COST-573 are completed:
- Set `SKIP_DATE_RANGE_TESTS=true` for `full` profile
- Update test count estimate (~3200 tests, ~90 min)
- Add comments referencing FLPATH-4131, COST-7253, COST-573

#### 4. JUnit Suite Name

Add `-o junit_suite_name=iqe-cost-management-onprem` to pytest commands to distinguish IQE results from chart test results in CI reports.

#### 5. New Chart-Level Sources Tests

Added to `tests/suites/sources/test_sources_api.py`:
- `TestSourcesPauseResume` - Verifies PATCH pause/resume works (FLPATH-3486)
- `TestSourcesTimestamps` - Verifies `updated_timestamp` is modified on PATCH (FLPATH-3420)

#### 6. IQE Loop Script

Added `scripts/qe/run-iqe-loop.sh` for local testing:
- Runs tests multiple times with cleanup between iterations
- Helps identify flaky tests
- Provides summary table of results

### Testing

- Verified source CRUD tests pass in CI
- Verified Kafka configuration enables ROS test in container
- Full profile IQE run: **2260 passed**, 32 failed (unrelated volume edge cases)
- Chart tests pass including new sources tests

### Related Issues

- FLPATH-3438 (On-Prem IQE Test Enablement)
- FLPATH-3423 (Source CRUD backend fix - resolved)
- FLPATH-3486 (Source pause/resume)
- FLPATH-3420 (Source updated_timestamp)
- FLPATH-4131 (90-day test enablement - blocked on COST-7253/COST-573)

Marked as Draft until IQE MR is merged with required source CRUD test fixes