### PR TITLE
chore: release cost-onprem v0.2.20-rc4

### DIFF
--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.20-rc3
-appVersion: "0.2.20-rc3"
+version: 0.2.20-rc4
+appVersion: "0.2.20-rc4"
 
 keywords:
   - cost-management


### PR DESCRIPTION
Bump cost-onprem chart version to v0.2.20-rc4.

This PR triggers the chart-releaser workflow on merge to main,
which publishes the chart to the GitHub Pages Helm repository.

Made with [Cursor](https://cursor.com)