### PR TITLE
fix: derive is_org_admin from Keycloak org-admin realm role

### DIFF
--- a/cost-onprem/templates/_helpers-rbac.tpl
+++ b/cost-onprem/templates/_helpers-rbac.tpl
@@ -115,6 +115,9 @@ Provides DB, Redis, and application configuration for non-Clowder mode.
   value: "00000000-0000-4000-a000-000000000004"
 - name: CLOWDER_ENABLED
   value: "false"
+  {{/* On-prem has no Back Office Proxy (BOP/mbop); bypass its identity
+       verification so RBAC accepts the X-Rh-Identity header directly from
+       Envoy. Required for on-prem; SaaS uses BOP for this check. */}}
 - name: BYPASS_BOP_VERIFICATION
   value: "True"
 - name: KAFKA_ENABLED

--- a/cost-onprem/templates/_helpers-rbac.tpl
+++ b/cost-onprem/templates/_helpers-rbac.tpl
@@ -148,6 +148,51 @@ RBAC service port (always 8000 — internal only, not user-configurable).
 {{- end -}}
 
 {{/*
+Resolve the bootstrap admin identity from jwtAuth.realmUsers.
+Finds the first entry with orgAdmin=true and returns username, orgId,
+accountNumber. Falls back to rbac.bootstrapAdmin values if realmUsers
+is empty or has no orgAdmin entry.
+*/}}
+{{- define "cost-onprem.rbac.bootstrapAdmin.username" -}}
+{{- $found := false -}}
+{{- range .Values.jwtAuth.realmUsers -}}
+  {{- if and (not $found) .orgAdmin -}}
+    {{- $found = true -}}
+    {{- .username -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $found -}}
+  {{- .Values.rbac.bootstrapAdmin.username | default "admin" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cost-onprem.rbac.bootstrapAdmin.orgId" -}}
+{{- $found := false -}}
+{{- range .Values.jwtAuth.realmUsers -}}
+  {{- if and (not $found) .orgAdmin -}}
+    {{- $found = true -}}
+    {{- .orgId -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $found -}}
+  {{- .Values.rbac.bootstrapAdmin.orgId | default "org1234567" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cost-onprem.rbac.bootstrapAdmin.accountNumber" -}}
+{{- $found := false -}}
+{{- range .Values.jwtAuth.realmUsers -}}
+  {{- if and (not $found) .orgAdmin -}}
+    {{- $found = true -}}
+    {{- .accountNumber -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $found -}}
+  {{- .Values.rbac.bootstrapAdmin.accountNumber | default "7890123" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 RBAC database secret name. Reuses the main DB credentials secret
 with RBAC-specific keys, or a dedicated secret.
 */}}

--- a/cost-onprem/templates/_helpers-rbac.tpl
+++ b/cost-onprem/templates/_helpers-rbac.tpl
@@ -153,19 +153,22 @@ RBAC service port (always 8000 — internal only, not user-configurable).
 {{/*
 Resolve the bootstrap admin identity from jwtAuth.realmUsers.
 Finds the first entry with orgAdmin=true and returns username, orgId,
-accountNumber. Falls back to rbac.bootstrapAdmin values if realmUsers
-is empty or has no orgAdmin entry.
+accountNumber. When bootstrapAdmin.enabled is true and no orgAdmin
+user exists, the template fails with an actionable error.
 */}}
 {{- define "cost-onprem.rbac.bootstrapAdmin.username" -}}
 {{- $found := false -}}
 {{- range .Values.jwtAuth.realmUsers -}}
   {{- if and (not $found) .orgAdmin -}}
     {{- $found = true -}}
-    {{- .username -}}
+    {{- .username | required "jwtAuth.realmUsers: orgAdmin entry must have a username" -}}
   {{- end -}}
 {{- end -}}
 {{- if not $found -}}
-  {{- .Values.rbac.bootstrapAdmin.username | default "admin" -}}
+  {{- if .Values.rbac.bootstrapAdmin.enabled -}}
+    {{- fail "rbac.bootstrapAdmin.enabled is true but no orgAdmin:true entry found in jwtAuth.realmUsers" -}}
+  {{- end -}}
+  {{- "admin" -}}
 {{- end -}}
 {{- end -}}
 
@@ -174,11 +177,11 @@ is empty or has no orgAdmin entry.
 {{- range .Values.jwtAuth.realmUsers -}}
   {{- if and (not $found) .orgAdmin -}}
     {{- $found = true -}}
-    {{- .orgId -}}
+    {{- .orgId | required "jwtAuth.realmUsers: orgAdmin entry must have an orgId" -}}
   {{- end -}}
 {{- end -}}
 {{- if not $found -}}
-  {{- .Values.rbac.bootstrapAdmin.orgId | default "org1234567" -}}
+  {{- "org1234567" -}}
 {{- end -}}
 {{- end -}}
 
@@ -187,11 +190,11 @@ is empty or has no orgAdmin entry.
 {{- range .Values.jwtAuth.realmUsers -}}
   {{- if and (not $found) .orgAdmin -}}
     {{- $found = true -}}
-    {{- .accountNumber -}}
+    {{- .accountNumber | required "jwtAuth.realmUsers: orgAdmin entry must have an accountNumber" -}}
   {{- end -}}
 {{- end -}}
 {{- if not $found -}}
-  {{- .Values.rbac.bootstrapAdmin.accountNumber | default "7890123" -}}
+  {{- "7890123" -}}
 {{- end -}}
 {{- end -}}
 

--- a/cost-onprem/templates/gateway/configmap-envoy.yaml
+++ b/cost-onprem/templates/gateway/configmap-envoy.yaml
@@ -375,8 +375,10 @@ data:
                           -- Use replace to avoid duplicate headers
                           request_handle:headers():replace("X-Rh-Identity", xrhid_b64)
 
-                          -- Forward the original Authorization header as X-Bearer-Token
-                          -- Try both capitalization variants for case-insensitive lookup
+                          -- Forward the raw JWT as X-Bearer-Token for backends that
+                          -- need it (e.g., oauth-proxy session refresh). Envoy has
+                          -- already validated the signature via jwt_authn; backends
+                          -- MUST NOT trust this header for authz — use X-Rh-Identity.
                           local auth_header = request_handle:headers():get("authorization")
                           if not auth_header then
                             auth_header = request_handle:headers():get("Authorization")

--- a/cost-onprem/templates/gateway/configmap-envoy.yaml
+++ b/cost-onprem/templates/gateway/configmap-envoy.yaml
@@ -227,11 +227,10 @@ data:
                       -- permissions from the "Cost Admin Default" group (seeded by the migration
                       -- job with "Cost Administrator" role = cost-management:*:*).
                       --
-                      -- In on-prem there is no BOP. The org_admin_usernames table below is
-                      -- rendered from jwtAuth.orgAdminUsernames in values.yaml. Only listed
-                      -- usernames get is_org_admin=true. When the list is empty (default),
-                      -- is_org_admin is false for everyone and admin access must be granted
-                      -- through explicit RBAC group membership.
+                      -- In on-prem, is_org_admin is derived from the Keycloak "org-admin"
+                      -- realm role. If the JWT contains "org-admin" in realm_access.roles,
+                      -- the user gets is_org_admin=true. Keycloak is the single source of
+                      -- truth — assign/remove the role in the Keycloak admin console.
                       --
                       -- Both Koku and ROS route through this gateway and receive the same
                       -- X-Rh-Identity header. Both services enforce RBAC permissions by
@@ -241,12 +240,17 @@ data:
                       -- middleware returns 403 without it and there is no bypass.
                       -- =============================================================================
 
-                      -- Org admin lookup table (rendered from jwtAuth.orgAdminUsernames)
-                      local org_admin_usernames = {
-                        {{- range .Values.jwtAuth.orgAdminUsernames }}
-                        [{{ . | quote }}] = true,
-                        {{- end }}
-                      }
+                      -- Check if JWT realm_access.roles contains a specific role
+                      local function has_realm_role(jwt_data, role_name)
+                        local realm_access = jwt_data["realm_access"]
+                        if realm_access == nil then return false end
+                        local roles = realm_access["roles"]
+                        if roles == nil then return false end
+                        for _, role in ipairs(roles) do
+                          if role == role_name then return true end
+                        end
+                        return false
+                      end
 
                       local function build_xrhid_json(org_id, account_number, user_type, username, email, is_org_admin)
                         local function escape_json(str)
@@ -363,7 +367,7 @@ data:
                             email = username .. "@example.com"
                           end
 
-                          local is_org_admin = org_admin_usernames[username] or false
+                          local is_org_admin = has_realm_role(jwt_data, "org-admin")
                           local xrhid_json = build_xrhid_json(org_id, account_number, "User", username, email, is_org_admin)
                           local xrhid_b64 = request_handle:base64Escape(xrhid_json)
 

--- a/cost-onprem/templates/rbac/admin-bootstrap-job.yaml
+++ b/cost-onprem/templates/rbac/admin-bootstrap-job.yaml
@@ -41,9 +41,9 @@ spec:
             MAX_WAIT=300
             ELAPSED=0
 
-            BOOTSTRAP_USERNAME="{{ .Values.rbac.bootstrapAdmin.username }}"
-            BOOTSTRAP_ORG_ID="{{ .Values.rbac.bootstrapAdmin.orgId }}"
-            BOOTSTRAP_ACCOUNT_NUMBER="{{ .Values.rbac.bootstrapAdmin.accountNumber }}"
+            BOOTSTRAP_USERNAME="{{ include "cost-onprem.rbac.bootstrapAdmin.username" . }}"
+            BOOTSTRAP_ORG_ID="{{ include "cost-onprem.rbac.bootstrapAdmin.orgId" . }}"
+            BOOTSTRAP_ACCOUNT_NUMBER="{{ include "cost-onprem.rbac.bootstrapAdmin.accountNumber" . }}"
 
             echo "=== insights-rbac admin bootstrap job ==="
             echo "Username: ${BOOTSTRAP_USERNAME}"

--- a/cost-onprem/templates/rbac/admin-bootstrap-job.yaml
+++ b/cost-onprem/templates/rbac/admin-bootstrap-job.yaml
@@ -63,14 +63,18 @@ spec:
             echo "✓ PostgreSQL is ready (waited ${ELAPSED}s)"
 
             echo "Creating Tenant, Principal, Group, and Policy for admin user..."
-            python manage.py shell <<BOOTSTRAP_SCRIPT
+            export SYNC_USERNAME="${BOOTSTRAP_USERNAME}"
+            export SYNC_ORG_ID="${BOOTSTRAP_ORG_ID}"
+            export SYNC_ACCOUNT_NUMBER="${BOOTSTRAP_ACCOUNT_NUMBER}"
+            python manage.py shell <<'BOOTSTRAP_SCRIPT'
+            import os
             from api.models import Tenant
             from management.models import Group, Policy, Role, Principal
             from django.core.cache import cache
 
-            username = "${BOOTSTRAP_USERNAME}"
-            org_id = "${BOOTSTRAP_ORG_ID}"
-            acct_number = "${BOOTSTRAP_ACCOUNT_NUMBER}"
+            username = os.environ['SYNC_USERNAME']
+            org_id = os.environ['SYNC_ORG_ID']
+            acct_number = os.environ['SYNC_ACCOUNT_NUMBER']
 
             public_tenant = Tenant.objects.get(tenant_name='public')
             admin_default_roles = Role.objects.filter(admin_default=True, tenant=public_tenant)

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -842,15 +842,34 @@ jwtAuth:
         cpu: 100m
         memory: 128Mi
 
-  # Org admin usernames: Keycloak usernames that receive is_org_admin=true in
-  # the X-Rh-Identity header. This triggers insights-rbac's admin_default role
-  # assignment (e.g. "Cost Administrator" via the admin_default group).
-  # Leave empty to keep is_org_admin=false for all users (default, most secure).
-  orgAdminUsernames: []
-  # Example:
-  #   orgAdminUsernames:
-  #     - admin
-  #     - cost-mgmt-operator
+  # Keycloak realm users provisioned by deploy-rhbk.sh -f <this-file>.
+  # Each entry defines a user in the Keycloak realm with Cost Management attributes.
+  #
+  # orgAdmin: true assigns the Keycloak "org-admin" realm role to the user.
+  # The Envoy gateway reads this role from the JWT (realm_access.roles) and sets
+  # is_org_admin=true in X-Rh-Identity, triggering insights-rbac's admin_default
+  # group (Cost Administrator = cost-management:*:*).
+  #
+  # Keycloak is the single source of truth — after initial provisioning, admin
+  # status can also be managed directly in the Keycloak admin console by
+  # assigning/removing the "org-admin" realm role.
+  realmUsers:
+    - username: admin
+      password: admin
+      email: admin@test.com
+      firstName: Admin
+      lastName: User
+      orgId: "org1234567"
+      accountNumber: "7890123"
+      orgAdmin: true
+    - username: viewer
+      password: viewer
+      email: viewer@test.com
+      firstName: Viewer
+      lastName: User
+      orgId: "org1234567"
+      accountNumber: "7890123"
+      orgAdmin: false
 
   # Keycloak configuration for JWT validation
   # Supported operator: Red Hat Build of Keycloak (RHBK) v22+ - k8s.keycloak.org/v2alpha1

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -681,16 +681,15 @@ rbac:
         memory: 2Gi
 
   # Bootstrap an initial admin user with Cost Administrator permissions.
-  # Enable after creating the corresponding user in Keycloak with matching
-  # org_id and account_number attributes (e.g. via deploy-rhbk.sh).
   # A post-install/post-upgrade hook Job creates the RBAC Tenant, Principal,
   # Group, and Policy so the user can access the API immediately.
   # All operations are idempotent (safe to leave enabled across upgrades).
+  #
+  # The bootstrap user identity (username, orgId, accountNumber) is derived
+  # from the first orgAdmin:true entry in jwtAuth.realmUsers — no need to
+  # duplicate credentials here. Enable this toggle after running deploy-rhbk.sh.
   bootstrapAdmin:
     enabled: false
-    username: "admin"
-    orgId: "org1234567"
-    accountNumber: "7890123"
 
 # -----------------------------------------------------------------------------
 # Shared Infrastructure - Kafka

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -844,6 +844,10 @@ jwtAuth:
   # Keycloak realm users provisioned by deploy-rhbk.sh -f <this-file>.
   # Each entry defines a user in the Keycloak realm with Cost Management attributes.
   #
+  # WARNING: Change default passwords before deploying to production.
+  # These are initial development/test defaults only. FedRAMP and production
+  # environments require passwords that meet organizational complexity policy.
+  #
   # orgAdmin: true assigns the Keycloak "org-admin" realm role to the user.
   # The Envoy gateway reads this role from the JWT (realm_access.roles) and sets
   # is_org_admin=true in X-Rh-Identity, triggering insights-rbac's admin_default

--- a/docs/operations/rbac-setup.md
+++ b/docs/operations/rbac-setup.md
@@ -2,8 +2,23 @@
 
 Role-Based Access Control (RBAC) configuration, user management, and troubleshooting for Cost Management On-Premise.
 
+## Breaking Changes
+
+> **Chart ≥ 0.2.20**: `jwtAuth.orgAdminUsernames` has been removed.
+> Admin status is now determined by the Keycloak **org-admin** realm role, which
+> is assigned automatically when `orgAdmin: true` is set on a user in
+> `jwtAuth.realmUsers`. If you previously set `orgAdminUsernames`, migrate those
+> usernames into `jwtAuth.realmUsers` entries with `orgAdmin: true` and re-run
+> `deploy-rhbk.sh -f <values.yaml>`.
+>
+> Similarly, `bootstrapAdmin.username`, `bootstrapAdmin.orgId`, and
+> `bootstrapAdmin.accountNumber` are now derived from the first `orgAdmin: true`
+> entry in `jwtAuth.realmUsers` — explicit values in `bootstrapAdmin` are no
+> longer required.
+
 ## Table of Contents
 
+- [Breaking Changes](#breaking-changes)
 - [Overview](#overview)
 - [Architecture](#architecture)
 - [Prerequisites](#prerequisites)

--- a/docs/operations/rbac-setup.md
+++ b/docs/operations/rbac-setup.md
@@ -23,7 +23,7 @@ Cost Management On-Premise uses [insights-rbac](https://github.com/RedHatInsight
 
 Key properties:
 - Authorization is **role-based**, not attribute-based
-- `is_org_admin` is **false by default** in the identity header — admin privileges come from RBAC roles only. Specific usernames can be granted `is_org_admin: true` via `jwtAuth.orgAdminUsernames` in `values.yaml`, which triggers the `admin_default` group mechanism (see [Identity Header](#identity-header))
+- `is_org_admin` defaults to **true for the `admin` user** via `jwtAuth.realmUsers` (where `orgAdmin: true`). This triggers the `admin_default` group mechanism, granting Cost Administrator permissions automatically. Additional users can be added to `realmUsers`, or `orgAdmin` can be set to `false` for the most restrictive posture where all access requires explicit RBAC group membership (see [Identity Header](#identity-header))
 - Permissions are scoped by `resourceDefinitions` (e.g., specific clusters, namespaces)
 - The system seeds 5 built-in roles covering common access patterns
 - RBAC is **always enabled** for both Koku and ROS — there is no toggle to disable it
@@ -162,7 +162,22 @@ The `x-rh-identity` header is constructed by the Envoy gateway and contains:
 }
 ```
 
-**Important**: `is_org_admin` is `false` by default. Specific usernames listed in `jwtAuth.orgAdminUsernames` (in `values.yaml`) receive `is_org_admin: true`, which triggers insights-rbac's `admin_default` group mechanism — granting Cost Administrator permissions automatically. When the list is empty (default), all admin access must come through explicit RBAC group membership. See the [PoC Analysis](https://gist.github.com/jordigilh/c81c73ba411637e24a30acd6a743e5fb) for security rationale.
+**Important**: `is_org_admin` is derived from the Keycloak **`org-admin` realm role**. The Envoy gateway reads `realm_access.roles` from the JWT and sets `is_org_admin: true` when the `org-admin` role is present. Keycloak is the single source of truth for admin status.
+
+For initial provisioning, `deploy-rhbk.sh -f values.yaml` reads `jwtAuth.realmUsers` and assigns the `org-admin` role to users with `orgAdmin: true`:
+
+```yaml
+jwtAuth:
+  realmUsers:
+    - username: admin
+      password: admin
+      orgAdmin: true      # assigned "org-admin" realm role → is_org_admin=true
+    - username: viewer
+      password: viewer
+      orgAdmin: false     # no org-admin role → standard user
+```
+
+After deployment, admin status can be managed directly in the Keycloak admin console by assigning or removing the `org-admin` realm role -- no `helm upgrade` required. See the [PoC Analysis](https://gist.github.com/jordigilh/c81c73ba411637e24a30acd6a743e5fb) for security rationale.
 
 ---
 

--- a/docs/operations/rbac-setup.md
+++ b/docs/operations/rbac-setup.md
@@ -60,7 +60,7 @@ sequenceDiagram
     U->>KC: Authenticate
     KC-->>U: JWT token
     U->>GW: API request + JWT
-    GW->>GW: Validate JWT, build x-rh-identity<br/>(is_org_admin = false)
+    GW->>GW: Validate JWT, build x-rh-identity<br/>(is_org_admin from JWT org-admin role)
     alt Cost Management request
         GW->>K: Forward request + x-rh-identity
         K->>R: GET /api/rbac/v1/access/<br/>?application=cost-management
@@ -81,7 +81,7 @@ sequenceDiagram
 ```
 
 1. User authenticates via Keycloak and obtains a JWT
-2. Envoy validates the JWT and constructs the `x-rh-identity` header (with `is_org_admin: false`)
+2. Envoy validates the JWT and constructs the `x-rh-identity` header (`is_org_admin` derived from the JWT `org-admin` realm role)
 3. The request is routed to either Koku or ROS, depending on the API path
 4. Both services call insights-rbac's `/api/rbac/v1/access/` endpoint with the forwarded identity
 5. insights-rbac resolves the user's groups → policies → roles → permissions
@@ -166,7 +166,7 @@ The `x-rh-identity` header is constructed by the Envoy gateway and contains:
     "user": {
       "username": "<from-jwt>",
       "email": "<from-jwt>",
-      "is_org_admin": false
+      "is_org_admin": true
     }
   },
   "entitlements": {
@@ -176,6 +176,8 @@ The `x-rh-identity` header is constructed by the Envoy gateway and contains:
   }
 }
 ```
+
+`is_org_admin` is `true` when the JWT contains the `org-admin` realm role, `false` otherwise.
 
 **Important**: `is_org_admin` is derived from the Keycloak **`org-admin` realm role**. The Envoy gateway reads `realm_access.roles` from the JWT and sets `is_org_admin: true` when the `org-admin` role is present. Keycloak is the single source of truth for admin status.
 
@@ -193,6 +195,31 @@ jwtAuth:
 ```
 
 After deployment, admin status can be managed directly in the Keycloak admin console by assigning or removing the `org-admin` realm role -- no `helm upgrade` required. See the [PoC Analysis](https://gist.github.com/jordigilh/c81c73ba411637e24a30acd6a743e5fb) for security rationale.
+
+### Production Hardening (FedRAMP)
+
+**Brute-force protection (AC-7)**: RHBK includes built-in brute-force detection that is **disabled by default** in development realms. Production and FedRAMP deployments **must** enable it:
+
+1. In the Keycloak admin console, navigate to **Realm Settings → Security Defenses → Brute Force Detection**.
+2. Enable **Permanent Lockout** or configure a lockout duration and failure threshold.
+3. Alternatively, configure via the `KeycloakRealmImport` CR:
+
+```yaml
+spec:
+  realm:
+    bruteForceProtected: true
+    permanentLockout: false
+    maxFailureWaitSeconds: 900
+    failureFactor: 5
+    waitIncrementSeconds: 60
+```
+
+**Password policy (IA-5)**: The default `realmUsers` in `values.yaml` use simple passwords for development convenience. Production deployments must:
+
+- Change all passwords in `jwtAuth.realmUsers` before deployment.
+- Configure a Keycloak password policy (Realm Settings → Authentication → Password Policy) that enforces organizational complexity requirements.
+
+**TLS (SC-8)**: The `deploy-rhbk.sh` script uses `curl -sk` (skip TLS verification) for test/dev environments. Production deployments must configure a trusted CA bundle and use `--cacert /path/to/ca-bundle.crt`.
 
 ---
 
@@ -514,7 +541,9 @@ echo "Both caches flushed — permission changes are now active"
 RBAC_POD=$(kubectl get pod -l app.kubernetes.io/component=rbac-api -n <namespace> -o jsonpath='{.items[0].metadata.name}')
 
 # Create identity header for the user
-IDENTITY=$(echo -n '{"org_id":"<org>","identity":{"org_id":"<org>","account_number":"<acct>","type":"User","user":{"username":"<user>","email":"<email>","is_org_admin":false}},"entitlements":{"cost_management":{"is_entitled":true}}}' | base64 | tr -d '\n')
+# Set IS_ORG_ADMIN to true for admin users (those with the org-admin Keycloak role), false otherwise
+IS_ORG_ADMIN=false
+IDENTITY=$(echo -n "{\"org_id\":\"<org>\",\"identity\":{\"org_id\":\"<org>\",\"account_number\":\"<acct>\",\"type\":\"User\",\"user\":{\"username\":\"<user>\",\"email\":\"<email>\",\"is_org_admin\":${IS_ORG_ADMIN}}},\"entitlements\":{\"cost_management\":{\"is_entitled\":true}}}" | base64 | tr -d '\n')
 
 # Query RBAC access endpoint
 kubectl exec -it $RBAC_POD -n <namespace> -- \

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -93,7 +93,6 @@ log_header() {
         echo ""
     }
     return 0
-    return 0
 }
 
 # Backward compatibility aliases
@@ -1358,14 +1357,16 @@ create_or_update_user() {
           firstName:$fn, lastName:$ln,
           attributes:{org_id:[$org], account_number:[$acct]}}')
 
-    local USER_HTTP_CODE=$(curl -sk -o /tmp/user_response.txt -w "%{http_code}" \
+    local tmp_response
+    tmp_response=$(mktemp "${TMPDIR:-/tmp}/rhbk-user-XXXXXX")
+    local USER_HTTP_CODE=$(curl -sk -o "$tmp_response" -w "%{http_code}" \
         -X POST "$keycloak_url/admin/realms/$REALM_NAME/users" \
         -H "Authorization: Bearer $access_token" \
         -H "Content-Type: application/json" \
         -d "$create_payload" 2>/dev/null)
 
-    local USER_RESPONSE=$(cat /tmp/user_response.txt 2>/dev/null || echo "")
-    rm -f /tmp/user_response.txt
+    local USER_RESPONSE=$(cat "$tmp_response" 2>/dev/null || echo "")
+    rm -f "$tmp_response"
 
     local USER_ID=""
     if [ "$USER_HTTP_CODE" = "409" ] || { echo "$USER_RESPONSE" | jq empty >/dev/null 2>&1 && echo "$USER_RESPONSE" | jq -e '.errorMessage // empty | test("already exists|Conflict"; "i")' >/dev/null 2>&1; }; then
@@ -1396,16 +1397,18 @@ create_or_update_user() {
         return 1
     fi
 
-    # Set password
-    curl -sk -X PUT "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID/reset-password" \
+    # Set password (check HTTP status, not just curl exit code)
+    local pw_http_code
+    pw_http_code=$(curl -sk -o /dev/null -w "%{http_code}" \
+        -X PUT "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID/reset-password" \
         -H "Authorization: Bearer $access_token" \
         -H "Content-Type: application/json" \
-        -d "$(jq -n --arg p "$password" '{type:"password",value:$p,temporary:false}')" 2>/dev/null
+        -d "$(jq -n --arg p "$password" '{type:"password",value:$p,temporary:false}')" 2>/dev/null)
 
-    if [ $? -eq 0 ]; then
+    if [ "$pw_http_code" = "204" ] || [ "$pw_http_code" = "200" ]; then
         echo_success "✓ Password set for user '$username'"
     else
-        echo_warning "Could not set password for user '$username'"
+        echo_warning "Could not set password for user '$username' (HTTP $pw_http_code)"
     fi
 
     # Manage org-admin realm role assignment based on orgAdmin flag.

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -45,6 +45,7 @@ COST_MGMT_UI_CLIENT_ID=${COST_MGMT_UI_CLIENT_ID:-cost-management-ui}
 COST_MGMT_NAMESPACE=${COST_MGMT_NAMESPACE:-cost-onprem}
 COST_MGMT_RELEASE_NAME=${COST_MGMT_RELEASE_NAME:-cost-onprem}
 KEYCLOAK_INSTANCES=${KEYCLOAK_INSTANCES:-1}
+VALUES_FILE=""  # Helm values file for reading jwtAuth.realmUsers
 
 # OpenShift cluster-specific configuration (auto-detected)
 CLUSTER_DOMAIN=""
@@ -792,11 +793,16 @@ spec:
               access.token.claim: "true"
               claim.name: email_verified
               jsonType.label: boolean
+    roles:
+      realm:
+        - name: org-admin
+          description: "Grants is_org_admin=true in the X-Rh-Identity header, triggering insights-rbac admin_default role assignment (Cost Administrator)."
     defaultDefaultClientScopes:
       - openid
       - api.console
       - profile
       - email
+      - roles
     clients:
       - clientId: $COST_MGMT_OPERATOR_CLIENT_ID
         name: "Cost Management Metrics Operator Service Account"
@@ -813,6 +819,7 @@ spec:
           - openid
           - email
           - api.console
+          - roles
         protocolMappers:
           - name: audience-mapper
             protocol: openid-connect
@@ -887,6 +894,7 @@ spec:
           - api.console
           - profile
           - email
+          - roles
         optionalClientScopes:
           - offline_access
         protocolMappers:
@@ -1284,14 +1292,140 @@ extract_client_secret() {
     echo ""
 }
 
-# Function to create test user with org_id and account_number attributes
-create_test_user() {
-    echo_header "CREATING ADMIN USER"
+# Read realm users from values file (jwtAuth.realmUsers) or return default JSON
+get_realm_users_json() {
+    if [ -n "$VALUES_FILE" ] && [ -f "$VALUES_FILE" ]; then
+        # Parse jwtAuth.realmUsers from the values file using python3
+        local users_json
+        users_json=$(python3 -c "
+import sys, json
+try:
+    import yaml
+except ImportError:
+    sys.exit(1)
+with open(sys.argv[1]) as f:
+    vals = yaml.safe_load(f)
+users = vals.get('jwtAuth', {}).get('realmUsers', [])
+json.dump(users, sys.stdout)
+" "$VALUES_FILE" 2>/dev/null)
 
-    # Get Keycloak URL from Route
+        if [ $? -eq 0 ] && [ -n "$users_json" ] && [ "$users_json" != "[]" ]; then
+            echo "$users_json"
+            return 0
+        fi
+        echo_warning "Could not parse realmUsers from $VALUES_FILE, using defaults"
+    fi
+
+    # Default: single admin user matching historical behavior
+    cat <<'DEFAULT_USERS'
+[{"username":"admin","password":"admin","email":"admin@test.com","firstName":"Admin","lastName":"User","orgId":"org1234567","accountNumber":"7890123","orgAdmin":true}]
+DEFAULT_USERS
+}
+
+# Create or update a single Keycloak realm user
+# Args: $1=keycloak_url $2=access_token $3=user_json (single user object)
+create_or_update_user() {
+    local keycloak_url="$1"
+    local access_token="$2"
+    local user_json="$3"
+
+    local username=$(echo "$user_json" | jq -r '.username')
+    local password=$(echo "$user_json" | jq -r '.password // "changeme"')
+    local email=$(echo "$user_json" | jq -r '.email // (.username + "@noreply.local")')
+    local first_name=$(echo "$user_json" | jq -r '.firstName // "User"')
+    local last_name=$(echo "$user_json" | jq -r '.lastName // ""')
+    local org_id=$(echo "$user_json" | jq -r '.orgId // "org1234567"')
+    local account_number=$(echo "$user_json" | jq -r '.accountNumber // "7890123"')
+
+    echo_info "Creating user '$username' (org_id=$org_id)..."
+
+    local create_payload=$(jq -n \
+        --arg u "$username" --arg e "$email" \
+        --arg fn "$first_name" --arg ln "$last_name" \
+        --arg org "$org_id" --arg acct "$account_number" \
+        '{username:$u, email:$e, emailVerified:true, enabled:true,
+          firstName:$fn, lastName:$ln,
+          attributes:{org_id:[$org], account_number:[$acct]}}')
+
+    local USER_HTTP_CODE=$(curl -sk -o /tmp/user_response.txt -w "%{http_code}" \
+        -X POST "$keycloak_url/admin/realms/$REALM_NAME/users" \
+        -H "Authorization: Bearer $access_token" \
+        -H "Content-Type: application/json" \
+        -d "$create_payload" 2>/dev/null)
+
+    local USER_RESPONSE=$(cat /tmp/user_response.txt 2>/dev/null || echo "")
+    rm -f /tmp/user_response.txt
+
+    local USER_ID=""
+    if [ "$USER_HTTP_CODE" = "409" ] || { echo "$USER_RESPONSE" | jq empty >/dev/null 2>&1 && echo "$USER_RESPONSE" | jq -e '.errorMessage // empty | test("already exists|Conflict"; "i")' >/dev/null 2>&1; }; then
+        echo_info "User '$username' already exists, updating..."
+        local USERS_RESPONSE=$(curl -sk -X GET "$keycloak_url/admin/realms/$REALM_NAME/users?username=$username&exact=true" \
+            -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" 2>/dev/null)
+        USER_ID=$(safe_jq '.[0].id // empty' "$USERS_RESPONSE")
+
+        if [ -n "$USER_ID" ]; then
+            curl -sk -X PUT "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID" \
+                -H "Authorization: Bearer $access_token" \
+                -H "Content-Type: application/json" \
+                -d "$create_payload" >/dev/null 2>&1
+            echo_success "✓ User '$username' updated"
+        fi
+    elif [ "$USER_HTTP_CODE" = "201" ] || [ "$USER_HTTP_CODE" = "200" ]; then
+        sleep 2
+        local USERS_RESPONSE=$(curl -sk -X GET "$keycloak_url/admin/realms/$REALM_NAME/users?username=$username&exact=true" \
+            -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" 2>/dev/null)
+        USER_ID=$(safe_jq '.[0].id // empty' "$USERS_RESPONSE")
+        echo_success "✓ User '$username' created"
+    fi
+
+    if [ -z "$USER_ID" ]; then
+        echo_warning "Could not determine user ID for '$username'"
+        return 1
+    fi
+
+    # Set password
+    curl -sk -X PUT "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID/reset-password" \
+        -H "Authorization: Bearer $access_token" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg p "$password" '{type:"password",value:$p,temporary:false}')" 2>/dev/null
+
+    if [ $? -eq 0 ]; then
+        echo_success "✓ Password set for user '$username'"
+    else
+        echo_warning "Could not set password for user '$username'"
+    fi
+
+    # Assign org-admin realm role if orgAdmin=true
+    local is_org_admin=$(echo "$user_json" | jq -r '.orgAdmin // false')
+    if [ "$is_org_admin" = "true" ]; then
+        # Look up the org-admin role ID
+        local role_json=$(curl -sk -X GET "$keycloak_url/admin/realms/$REALM_NAME/roles/org-admin" \
+            -H "Authorization: Bearer $access_token" 2>/dev/null)
+        local role_id=$(echo "$role_json" | jq -r '.id // empty')
+
+        if [ -n "$role_id" ]; then
+            curl -sk -X POST "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID/role-mappings/realm" \
+                -H "Authorization: Bearer $access_token" \
+                -H "Content-Type: application/json" \
+                -d "[$(echo "$role_json" | jq '{id:.id, name:.name}')]" 2>/dev/null
+            echo_success "✓ Assigned 'org-admin' realm role to '$username'"
+        else
+            echo_warning "Could not find 'org-admin' realm role — ensure realm import includes it"
+        fi
+    fi
+
+    return 0
+}
+
+# Create realm users from jwtAuth.realmUsers (values file) or defaults
+create_realm_users() {
+    echo_header "CREATING REALM USERS"
+
     local KEYCLOAK_URL=$(oc get route keycloak -n "$NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
     if [ -z "$KEYCLOAK_URL" ]; then
-        echo_warning "Could not determine Keycloak URL, skipping test user creation"
+        echo_warning "Could not determine Keycloak URL, skipping realm user creation"
         return 1
     fi
 
@@ -1305,7 +1439,6 @@ create_test_user() {
         return 1
     fi
 
-    # Get admin token
     echo_info "Obtaining admin access token..."
     local TOKEN_RESPONSE=$(curl -sk -X POST "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" \
         -H "Content-Type: application/x-www-form-urlencoded" \
@@ -1317,112 +1450,30 @@ create_test_user() {
     local ACCESS_TOKEN=$(safe_jq '.access_token // empty' "$TOKEN_RESPONSE")
 
     if [ -z "$ACCESS_TOKEN" ]; then
-        echo_warning "Could not obtain admin token, skipping test user creation"
+        echo_warning "Could not obtain admin token, skipping realm user creation"
         return 1
     fi
-
     echo_success "Admin token obtained"
 
-    # Create admin user with org_id and account_number attributes
-    # These values match the operator client's hardcoded values for testing.
-    # The admin user is granted Cost Administrator RBAC permissions by the
-    # _rbac_bootstrap fixture in tests/conftest.py.
-    #
-    # WORKAROUND: The org_id includes "org" prefix (org1234567 instead of 1234567)
-    # because the Koku image has a bug that prepends "org" to the org_id when
-    # creating tenant schemas. This results in schema names like "orgorg1234567"
-    # when the org_id is "org1234567". Once the Koku bug is fixed, change this
-    # back to a plain numeric org_id like "1234567".
-    # See: https://github.com/project-koku/koku/issues/XXXX (TODO: add issue link)
-    #
-    # REQUIRED ATTRIBUTES for Cost Management:
-    #   - org_id: Tenant identifier (maps to database schema)
-    #   - account_number: Customer account identifier
+    local USERS_JSON
+    USERS_JSON=$(get_realm_users_json)
+    local user_count=$(echo "$USERS_JSON" | jq 'length')
 
-    echo_info "Creating user 'admin' with org_id and account_number attributes..."
-    local USER_HTTP_CODE=$(curl -sk -o /tmp/user_response.txt -w "%{http_code}" -X POST "$KEYCLOAK_URL/admin/realms/$REALM_NAME/users" \
-        -H "Authorization: Bearer $ACCESS_TOKEN" \
-        -H "Content-Type: application/json" \
-        -d "{
-            \"username\": \"admin\",
-            \"email\": \"admin@test.com\",
-            \"emailVerified\": true,
-            \"enabled\": true,
-            \"firstName\": \"Admin\",
-            \"lastName\": \"User\",
-            \"attributes\": {
-                \"org_id\": [\"org1234567\"],
-                \"account_number\": [\"7890123\"]
-            }
-        }" 2>/dev/null)
-
-    local USER_RESPONSE=$(cat /tmp/user_response.txt 2>/dev/null || echo "")
-    rm -f /tmp/user_response.txt
-
-    local USER_ID=""
-    if [ "$USER_HTTP_CODE" = "409" ] || { echo "$USER_RESPONSE" | jq empty >/dev/null 2>&1 && echo "$USER_RESPONSE" | jq -e '.errorMessage // empty | test("already exists|Conflict"; "i")' >/dev/null 2>&1; }; then
-        echo_warning "User 'admin' may already exist, attempting to find it..."
-        # Get existing user
-        local USERS_RESPONSE=$(curl -sk -X GET "$KEYCLOAK_URL/admin/realms/$REALM_NAME/users?username=admin&exact=true" \
-            -H "Authorization: Bearer $ACCESS_TOKEN" \
-            -H "Content-Type: application/json" 2>/dev/null)
-        USER_ID=$(safe_jq '.[0].id // empty' "$USERS_RESPONSE")
-
-        if [ -n "$USER_ID" ]; then
-            echo_info "Found existing user 'admin', updating with attributes..."
-            # Update user with attributes
-            curl -sk -X PUT "$KEYCLOAK_URL/admin/realms/$REALM_NAME/users/$USER_ID" \
-                -H "Authorization: Bearer $ACCESS_TOKEN" \
-                -H "Content-Type: application/json" \
-                -d '{
-                    "username": "admin",
-                    "email": "admin@test.com",
-                    "emailVerified": true,
-                    "enabled": true,
-                    "firstName": "Admin",
-                    "lastName": "User",
-                    "attributes": {
-                        "org_id": ["org1234567"],
-                        "account_number": ["7890123"]
-                    }
-                }' >/dev/null 2>&1
-            echo_success "✓ User 'admin' updated"
-        fi
-    elif [ "$USER_HTTP_CODE" = "201" ] || [ "$USER_HTTP_CODE" = "200" ]; then
-        # User created successfully, get ID from users list
-        sleep 2
-        local USERS_RESPONSE=$(curl -sk -X GET "$KEYCLOAK_URL/admin/realms/$REALM_NAME/users?username=admin&exact=true" \
-            -H "Authorization: Bearer $ACCESS_TOKEN" \
-            -H "Content-Type: application/json" 2>/dev/null)
-        USER_ID=$(safe_jq '.[0].id // empty' "$USERS_RESPONSE")
-        echo_success "✓ User 'admin' created"
-    fi
-
-    if [ -z "$USER_ID" ]; then
-        echo_warning "Could not determine user ID for 'admin'"
-        return 1
-    fi
-
-    echo_info "User ID: $USER_ID"
-
-    # Set user password
-    echo_info "Setting password for user 'admin'..."
-    local PASSWORD_RESPONSE=$(curl -sk -X PUT "$KEYCLOAK_URL/admin/realms/$REALM_NAME/users/$USER_ID/reset-password" \
-        -H "Authorization: Bearer $ACCESS_TOKEN" \
-        -H "Content-Type: application/json" \
-        -d '{
-            "type": "password",
-            "value": "admin",
-            "temporary": false
-        }' 2>/dev/null)
-
-    if [ $? -eq 0 ]; then
-        echo_success "✓ Password set for user 'admin'"
+    echo_info "Provisioning $user_count realm user(s)..."
+    if [ -n "$VALUES_FILE" ]; then
+        echo_info "  Source: $VALUES_FILE (jwtAuth.realmUsers)"
     else
-        echo_warning "Could not set password for user 'admin' (may already be set)"
+        echo_info "  Source: built-in defaults (use -f <values.yaml> to customize)"
     fi
 
-    echo_success "✓ Admin user creation complete"
+    local i=0
+    while [ $i -lt "$user_count" ]; do
+        local user_obj=$(echo "$USERS_JSON" | jq ".[$i]")
+        create_or_update_user "$KEYCLOAK_URL" "$ACCESS_TOKEN" "$user_obj"
+        i=$((i + 1))
+    done
+
+    echo_success "✓ Realm user provisioning complete"
     echo ""
 }
 
@@ -1573,7 +1624,7 @@ main() {
     create_kubernetes_realm
     configure_admin_console
     extract_client_secret
-    create_test_user
+    create_realm_users
 
     # Validate and summarize
     if validate_deployment; then
@@ -1583,6 +1634,23 @@ main() {
         exit 1
     fi
 }
+
+# Parse flags (extract -f/--values before command dispatch)
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -f|--values)
+            VALUES_FILE="$2"
+            if [ -z "$VALUES_FILE" ] || [ ! -f "$VALUES_FILE" ]; then
+                echo_error "Values file not found: ${VALUES_FILE:-<empty>}"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 # Handle script arguments
 case "${1:-}" in
@@ -1595,13 +1663,19 @@ case "${1:-}" in
         exit $?
         ;;
     "help"|"-h"|"--help")
-        echo "Usage: $0 [command]"
+        echo "Usage: $0 [-f <values.yaml>] [command]"
         echo ""
         echo "Commands:"
         echo "  (no command)    Deploy RHBK with all components"
         echo "  validate        Validate existing deployment"
         echo "  cleanup         Remove all RHBK resources"
         echo "  help            Show this help message"
+        echo ""
+        echo "Options:"
+        echo "  -f, --values <file>   Helm values file to read jwtAuth.realmUsers from."
+        echo "                        Users listed under jwtAuth.realmUsers will be created"
+        echo "                        in the Keycloak realm. Without this flag, a default"
+        echo "                        admin/admin user is created."
         echo ""
         echo "Environment Variables:"
         echo "  RHBK_NAMESPACE            Target namespace (default: keycloak)"
@@ -1618,28 +1692,20 @@ case "${1:-}" in
         echo "      Access them via: oc get secret keycloak-initial-admin -n keycloak"
         echo ""
         echo "Examples:"
-        echo "  # Deploy with default settings"
+        echo "  # Deploy with default admin/admin user"
         echo "  $0"
+        echo ""
+        echo "  # Deploy with users from values.yaml"
+        echo "  $0 -f cost-onprem/values.yaml"
         echo ""
         echo "  # Deploy with custom storage class"
         echo "  STORAGE_CLASS=gp2 $0"
-        echo ""
-        echo "  # Deploy with HA configuration"
-        echo "  KEYCLOAK_INSTANCES=2 $0"
         echo ""
         echo "  # Validate existing deployment"
         echo "  $0 validate"
         echo ""
         echo "  # Clean up deployment"
         echo "  $0 cleanup"
-        echo ""
-        echo "RHBK Operator Details:"
-        echo "  This script uses the RHBK operator (k8s.keycloak.org/v2alpha1)"
-        echo ""
-        echo "  Key features:"
-        echo "  - Uses KeycloakRealmImport instead of KeycloakRealm"
-        echo "  - Clients are defined within the realm import"
-        echo "  - Different CR structure for Keycloak instances"
         exit 0
         ;;
     "")

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -822,8 +822,14 @@ spec:
               userinfo.token.claim: "true"
               id.token.claim: "true"
               access.token.claim: "true"
-              claim.name: resource_access.${client_id}.roles
+              claim.name: "resource_access.\${client_id}.roles"
               jsonType.label: String
+          - name: audience resolve
+            protocol: openid-connect
+            protocolMapper: oidc-audience-resolve-mapper
+            config:
+              introspection.token.claim: "true"
+              access.token.claim: "true"
     roles:
       realm:
         - name: org-admin
@@ -854,7 +860,6 @@ spec:
           - roles
         optionalClientScopes:
           - offline_access
-          - roles
         protocolMappers:
           - name: audience-mapper
             protocol: openid-connect
@@ -933,7 +938,6 @@ spec:
           - roles
         optionalClientScopes:
           - offline_access
-          - roles
         protocolMappers:
           - name: aud-mapper-cost-management-ui
             protocol: openid-connect

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -1448,6 +1448,18 @@ create_or_update_user() {
     return 0
 }
 
+# Acquire a short-lived Keycloak admin token via password grant.
+# Args: $1=keycloak_url $2=admin_username $3=admin_password
+_obtain_admin_token() {
+    local url="$1" user="$2" pass="$3"
+    curl -sk -X POST "${url}/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "username=${user}" \
+        -d "password=${pass}" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" 2>/dev/null | jq -r '.access_token // empty'
+}
+
 # Create realm users from jwtAuth.realmUsers (values file) or defaults
 create_realm_users() {
     echo_header "CREATING REALM USERS"
@@ -1468,20 +1480,9 @@ create_realm_users() {
         return 1
     fi
 
-    # Acquire a short-lived admin token. Keycloak master-realm tokens default
-    # to 60s, so we re-acquire before each user to avoid mid-loop expiry.
-    _obtain_admin_token() {
-        curl -sk -X POST "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "username=$ADMIN_USERNAME" \
-            -d "password=$ADMIN_PASSWORD" \
-            -d "grant_type=password" \
-            -d "client_id=admin-cli" 2>/dev/null | jq -r '.access_token // empty'
-    }
-
     echo_info "Obtaining admin access token..."
     local ACCESS_TOKEN
-    ACCESS_TOKEN=$(_obtain_admin_token)
+    ACCESS_TOKEN=$(_obtain_admin_token "$KEYCLOAK_URL" "$ADMIN_USERNAME" "$ADMIN_PASSWORD")
 
     if [ -z "$ACCESS_TOKEN" ]; then
         echo_warning "Could not obtain admin token, skipping realm user creation"
@@ -1507,7 +1508,7 @@ create_realm_users() {
     local fail_count=0
     while [ $i -lt "$user_count" ]; do
         # Re-acquire token before each user to guard against TTL expiry
-        ACCESS_TOKEN=$(_obtain_admin_token)
+        ACCESS_TOKEN=$(_obtain_admin_token "$KEYCLOAK_URL" "$ADMIN_USERNAME" "$ADMIN_PASSWORD")
         if [ -z "$ACCESS_TOKEN" ]; then
             echo_error "Admin token expired and could not be renewed"
             return 1
@@ -1572,24 +1573,29 @@ display_summary() {
     echo_info "  Secret stored in: keycloak-client-secret-cost-management-ui"
     echo ""
 
-    echo_info "Admin User Information:"
-    echo_info "  User: admin"
-    echo_info "    Password: admin"
-    echo_info "    Email: admin@test.com (verified)"
-    echo_info "    Attributes:"
-    echo_info "      org_id: org1234567 (includes 'org' prefix as workaround for Koku bug)"
-    echo_info "      account_number: 7890123"
+    echo_info "Provisioned Realm Users:"
+    local USERS_JSON
+    USERS_JSON=$(get_realm_users_json 2>/dev/null) || USERS_JSON='[]'
+    local u_count
+    u_count=$(echo "$USERS_JSON" | jq 'length')
+    local u=0
+    while [ $u -lt "$u_count" ]; do
+        local u_name u_org u_acct u_admin
+        u_name=$(echo "$USERS_JSON" | jq -r ".[$u].username")
+        u_org=$(echo "$USERS_JSON" | jq -r ".[$u].orgId // \"org1234567\"")
+        u_acct=$(echo "$USERS_JSON" | jq -r ".[$u].accountNumber // \"7890123\"")
+        u_admin=$(echo "$USERS_JSON" | jq -r ".[$u].orgAdmin // false")
+        local role_info=""
+        [ "$u_admin" = "true" ] && role_info=" (org-admin)"
+        echo_info "  ${u_name}${role_info}  org_id=${u_org}  account_number=${u_acct}"
+        u=$((u + 1))
+    done
     echo_info ""
     echo_info "  RBAC Permissions:"
-    echo_info "    To grant this user Cost Administrator automatically on helm install/upgrade,"
-    echo_info "    set the following in your values.yaml or --set flags:"
-    echo_info ""
+    echo_info "    To grant the admin user Cost Administrator on helm install/upgrade:"
     echo_info "      rbac.bootstrapAdmin.enabled=true"
     echo_info ""
-    echo_info "    The defaults (username=admin, orgId=org1234567, accountNumber=7890123)"
-    echo_info "    match this user. See docs/operations/rbac-setup.md for details."
-    echo_info ""
-    echo_info "    Alternatively, run after chart install:"
+    echo_info "    Or run after chart install:"
     echo_info "      NAMESPACE=${COST_MGMT_NAMESPACE} ./scripts/sync-rbac-admin.sh"
     echo ""
 
@@ -1685,7 +1691,8 @@ main() {
     fi
 }
 
-# Parse flags (extract -f/--values before command dispatch)
+# Parse all flags and collect the command in a single pass
+COMMAND=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -f|--values)
@@ -1696,14 +1703,20 @@ while [[ $# -gt 0 ]]; do
             fi
             shift 2
             ;;
+        -*)
+            echo_error "Unknown flag: $1"
+            echo_info "Use '$0 help' for usage information"
+            exit 1
+            ;;
         *)
-            break
+            COMMAND="$1"
+            shift
             ;;
     esac
 done
 
 # Handle script arguments
-case "${1:-}" in
+case "${COMMAND}" in
     "cleanup"|"clean")
         cleanup_deployment
         exit 0

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -1314,7 +1314,7 @@ with open(sys.argv[1]) as f:
     vals = yaml.safe_load(f)
 users = vals.get('jwtAuth', {}).get('realmUsers', [])
 json.dump(users, sys.stdout)
-" "$VALUES_FILE" 2>/dev/null)
+" "$VALUES_FILE")
 
         local parse_rc=$?
         if [ $parse_rc -ne 0 ]; then
@@ -1504,6 +1504,7 @@ create_realm_users() {
     fi
 
     local i=0
+    local fail_count=0
     while [ $i -lt "$user_count" ]; do
         # Re-acquire token before each user to guard against TTL expiry
         ACCESS_TOKEN=$(_obtain_admin_token)
@@ -1512,11 +1513,17 @@ create_realm_users() {
             return 1
         fi
         local user_obj=$(echo "$USERS_JSON" | jq ".[$i]")
-        create_or_update_user "$KEYCLOAK_URL" "$ACCESS_TOKEN" "$user_obj"
+        if ! create_or_update_user "$KEYCLOAK_URL" "$ACCESS_TOKEN" "$user_obj"; then
+            fail_count=$((fail_count + 1))
+        fi
         i=$((i + 1))
     done
 
-    echo_success "✓ Realm user provisioning complete"
+    if [ "$fail_count" -gt 0 ]; then
+        echo_error "$fail_count of $user_count user(s) failed to provision"
+        return 1
+    fi
+    echo_success "✓ All $user_count realm user(s) provisioned successfully"
     echo ""
 }
 

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -818,6 +818,7 @@ spec:
         directAccessGrantsEnabled: false
         implicitFlowEnabled: false
         publicClient: false
+        fullScopeAllowed: true
         protocol: openid-connect
         defaultClientScopes:
           - openid
@@ -888,6 +889,7 @@ spec:
         directAccessGrantsEnabled: true
         implicitFlowEnabled: false
         publicClient: false
+        fullScopeAllowed: true
         protocol: openid-connect
         redirectUris:
           - "${UI_BASE_URL}/oauth2/callback"

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -797,6 +797,33 @@ spec:
               access.token.claim: "true"
               claim.name: email_verified
               jsonType.label: boolean
+      - name: roles
+        description: "OpenID Connect scope that adds realm and client role mappings to the token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "false"
+        protocolMappers:
+          - name: realm roles
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-realm-role-mapper
+            config:
+              multivalued: "true"
+              userinfo.token.claim: "true"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: realm_access.roles
+              jsonType.label: String
+          - name: client roles
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-client-role-mapper
+            config:
+              multivalued: "true"
+              userinfo.token.claim: "true"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: resource_access.${client_id}.roles
+              jsonType.label: String
     roles:
       realm:
         - name: org-admin

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -825,6 +825,9 @@ spec:
           - email
           - api.console
           - roles
+        optionalClientScopes:
+          - offline_access
+          - roles
         protocolMappers:
           - name: audience-mapper
             protocol: openid-connect
@@ -903,6 +906,7 @@ spec:
           - roles
         optionalClientScopes:
           - offline_access
+          - roles
         protocolMappers:
           - name: aud-mapper-cost-management-ui
             protocol: openid-connect

--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -10,6 +10,11 @@
 #   LOG_LEVEL - Control output verbosity (ERROR|WARN|INFO|DEBUG, default: WARN)
 #   RHBK_NAMESPACE - Target namespace for operator, Keycloak, and DB (default: keycloak)
 #
+# TLS Note: This script uses curl -sk (skip TLS verification) because test/dev
+# environments typically use self-signed certificates. For FedRAMP or production
+# environments requiring SC-8 compliance, configure a trusted CA bundle and
+# replace -sk with --cacert /path/to/ca-bundle.crt.
+#
 # Keycloak database image (embedded in deploy_postgresql):
 #   registry.redhat.io/rhel10/postgresql-16:10.1
 #
@@ -1302,6 +1307,7 @@ import sys, json
 try:
     import yaml
 except ImportError:
+    print('ERROR: PyYAML is required to parse values files. Install with: pip3 install pyyaml', file=sys.stderr)
     sys.exit(1)
 with open(sys.argv[1]) as f:
     vals = yaml.safe_load(f)
@@ -1309,11 +1315,16 @@ users = vals.get('jwtAuth', {}).get('realmUsers', [])
 json.dump(users, sys.stdout)
 " "$VALUES_FILE" 2>/dev/null)
 
-        if [ $? -eq 0 ] && [ -n "$users_json" ] && [ "$users_json" != "[]" ]; then
+        local parse_rc=$?
+        if [ $parse_rc -ne 0 ]; then
+            echo_error "Failed to parse $VALUES_FILE (exit code $parse_rc). Ensure python3 and PyYAML are installed."
+            return 1
+        fi
+        if [ -n "$users_json" ] && [ "$users_json" != "[]" ]; then
             echo "$users_json"
             return 0
         fi
-        echo_warning "Could not parse realmUsers from $VALUES_FILE, using defaults"
+        echo_warning "No realmUsers found in $VALUES_FILE, using defaults"
     fi
 
     # Default: single admin user matching historical behavior
@@ -1397,23 +1408,36 @@ create_or_update_user() {
         echo_warning "Could not set password for user '$username'"
     fi
 
-    # Assign org-admin realm role if orgAdmin=true
+    # Manage org-admin realm role assignment based on orgAdmin flag.
+    # This ensures the declared state in realmUsers is enforced on every run.
     local is_org_admin=$(echo "$user_json" | jq -r '.orgAdmin // false')
-    if [ "$is_org_admin" = "true" ]; then
-        # Look up the org-admin role ID
-        local role_json=$(curl -sk -X GET "$keycloak_url/admin/realms/$REALM_NAME/roles/org-admin" \
-            -H "Authorization: Bearer $access_token" 2>/dev/null)
-        local role_id=$(echo "$role_json" | jq -r '.id // empty')
+    local role_json=$(curl -sk -X GET "$keycloak_url/admin/realms/$REALM_NAME/roles/org-admin" \
+        -H "Authorization: Bearer $access_token" 2>/dev/null)
+    local role_id=$(echo "$role_json" | jq -r '.id // empty')
 
-        if [ -n "$role_id" ]; then
-            curl -sk -X POST "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID/role-mappings/realm" \
-                -H "Authorization: Bearer $access_token" \
-                -H "Content-Type: application/json" \
-                -d "[$(echo "$role_json" | jq '{id:.id, name:.name}')]" 2>/dev/null
-            echo_success "✓ Assigned 'org-admin' realm role to '$username'"
-        else
-            echo_warning "Could not find 'org-admin' realm role — ensure realm import includes it"
-        fi
+    if [ -z "$role_id" ]; then
+        echo_warning "Could not find 'org-admin' realm role — ensure realm import includes it"
+        return 0
+    fi
+
+    local role_payload="[$(echo "$role_json" | jq '{id:.id, name:.name}')]"
+    local audit_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    if [ "$is_org_admin" = "true" ]; then
+        curl -sk -X POST "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID/role-mappings/realm" \
+            -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" \
+            -d "$role_payload" 2>/dev/null
+        echo_success "✓ Assigned 'org-admin' realm role to '$username'"
+        echo "[AUDIT] $audit_ts action=assign_role user=$username role=org-admin realm=$REALM_NAME actor=deploy-rhbk.sh"
+    else
+        # Remove org-admin role if previously assigned (Day 2: orgAdmin changed to false)
+        curl -sk -X DELETE "$keycloak_url/admin/realms/$REALM_NAME/users/$USER_ID/role-mappings/realm" \
+            -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" \
+            -d "$role_payload" 2>/dev/null
+        echo_info "Ensured '$username' does not have 'org-admin' realm role"
+        echo "[AUDIT] $audit_ts action=remove_role user=$username role=org-admin realm=$REALM_NAME actor=deploy-rhbk.sh"
     fi
 
     return 0
@@ -1439,15 +1463,20 @@ create_realm_users() {
         return 1
     fi
 
-    echo_info "Obtaining admin access token..."
-    local TOKEN_RESPONSE=$(curl -sk -X POST "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" \
-        -H "Content-Type: application/x-www-form-urlencoded" \
-        -d "username=$ADMIN_USERNAME" \
-        -d "password=$ADMIN_PASSWORD" \
-        -d "grant_type=password" \
-        -d "client_id=admin-cli" 2>/dev/null)
+    # Acquire a short-lived admin token. Keycloak master-realm tokens default
+    # to 60s, so we re-acquire before each user to avoid mid-loop expiry.
+    _obtain_admin_token() {
+        curl -sk -X POST "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "username=$ADMIN_USERNAME" \
+            -d "password=$ADMIN_PASSWORD" \
+            -d "grant_type=password" \
+            -d "client_id=admin-cli" 2>/dev/null | jq -r '.access_token // empty'
+    }
 
-    local ACCESS_TOKEN=$(safe_jq '.access_token // empty' "$TOKEN_RESPONSE")
+    echo_info "Obtaining admin access token..."
+    local ACCESS_TOKEN
+    ACCESS_TOKEN=$(_obtain_admin_token)
 
     if [ -z "$ACCESS_TOKEN" ]; then
         echo_warning "Could not obtain admin token, skipping realm user creation"
@@ -1457,6 +1486,9 @@ create_realm_users() {
 
     local USERS_JSON
     USERS_JSON=$(get_realm_users_json)
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
     local user_count=$(echo "$USERS_JSON" | jq 'length')
 
     echo_info "Provisioning $user_count realm user(s)..."
@@ -1468,6 +1500,12 @@ create_realm_users() {
 
     local i=0
     while [ $i -lt "$user_count" ]; do
+        # Re-acquire token before each user to guard against TTL expiry
+        ACCESS_TOKEN=$(_obtain_admin_token)
+        if [ -z "$ACCESS_TOKEN" ]; then
+            echo_error "Admin token expired and could not be renewed"
+            return 1
+        fi
         local user_obj=$(echo "$USERS_JSON" | jq ".[$i]")
         create_or_update_user "$KEYCLOAK_URL" "$ACCESS_TOKEN" "$user_obj"
         i=$((i + 1))

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -433,7 +433,14 @@ deploy_rhbk() {
         export VERBOSE="true"
     fi
 
-    if ! execute_script "${SCRIPT_DEPLOY_RHBK}"; then
+    local rhbk_args=()
+    local chart_values="${PROJECT_ROOT}/cost-onprem/values.yaml"
+    if [[ -f "${chart_values}" ]]; then
+        rhbk_args+=(-f "${chart_values}")
+        log_info "Provisioning Keycloak users from: ${chart_values}"
+    fi
+
+    if ! execute_script "${SCRIPT_DEPLOY_RHBK}" "${rhbk_args[@]}"; then
         log_error "Red Hat Build of Keycloak (RHBK) deployment failed"
         exit 1
     fi

--- a/scripts/run-iqe-tests-local.sh
+++ b/scripts/run-iqe-tests-local.sh
@@ -483,7 +483,16 @@ extract_cluster_config() {
             kc_token=$(curl -sk -X POST "https://${kc_host}/realms/master/protocol/openid-connect/token" \
                 -d "client_id=admin-cli&grant_type=password&username=${kc_admin_user}&password=${kc_admin_pass}" 2>/dev/null | jq -r '.access_token // empty')
             if [ -n "$kc_token" ]; then
-                kc_user_json=$(curl -sk "https://${kc_host}/admin/realms/kubernetes/users?username=admin&exact=true" \
+                # Find the first user with the org-admin realm role
+                local admin_username="admin"
+                local role_members
+                role_members=$(curl -sk "https://${kc_host}/admin/realms/kubernetes/roles/org-admin/users" \
+                    -H "Authorization: Bearer ${kc_token}" 2>/dev/null)
+                local detected_admin
+                detected_admin=$(echo "$role_members" | jq -r '.[0].username // empty')
+                [ -n "$detected_admin" ] && admin_username="$detected_admin"
+
+                kc_user_json=$(curl -sk "https://${kc_host}/admin/realms/kubernetes/users?username=${admin_username}&exact=true" \
                     -H "Authorization: Bearer ${kc_token}" 2>/dev/null)
                 local detected_org detected_acct
                 detected_org=$(echo "$kc_user_json" | jq -r '.[0].attributes.org_id[0] // empty')

--- a/scripts/run-iqe-tests-local.sh
+++ b/scripts/run-iqe-tests-local.sh
@@ -470,8 +470,31 @@ extract_cluster_config() {
     export DYNACONF_users__cost_onprem_user__auth__jwt_grant_type="client_credentials"
     export DYNACONF_users__cost_onprem_user__auth__client_id="$DYNACONF_ONPREM_CLIENT_ID"
     export DYNACONF_users__cost_onprem_user__auth__client_secret="$DYNACONF_ONPREM_CLIENT_SECRET"
-    export DYNACONF_users__cost_onprem_user__identity__account_number="7890123"
-    export DYNACONF_users__cost_onprem_user__identity__org_id="org1234567"
+    # Read org_id and account_number from Keycloak (canonical source: jwtAuth.realmUsers)
+    local iqe_org_id="org1234567"
+    local iqe_acct="7890123"
+    local kc_host
+    kc_host=$(kubectl get route keycloak -n "$KEYCLOAK_NS" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+    if [ -n "$kc_host" ]; then
+        local kc_admin_user kc_admin_pass kc_token kc_user_json
+        kc_admin_user=$(kubectl get secret keycloak-initial-admin -n "$KEYCLOAK_NS" -o jsonpath='{.data.username}' 2>/dev/null | base64 -d || echo "admin")
+        kc_admin_pass=$(kubectl get secret keycloak-initial-admin -n "$KEYCLOAK_NS" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo "")
+        if [ -n "$kc_admin_pass" ]; then
+            kc_token=$(curl -sk -X POST "https://${kc_host}/realms/master/protocol/openid-connect/token" \
+                -d "client_id=admin-cli&grant_type=password&username=${kc_admin_user}&password=${kc_admin_pass}" 2>/dev/null | jq -r '.access_token // empty')
+            if [ -n "$kc_token" ]; then
+                kc_user_json=$(curl -sk "https://${kc_host}/admin/realms/kubernetes/users?username=admin&exact=true" \
+                    -H "Authorization: Bearer ${kc_token}" 2>/dev/null)
+                local detected_org detected_acct
+                detected_org=$(echo "$kc_user_json" | jq -r '.[0].attributes.org_id[0] // empty')
+                detected_acct=$(echo "$kc_user_json" | jq -r '.[0].attributes.account_number[0] // empty')
+                [ -n "$detected_org" ] && iqe_org_id="$detected_org"
+                [ -n "$detected_acct" ] && iqe_acct="$detected_acct"
+            fi
+        fi
+    fi
+    export DYNACONF_users__cost_onprem_user__identity__account_number="$iqe_acct"
+    export DYNACONF_users__cost_onprem_user__identity__org_id="$iqe_org_id"
     
     if [ "$DRY_RUN" = true ]; then
         log "[DRY RUN] Cluster configuration:"

--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -326,11 +326,9 @@ if [ -n "$KEYCLOAK_HOST" ]; then
         
         if [ -n "$ADMIN_TOKEN" ]; then
             # Find the first user with the org-admin realm role
-            local admin_username="admin"
-            local role_members
+            admin_username="admin"
             role_members=$(curl -sk "https://${KEYCLOAK_HOST}/admin/realms/kubernetes/roles/org-admin/users" \
                 -H "Authorization: Bearer ${ADMIN_TOKEN}" 2>/dev/null)
-            local detected_admin
             detected_admin=$(echo "$role_members" | jq -r '.[0].username // empty')
             [ -n "$detected_admin" ] && admin_username="$detected_admin"
 

--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -325,7 +325,16 @@ if [ -n "$KEYCLOAK_HOST" ]; then
             -d "password=${KEYCLOAK_ADMIN_PASS}" 2>/dev/null | jq -r '.access_token // empty')
         
         if [ -n "$ADMIN_TOKEN" ]; then
-            USER_JSON=$(curl -sk "https://${KEYCLOAK_HOST}/admin/realms/kubernetes/users?username=admin&exact=true" \
+            # Find the first user with the org-admin realm role
+            local admin_username="admin"
+            local role_members
+            role_members=$(curl -sk "https://${KEYCLOAK_HOST}/admin/realms/kubernetes/roles/org-admin/users" \
+                -H "Authorization: Bearer ${ADMIN_TOKEN}" 2>/dev/null)
+            local detected_admin
+            detected_admin=$(echo "$role_members" | jq -r '.[0].username // empty')
+            [ -n "$detected_admin" ] && admin_username="$detected_admin"
+
+            USER_JSON=$(curl -sk "https://${KEYCLOAK_HOST}/admin/realms/kubernetes/users?username=${admin_username}&exact=true" \
                 -H "Authorization: Bearer ${ADMIN_TOKEN}" 2>/dev/null)
             USER_ORG_ID=$(echo "$USER_JSON" | jq -r '.[0].attributes.org_id[0] // empty')
             USER_ACCT=$(echo "$USER_JSON" | jq -r '.[0].attributes.account_number[0] // empty')

--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -308,15 +308,16 @@ KEYCLOAK_CLIENT_SECRET=$(kubectl get secret "$KEYCLOAK_SECRET_NAME" -n "$KEYCLOA
 KEYCLOAK_HOST=$(kubectl get route keycloak -n keycloak -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 OAUTH_URL="https://${KEYCLOAK_HOST}/realms/kubernetes/protocol/openid-connect"
 
-# Get org_id from Keycloak admin user (or use default)
-ORG_ID="org1234567"  # Default value
+# Get org_id and account_number from Keycloak admin user.
+# Canonical source of truth: jwtAuth.realmUsers in values.yaml — these values
+# are provisioned into Keycloak by deploy-rhbk.sh and read back here dynamically.
+ORG_ID="org1234567"
+ACCOUNT_NUMBER="7890123"
 if [ -n "$KEYCLOAK_HOST" ]; then
-    # Get admin credentials
     KEYCLOAK_ADMIN_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d || echo "")
     KEYCLOAK_ADMIN_USER="${KEYCLOAK_ADMIN_USER:-admin}"
     KEYCLOAK_ADMIN_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo "")
     if [ -n "$KEYCLOAK_ADMIN_PASS" ]; then
-        # Get admin token
         ADMIN_TOKEN=$(curl -sk -X POST "https://${KEYCLOAK_HOST}/realms/master/protocol/openid-connect/token" \
             -d "client_id=admin-cli" \
             -d "grant_type=password" \
@@ -324,12 +325,12 @@ if [ -n "$KEYCLOAK_HOST" ]; then
             -d "password=${KEYCLOAK_ADMIN_PASS}" 2>/dev/null | jq -r '.access_token // empty')
         
         if [ -n "$ADMIN_TOKEN" ]; then
-            # Query the "admin" user created by deploy-rhbk.sh (not "test")
-            USER_ORG_ID=$(curl -sk "https://${KEYCLOAK_HOST}/admin/realms/kubernetes/users?username=admin&exact=true" \
-                -H "Authorization: Bearer ${ADMIN_TOKEN}" 2>/dev/null | jq -r '.[0].attributes.org_id[0] // empty')
-            if [ -n "$USER_ORG_ID" ]; then
-                ORG_ID="$USER_ORG_ID"
-            fi
+            USER_JSON=$(curl -sk "https://${KEYCLOAK_HOST}/admin/realms/kubernetes/users?username=admin&exact=true" \
+                -H "Authorization: Bearer ${ADMIN_TOKEN}" 2>/dev/null)
+            USER_ORG_ID=$(echo "$USER_JSON" | jq -r '.[0].attributes.org_id[0] // empty')
+            USER_ACCT=$(echo "$USER_JSON" | jq -r '.[0].attributes.account_number[0] // empty')
+            [ -n "$USER_ORG_ID" ] && ORG_ID="$USER_ORG_ID"
+            [ -n "$USER_ACCT" ] && ACCOUNT_NUMBER="$USER_ACCT"
         fi
     fi
 fi
@@ -811,7 +812,7 @@ spec:
           key: CLIENT_SECRET
           optional: true
     - name: DYNACONF_users__cost_onprem_user__identity__account_number
-      value: "7890123"
+      value: "${ACCOUNT_NUMBER}"
     - name: DYNACONF_users__cost_onprem_user__identity__org_id
       value: "${ORG_ID}"
     

--- a/scripts/sync-rbac-admin.sh
+++ b/scripts/sync-rbac-admin.sh
@@ -89,14 +89,16 @@ echo "RBAC pod: ${RBAC_POD}"
 
 echo "Creating Tenant, Principal, Group, and Policy..."
 kubectl exec -n "${NAMESPACE}" "${RBAC_POD}" -- \
+  env SYNC_USERNAME="${USERNAME}" SYNC_ORG_ID="${ORG_ID}" SYNC_ACCOUNT_NUMBER="${ACCOUNT_NUMBER}" \
   python /opt/rbac/rbac/manage.py shell -c "
+import os
 from api.models import Tenant
 from management.models import Group, Policy, Role, Principal
 from django.core.cache import cache
 
-username = \"${USERNAME}\"
-org_id = \"${ORG_ID}\"
-acct_number = \"${ACCOUNT_NUMBER}\"
+username = os.environ['SYNC_USERNAME']
+org_id = os.environ['SYNC_ORG_ID']
+acct_number = os.environ['SYNC_ACCOUNT_NUMBER']
 
 public_tenant = Tenant.objects.get(tenant_name='public')
 admin_default_roles = Role.objects.filter(admin_default=True, tenant=public_tenant)

--- a/scripts/sync-rbac-admin.sh
+++ b/scripts/sync-rbac-admin.sh
@@ -57,12 +57,16 @@ admin = next((u for u in users if u.get('orgAdmin')), None)
 if admin:
     json.dump(admin, sys.stdout)
 else:
+    print('ERROR: no orgAdmin:true entry found in jwtAuth.realmUsers', file=sys.stderr)
     sys.exit(1)
-" "$VALUES_FILE" 2>/dev/null) && {
-    USERNAME="${USERNAME:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('username','admin'))")}"
-    ORG_ID="${ORG_ID:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('orgId','org1234567'))")}"
-    ACCOUNT_NUMBER="${ACCOUNT_NUMBER:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('accountNumber','7890123'))")}"
-  } || echo "WARNING: Could not parse admin from $VALUES_FILE, using defaults"
+" "$VALUES_FILE")
+  if [ $? -ne 0 ] || [ -z "$admin_json" ]; then
+    echo "ERROR: Failed to parse admin identity from $VALUES_FILE"
+    exit 1
+  fi
+  USERNAME="${USERNAME:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('username','admin'))")}"
+  ORG_ID="${ORG_ID:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('orgId','org1234567'))")}"
+  ACCOUNT_NUMBER="${ACCOUNT_NUMBER:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('accountNumber','7890123'))")}"
 elif [ -n "$VALUES_FILE" ]; then
   echo "ERROR: Values file not found: $VALUES_FILE"
   exit 1

--- a/scripts/sync-rbac-admin.sh
+++ b/scripts/sync-rbac-admin.sh
@@ -16,25 +16,61 @@
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-cost-onprem}"
-USERNAME="admin"
-ORG_ID="org1234567"
-ACCOUNT_NUMBER="7890123"
+VALUES_FILE=""
+USERNAME=""
+ORG_ID=""
+ACCOUNT_NUMBER=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
+    -f|--values) VALUES_FILE="$2"; shift 2 ;;
     --username) USERNAME="$2"; shift 2 ;;
     --org-id) ORG_ID="$2"; shift 2 ;;
     --account-number) ACCOUNT_NUMBER="$2"; shift 2 ;;
     --namespace) NAMESPACE="$2"; shift 2 ;;
     -h|--help)
-      echo "Usage: $0 [--username USER] [--org-id ORG] [--account-number ACCT] [--namespace NS]"
+      echo "Usage: $0 [-f <values.yaml>] [--username USER] [--org-id ORG] [--account-number ACCT] [--namespace NS]"
       echo ""
-      echo "Defaults: username=admin, org-id=org1234567, account-number=7890123, namespace=cost-onprem"
+      echo "When -f is provided, the admin identity is read from the first orgAdmin:true"
+      echo "entry in jwtAuth.realmUsers. CLI flags override values-file fields."
+      echo ""
+      echo "Without -f, defaults to: username=admin, org-id=org1234567, account-number=7890123"
       exit 0
       ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+# Read admin identity from values file if provided
+if [ -n "$VALUES_FILE" ] && [ -f "$VALUES_FILE" ]; then
+  admin_json=$(python3 -c "
+import sys, json
+try:
+    import yaml
+except ImportError:
+    print('ERROR: pip3 install pyyaml is required when using -f', file=sys.stderr)
+    sys.exit(1)
+with open(sys.argv[1]) as f:
+    vals = yaml.safe_load(f)
+users = vals.get('jwtAuth', {}).get('realmUsers', [])
+admin = next((u for u in users if u.get('orgAdmin')), None)
+if admin:
+    json.dump(admin, sys.stdout)
+else:
+    sys.exit(1)
+" "$VALUES_FILE" 2>/dev/null) && {
+    USERNAME="${USERNAME:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('username','admin'))")}"
+    ORG_ID="${ORG_ID:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('orgId','org1234567'))")}"
+    ACCOUNT_NUMBER="${ACCOUNT_NUMBER:-$(echo "$admin_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('accountNumber','7890123'))")}"
+  } || echo "WARNING: Could not parse admin from $VALUES_FILE, using defaults"
+elif [ -n "$VALUES_FILE" ]; then
+  echo "ERROR: Values file not found: $VALUES_FILE"
+  exit 1
+fi
+
+USERNAME="${USERNAME:-admin}"
+ORG_ID="${ORG_ID:-org1234567}"
+ACCOUNT_NUMBER="${ACCOUNT_NUMBER:-7890123}"
 
 echo "=== RBAC Admin User Sync ==="
 echo "Namespace:      ${NAMESPACE}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,15 @@ _DEFAULT_ORG_ID = "org1234567"
 _DEFAULT_ACCOUNT_NUMBER = "7890123"
 
 
+def decode_jwt_payload(access_token: str) -> dict:
+    """Decode the payload section of a JWT without signature verification."""
+    payload_b64 = access_token.split(".")[1]
+    padding = 4 - len(payload_b64) % 4
+    if padding != 4:
+        payload_b64 += "=" * padding
+    return json.loads(base64.urlsafe_b64decode(payload_b64))
+
+
 # =============================================================================
 # Data Classes
 # =============================================================================
@@ -804,9 +813,7 @@ def _rbac_bootstrap(cluster_config: ClusterConfig, keycloak_config: KeycloakConf
     sa_default = f"service-account-{keycloak_config.client_id}"
     sa_mapper_override = "cost-mgmt-operator"
     try:
-        payload = token.access_token.split(".")[1]
-        payload += "=" * (4 - len(payload) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(payload))
+        claims = decode_jwt_payload(token.access_token)
         sa_username = claims.get("preferred_username") or claims.get("sub", sa_default)
     except Exception:
         sa_username = sa_default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,11 @@ pytest_plugins = ["suites.cost_management.conftest", "suites.sources.conftest"]
 # Disable SSL warnings for self-signed certificates
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+# Fallback identity values when Keycloak is unreachable.
+# Canonical source: jwtAuth.realmUsers in cost-onprem/values.yaml.
+_DEFAULT_ORG_ID = "org1234567"
+_DEFAULT_ACCOUNT_NUMBER = "7890123"
+
 
 # =============================================================================
 # Data Classes
@@ -719,7 +724,7 @@ def org_id(cluster_config: ClusterConfig, keycloak_config: KeycloakConfig) -> st
         ], check=False)
         
         if not admin_pass_result.stdout.strip():
-            return "org1234567"
+            return _DEFAULT_ORG_ID
         
         admin_password = base64.b64decode(admin_pass_result.stdout.strip()).decode("utf-8")
         
@@ -737,7 +742,7 @@ def org_id(cluster_config: ClusterConfig, keycloak_config: KeycloakConfig) -> st
         )
         
         if token_response.status_code != 200:
-            return "org1234567"
+            return _DEFAULT_ORG_ID
         
         admin_token = token_response.json().get("access_token")
         
@@ -757,9 +762,9 @@ def org_id(cluster_config: ClusterConfig, keycloak_config: KeycloakConfig) -> st
                 if org_id_value:
                     return org_id_value
         
-        return "org1234567"
+        return _DEFAULT_ORG_ID
     except Exception:
-        return "org1234567"
+        return _DEFAULT_ORG_ID
 
 
 # =============================================================================
@@ -832,8 +837,8 @@ def _rbac_bootstrap(cluster_config: ClusterConfig, keycloak_config: KeycloakConf
         return
 
     # Resolve org_id from the token claims or fall back to default
-    org_id_value = claims.get("org_id") or "org1234567"
-    acct_number = claims.get("account_number") or "1234567"
+    org_id_value = claims.get("org_id") or _DEFAULT_ORG_ID
+    acct_number = claims.get("account_number") or _DEFAULT_ACCOUNT_NUMBER
 
     bootstrap_script = render_bootstrap_script(sa_usernames, org_id_value, acct_number)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,8 +229,13 @@ def jwt_token(keycloak_config: KeycloakConfig) -> JWTToken:
     return obtain_jwt_token(keycloak_config)
 
 
-def obtain_user_jwt_token(keycloak_config: KeycloakConfig, cluster_config) -> JWTToken:
-    """Obtain a JWT token via password grant for the admin user.
+def obtain_user_jwt_token_for(
+    keycloak_config: KeycloakConfig,
+    cluster_config,
+    username: str = "admin",
+    password: str = "admin",
+) -> JWTToken:
+    """Obtain a JWT token via password grant for the given user.
 
     The cost-management-operator SA token has a ``service-account-*`` username
     that RBAC rejects with 400 ("Invalid format for a Service Account username").
@@ -251,8 +256,8 @@ def obtain_user_jwt_token(keycloak_config: KeycloakConfig, cluster_config) -> JW
             "grant_type": "password",
             "client_id": ui_client_id,
             "client_secret": ui_client_secret,
-            "username": "admin",
-            "password": "admin",
+            "username": username,
+            "password": password,
         },
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         verify=False,
@@ -261,7 +266,7 @@ def obtain_user_jwt_token(keycloak_config: KeycloakConfig, cluster_config) -> JW
 
     if response.status_code != 200:
         pytest.fail(
-            f"Failed to obtain user JWT token via password grant: "
+            f"Failed to obtain JWT token for {username!r} via password grant: "
             f"{response.status_code} - {response.text}"
         )
 
@@ -272,6 +277,11 @@ def obtain_user_jwt_token(keycloak_config: KeycloakConfig, cluster_config) -> JW
         access_token=token_data["access_token"],
         expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
     )
+
+
+def obtain_user_jwt_token(keycloak_config: KeycloakConfig, cluster_config) -> JWTToken:
+    """Obtain a JWT token via password grant for the admin user."""
+    return obtain_user_jwt_token_for(keycloak_config, cluster_config)
 
 
 @pytest.fixture(scope="function")

--- a/tests/suites/auth/conftest.py
+++ b/tests/suites/auth/conftest.py
@@ -35,3 +35,20 @@ def test_user_credentials():
         "username": "admin",
         "password": "admin",
     }
+
+
+@pytest.fixture
+def non_admin_user_credentials():
+    """Credentials for the non-admin viewer user (no org-admin realm role)."""
+    return {
+        "username": "viewer",
+        "password": "viewer",
+    }
+
+
+@pytest.fixture
+def http_session() -> requests.Session:
+    """Shared requests session with SSL verification disabled."""
+    session = requests.Session()
+    session.verify = False
+    return session

--- a/tests/suites/auth/test_keycloak.py
+++ b/tests/suites/auth/test_keycloak.py
@@ -68,16 +68,9 @@ class TestJWTTokenAcquisition:
 
     def test_token_payload_decodable(self, jwt_token):
         """Verify JWT payload can be decoded."""
-        import base64
-        import json
-        
-        payload_b64 = jwt_token.access_token.split(".")[1]
-        # Add padding if needed
-        padding = 4 - len(payload_b64) % 4
-        if padding != 4:
-            payload_b64 += "=" * padding
-        
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        
+        from conftest import decode_jwt_payload
+
+        payload = decode_jwt_payload(jwt_token.access_token)
+
         assert "exp" in payload, "Token missing 'exp' claim"
         assert "iss" in payload, "Token missing 'iss' claim"

--- a/tests/suites/auth/test_org_admin_identity.py
+++ b/tests/suites/auth/test_org_admin_identity.py
@@ -62,8 +62,8 @@ class TestOrgAdminIdentityPropagation:
         is_org_admin=true.
         """
         permissions = self._get_permissions(rbac_access_url, admin_jwt)
-        assert any("cost-management" in p for p in permissions), (
-            f"Admin should have cost-management permissions, got: {permissions}"
+        assert "cost-management:*:*" in permissions, (
+            f"Admin should have cost-management:*:* via admin_default, got: {permissions}"
         )
 
     def test_non_admin_lacks_cost_management_access(

--- a/tests/suites/auth/test_org_admin_identity.py
+++ b/tests/suites/auth/test_org_admin_identity.py
@@ -1,0 +1,81 @@
+"""
+Org-admin identity propagation tests.
+
+Validates the full chain: Keycloak org-admin realm role -> Envoy Lua filter
+reads realm_access.roles from the JWT -> sets is_org_admin in X-Rh-Identity ->
+RBAC grants admin_default permissions (cost-management:*:*).
+
+The observable proxy for is_org_admin is the RBAC /api/rbac/v1/access/ endpoint:
+admin users receive cost-management:*:* permissions via the admin_default group,
+while non-admin users with no RBAC group membership receive empty permissions.
+"""
+
+import pytest
+import requests
+
+from conftest import KeycloakConfig, ClusterConfig, obtain_user_jwt_token_for
+
+
+@pytest.mark.auth
+@pytest.mark.integration
+class TestOrgAdminIdentityPropagation:
+    """Verify that Envoy correctly propagates is_org_admin through the gateway."""
+
+    @pytest.fixture
+    def admin_jwt(self, keycloak_config: KeycloakConfig, cluster_config: ClusterConfig):
+        """JWT for the admin user (has org-admin realm role)."""
+        return obtain_user_jwt_token_for(keycloak_config, cluster_config)
+
+    @pytest.fixture
+    def viewer_jwt(self, keycloak_config: KeycloakConfig, cluster_config: ClusterConfig):
+        """JWT for the viewer user (no org-admin realm role)."""
+        return obtain_user_jwt_token_for(
+            keycloak_config, cluster_config, username="viewer", password="viewer",
+        )
+
+    @pytest.fixture
+    def rbac_access_url(self, gateway_url: str) -> str:
+        """RBAC access endpoint through the gateway."""
+        return f"{gateway_url}/rbac/v1/access/?application=cost-management&limit=50"
+
+    def _get_permissions(self, url: str, token) -> list[str]:
+        """Call RBAC access endpoint and return the list of permission strings."""
+        response = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {token.access_token}"},
+            verify=False,
+            timeout=30,
+        )
+        assert response.status_code == 200, (
+            f"RBAC /access/ returned {response.status_code}: {response.text[:200]}"
+        )
+        data = response.json()
+        return [entry["permission"] for entry in data.get("data", [])]
+
+    def test_admin_gets_full_cost_management_access(
+        self, rbac_access_url, admin_jwt,
+    ):
+        """Admin user (is_org_admin=true) receives cost-management:*:* from RBAC.
+
+        The admin_default group in RBAC grants Cost Administrator
+        (cost-management:*:*) to any user whose X-Rh-Identity has
+        is_org_admin=true.
+        """
+        permissions = self._get_permissions(rbac_access_url, admin_jwt)
+        assert any("cost-management" in p for p in permissions), (
+            f"Admin should have cost-management permissions, got: {permissions}"
+        )
+
+    def test_non_admin_lacks_cost_management_access(
+        self, rbac_access_url, viewer_jwt,
+    ):
+        """Non-admin user (is_org_admin=false, no group) gets no cost-management perms.
+
+        The viewer user has no RBAC group membership and is_org_admin=false,
+        so RBAC should return no cost-management permissions.
+        """
+        permissions = self._get_permissions(rbac_access_url, viewer_jwt)
+        wildcard_perms = [p for p in permissions if p == "cost-management:*:*"]
+        assert not wildcard_perms, (
+            f"Viewer should not have cost-management:*:* but got: {permissions}"
+        )

--- a/tests/suites/auth/test_org_admin_identity.py
+++ b/tests/suites/auth/test_org_admin_identity.py
@@ -13,7 +13,7 @@ while non-admin users with no RBAC group membership receive empty permissions.
 import pytest
 import requests
 
-from conftest import KeycloakConfig, ClusterConfig, obtain_user_jwt_token_for
+from conftest import KeycloakConfig, ClusterConfig, decode_jwt_payload, obtain_user_jwt_token_for
 
 
 @pytest.mark.auth
@@ -78,4 +78,49 @@ class TestOrgAdminIdentityPropagation:
         wildcard_perms = [p for p in permissions if p == "cost-management:*:*"]
         assert not wildcard_perms, (
             f"Viewer should not have cost-management:*:* but got: {permissions}"
+        )
+
+    @pytest.mark.parametrize(
+        "creds,expect_admin",
+        [
+            ({"username": "admin", "password": "admin"}, True),
+            ({"username": "viewer", "password": "viewer"}, False),
+        ],
+        ids=["admin-is-org-admin", "viewer-is-not-org-admin"],
+    )
+    def test_org_admin_role_determines_access(
+        self,
+        keycloak_config: KeycloakConfig,
+        cluster_config: ClusterConfig,
+        rbac_access_url: str,
+        creds: dict,
+        expect_admin: bool,
+    ):
+        """Architectural invariant: is_org_admin in the JWT controls RBAC access.
+
+        Any user with the org-admin realm role must receive
+        cost-management:*:*, and any user without it must not. This
+        parametrized test validates the invariant for every provisioned
+        user, ensuring the architecture works for N admins (not just the
+        bootstrapped one).
+        """
+        token = obtain_user_jwt_token_for(
+            keycloak_config, cluster_config,
+            username=creds["username"], password=creds["password"],
+        )
+        payload = decode_jwt_payload(token.access_token)
+        roles = payload.get("realm_access", {}).get("roles", [])
+        has_role = "org-admin" in roles
+
+        assert has_role == expect_admin, (
+            f"User {creds['username']}: expected org-admin={expect_admin}, "
+            f"JWT has roles={roles}"
+        )
+
+        permissions = self._get_permissions(rbac_access_url, token)
+        has_wildcard = "cost-management:*:*" in permissions
+
+        assert has_wildcard == expect_admin, (
+            f"User {creds['username']}: expected wildcard={expect_admin}, "
+            f"got permissions={permissions}"
         )

--- a/tests/suites/auth/test_ui_oauth.py
+++ b/tests/suites/auth/test_ui_oauth.py
@@ -5,23 +5,13 @@ Tests for the UI authentication flow with Keycloak (password grant).
 Migrated from scripts/test-ui-oauth-flow.sh
 """
 
-import base64
-import json
 import re
 
 import pytest
 import requests
 
+from conftest import decode_jwt_payload
 from utils import run_oc_command, get_route_url
-
-
-def _decode_jwt_payload(access_token: str) -> dict:
-    """Decode the payload section of a JWT without signature verification."""
-    payload_b64 = access_token.split(".")[1]
-    padding = 4 - len(payload_b64) % 4
-    if padding != 4:
-        payload_b64 += "=" * padding
-    return json.loads(base64.urlsafe_b64decode(payload_b64))
 
 
 def _obtain_token(http_session, keycloak_config, ui_client_config, credentials):
@@ -109,35 +99,29 @@ class TestUIOAuthFlow:
         http_session: requests.Session,
     ):
         """Verify JWT token can be obtained via password grant."""
-        if not ui_client_config.get("client_secret"):
-            # Try without client secret (public client)
-            data = {
-                "username": test_user_credentials["username"],
-                "password": test_user_credentials["password"],
-                "grant_type": "password",
-                "client_id": ui_client_config["client_id"],
-                "scope": "openid profile email roles",
-            }
-        else:
-            data = {
-                "username": test_user_credentials["username"],
-                "password": test_user_credentials["password"],
-                "grant_type": "password",
-                "client_id": ui_client_config["client_id"],
-                "client_secret": ui_client_config["client_secret"],
-                "scope": "openid profile email roles",
-            }
-        
+        data = {
+            "username": test_user_credentials["username"],
+            "password": test_user_credentials["password"],
+            "grant_type": "password",
+            "client_id": ui_client_config["client_id"],
+            "scope": "openid profile email roles",
+        }
+        if ui_client_config.get("client_secret"):
+            data["client_secret"] = ui_client_config["client_secret"]
+
         token_url = (
             f"{keycloak_config.url}/realms/{keycloak_config.realm}/"
             "protocol/openid-connect/token"
         )
-        
-        response = http_session.post(token_url, data=data, timeout=30)
-        
-        if response.status_code != 200:
-            pytest.skip(f"Password grant failed: {response.status_code}")
-        
+
+        try:
+            response = http_session.post(token_url, data=data, timeout=30)
+        except requests.exceptions.ConnectionError:
+            pytest.skip("Keycloak unreachable")
+
+        assert response.status_code == 200, (
+            f"Password grant failed: {response.status_code} — {response.text[:300]}"
+        )
         token_data = response.json()
         assert "access_token" in token_data, "No access_token in response"
 
@@ -149,7 +133,6 @@ class TestUIOAuthFlow:
         http_session: requests.Session,
     ):
         """Verify JWT contains required claims (preferred_username, org_id)."""
-        # Get token via password grant
         data = {
             "username": test_user_credentials["username"],
             "password": test_user_credentials["password"],
@@ -159,26 +142,24 @@ class TestUIOAuthFlow:
         }
         if ui_client_config.get("client_secret"):
             data["client_secret"] = ui_client_config["client_secret"]
-        
+
         token_url = (
             f"{keycloak_config.url}/realms/{keycloak_config.realm}/"
             "protocol/openid-connect/token"
         )
-        
-        response = http_session.post(token_url, data=data, timeout=30)
-        
-        if response.status_code != 200:
-            pytest.skip("Could not obtain token for claims validation")
-        
+
+        try:
+            response = http_session.post(token_url, data=data, timeout=30)
+        except requests.exceptions.ConnectionError:
+            pytest.skip("Keycloak unreachable")
+
+        assert response.status_code == 200, (
+            f"Could not obtain token for claims validation: "
+            f"{response.status_code} — {response.text[:300]}"
+        )
+
         access_token = response.json().get("access_token")
-        
-        # Decode JWT payload
-        payload_b64 = access_token.split(".")[1]
-        padding = 4 - len(payload_b64) % 4
-        if padding != 4:
-            payload_b64 += "=" * padding
-        
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        payload = decode_jwt_payload(access_token)
         
         # Check required claims
         assert "preferred_username" in payload, "JWT missing preferred_username"
@@ -211,7 +192,7 @@ class TestOrgAdminRealmRole:
         token = _obtain_token(
             http_session, keycloak_config, ui_client_config, test_user_credentials,
         )
-        payload = _decode_jwt_payload(token)
+        payload = decode_jwt_payload(token)
 
         realm_access = payload.get("realm_access", {})
         roles = realm_access.get("roles", [])
@@ -231,7 +212,7 @@ class TestOrgAdminRealmRole:
         token = _obtain_token(
             http_session, keycloak_config, ui_client_config, non_admin_user_credentials,
         )
-        payload = _decode_jwt_payload(token)
+        payload = decode_jwt_payload(token)
 
         realm_access = payload.get("realm_access", {})
         roles = realm_access.get("roles", [])

--- a/tests/suites/auth/test_ui_oauth.py
+++ b/tests/suites/auth/test_ui_oauth.py
@@ -14,6 +14,40 @@ import requests
 from utils import run_oc_command, get_route_url
 
 
+def _decode_jwt_payload(access_token: str) -> dict:
+    """Decode the payload section of a JWT without signature verification."""
+    payload_b64 = access_token.split(".")[1]
+    padding = 4 - len(payload_b64) % 4
+    if padding != 4:
+        payload_b64 += "=" * padding
+    return json.loads(base64.urlsafe_b64decode(payload_b64))
+
+
+def _obtain_token(http_session, keycloak_config, ui_client_config, credentials):
+    """Obtain an access token via password grant, returning the raw JWT string."""
+    data = {
+        "username": credentials["username"],
+        "password": credentials["password"],
+        "grant_type": "password",
+        "client_id": ui_client_config["client_id"],
+        "scope": "openid profile email",
+    }
+    if ui_client_config.get("client_secret"):
+        data["client_secret"] = ui_client_config["client_secret"]
+
+    token_url = (
+        f"{keycloak_config.url}/realms/{keycloak_config.realm}/"
+        "protocol/openid-connect/token"
+    )
+    response = http_session.post(token_url, data=data, timeout=30)
+    if response.status_code != 200:
+        pytest.skip(
+            f"Password grant failed for {credentials['username']!r}: "
+            f"{response.status_code}"
+        )
+    return response.json()["access_token"]
+
+
 @pytest.mark.auth
 @pytest.mark.integration
 class TestUIOAuthFlow:
@@ -153,3 +187,54 @@ class TestUIOAuthFlow:
             pytest.skip("JWT missing org_id claim (may need Keycloak mapper)")
         if "account_number" not in payload:
             pytest.skip("JWT missing account_number claim (may need Keycloak mapper)")
+
+
+@pytest.mark.auth
+@pytest.mark.integration
+class TestOrgAdminRealmRole:
+    """Verify that Keycloak assigns the org-admin realm role correctly.
+
+    The org-admin role controls is_org_admin in the X-Rh-Identity header.
+    Admin users (orgAdmin: true in values.yaml) must have it; non-admin
+    users (orgAdmin: false) must not.
+    """
+
+    def test_admin_jwt_contains_org_admin_realm_role(
+        self,
+        keycloak_config,
+        ui_client_config,
+        test_user_credentials,
+        http_session: requests.Session,
+    ):
+        """Admin user's JWT must contain the org-admin realm role."""
+        token = _obtain_token(
+            http_session, keycloak_config, ui_client_config, test_user_credentials,
+        )
+        payload = _decode_jwt_payload(token)
+
+        realm_access = payload.get("realm_access", {})
+        roles = realm_access.get("roles", [])
+        assert "org-admin" in roles, (
+            f"Expected 'org-admin' in realm_access.roles for admin user, "
+            f"got: {roles}"
+        )
+
+    def test_non_admin_jwt_lacks_org_admin_realm_role(
+        self,
+        keycloak_config,
+        ui_client_config,
+        non_admin_user_credentials,
+        http_session: requests.Session,
+    ):
+        """Non-admin (viewer) user's JWT must NOT contain the org-admin realm role."""
+        token = _obtain_token(
+            http_session, keycloak_config, ui_client_config, non_admin_user_credentials,
+        )
+        payload = _decode_jwt_payload(token)
+
+        realm_access = payload.get("realm_access", {})
+        roles = realm_access.get("roles", [])
+        assert "org-admin" not in roles, (
+            f"Viewer user should not have 'org-admin' role, "
+            f"got: {roles}"
+        )

--- a/tests/suites/auth/test_ui_oauth.py
+++ b/tests/suites/auth/test_ui_oauth.py
@@ -7,6 +7,7 @@ Migrated from scripts/test-ui-oauth-flow.sh
 
 import base64
 import json
+import re
 
 import pytest
 import requests
@@ -94,10 +95,10 @@ class TestUIOAuthFlow:
             pytest.skip("Could not get oauth-proxy logs")
         
         logs = result.stdout.lower()
-        tls_errors = ["tls.*error", "certificate.*error", "x509"]
+        tls_errors = [r"tls.*error", r"certificate.*error", r"x509"]
         
         for pattern in tls_errors:
-            if pattern in logs:
+            if re.search(pattern, logs):
                 pytest.fail(f"TLS error found in oauth-proxy logs: {pattern}")
 
     def test_password_grant_token_acquisition(

--- a/tests/suites/auth/test_ui_oauth.py
+++ b/tests/suites/auth/test_ui_oauth.py
@@ -21,7 +21,7 @@ def _obtain_token(http_session, keycloak_config, ui_client_config, credentials):
         "password": credentials["password"],
         "grant_type": "password",
         "client_id": ui_client_config["client_id"],
-        "scope": "openid profile email roles",
+        "scope": "openid profile email",
     }
     if ui_client_config.get("client_secret"):
         data["client_secret"] = ui_client_config["client_secret"]
@@ -104,7 +104,7 @@ class TestUIOAuthFlow:
             "password": test_user_credentials["password"],
             "grant_type": "password",
             "client_id": ui_client_config["client_id"],
-            "scope": "openid profile email roles",
+            "scope": "openid profile email",
         }
         if ui_client_config.get("client_secret"):
             data["client_secret"] = ui_client_config["client_secret"]
@@ -138,7 +138,7 @@ class TestUIOAuthFlow:
             "password": test_user_credentials["password"],
             "grant_type": "password",
             "client_id": ui_client_config["client_id"],
-            "scope": "openid profile email roles",
+            "scope": "openid profile email",
         }
         if ui_client_config.get("client_secret"):
             data["client_secret"] = ui_client_config["client_secret"]

--- a/tests/suites/auth/test_ui_oauth.py
+++ b/tests/suites/auth/test_ui_oauth.py
@@ -31,7 +31,7 @@ def _obtain_token(http_session, keycloak_config, ui_client_config, credentials):
         "password": credentials["password"],
         "grant_type": "password",
         "client_id": ui_client_config["client_id"],
-        "scope": "openid profile email",
+        "scope": "openid profile email roles",
     }
     if ui_client_config.get("client_secret"):
         data["client_secret"] = ui_client_config["client_secret"]
@@ -116,7 +116,7 @@ class TestUIOAuthFlow:
                 "password": test_user_credentials["password"],
                 "grant_type": "password",
                 "client_id": ui_client_config["client_id"],
-                "scope": "openid profile email",
+                "scope": "openid profile email roles",
             }
         else:
             data = {
@@ -125,7 +125,7 @@ class TestUIOAuthFlow:
                 "grant_type": "password",
                 "client_id": ui_client_config["client_id"],
                 "client_secret": ui_client_config["client_secret"],
-                "scope": "openid profile email",
+                "scope": "openid profile email roles",
             }
         
         token_url = (
@@ -155,7 +155,7 @@ class TestUIOAuthFlow:
             "password": test_user_credentials["password"],
             "grant_type": "password",
             "client_id": ui_client_config["client_id"],
-            "scope": "openid profile email",
+            "scope": "openid profile email roles",
         }
         if ui_client_config.get("client_secret"):
             data["client_secret"] = ui_client_config["client_secret"]

--- a/tests/suites/ui/conftest.py
+++ b/tests/suites/ui/conftest.py
@@ -66,8 +66,10 @@ CMMO Source Creation:
 """
 
 import os
+import re
 import shutil
 from typing import Generator
+from urllib.parse import urlparse
 
 import pytest
 from playwright.sync_api import Browser, BrowserContext, Page, Playwright, sync_playwright
@@ -179,6 +181,45 @@ def keycloak_login_url(keycloak_config: KeycloakConfig) -> str:
 # =============================================================================
 
 
+def _assert_callback_completed(
+    page,
+    context: BrowserContext,
+    ui_url: str,
+    timeout: int = 10000,
+) -> None:
+    """Verify the OAuth2 proxy callback completed and session cookies are set.
+
+    After Keycloak redirects to /oauth2/callback, oauth2-proxy must exchange
+    the code for tokens and redirect to the app.  If the page is still at
+    /oauth2/callback, the token exchange failed (e.g. bad TLS, malformed
+    claim names, missing audience).
+    """
+    if "/oauth2/callback" in page.url:
+        try:
+            page.wait_for_url(
+                re.compile(rf".*{re.escape(urlparse(ui_url).netloc)}(?!/oauth2/callback).*"),
+                timeout=timeout,
+            )
+        except Exception:
+            raise RuntimeError(
+                f"OAuth2 callback did not complete. Page stuck at: {page.url}\n"
+                "oauth2-proxy failed to exchange the authorization code for tokens. "
+                "Check oauth-proxy container logs for errors (TLS, redirect_uri mismatch, "
+                "malformed roles scope, etc.)."
+            )
+
+    session_cookies = [
+        c for c in context.cookies()
+        if c["name"].startswith("_oauth2_proxy")
+        and c["name"] != "_oauth2_proxy_csrf"
+    ]
+    if not session_cookies:
+        raise RuntimeError(
+            f"Login completed (URL: {page.url}) but no _oauth2_proxy session "
+            "cookies were set. The OAuth2 callback may have returned an error page."
+        )
+
+
 def _login_context(
     browser: Browser,
     ui_url: str,
@@ -186,7 +227,10 @@ def _login_context(
     username: str,
     password: str,
 ) -> BrowserContext:
-    """Create a browser context authenticated via Keycloak password grant."""
+    """Create a browser context authenticated via Keycloak login form.
+
+    Verifies the OAuth2 callback completes and session cookies are set.
+    """
     context = browser.new_context(
         viewport={"width": 1920, "height": 1080},
         ignore_https_errors=True,
@@ -200,7 +244,8 @@ def _login_context(
     page.fill('input[name="password"]', password)
     page.click('input[type="submit"], button[type="submit"]')
 
-    page.wait_for_url(f"{ui_url}**", timeout=15000)
+    page.wait_for_url(f"{ui_url}**", timeout=30000)
+    _assert_callback_completed(page, context, ui_url)
     page.close()
     return context
 
@@ -298,12 +343,13 @@ def authenticated_context(
     page.fill('input[name="password"]', password)
     page.click('input[type="submit"], button[type="submit"]')
     
-    # Wait for redirect back to UI - use wildcard pattern that matches any path
-    # After login, UI may redirect to /openshift/cost-management or other paths
-    from urllib.parse import urlparse
+    # Wait for redirect back to UI host (any path)
     parsed = urlparse(ui_url)
     ui_host_pattern = f"**{parsed.netloc}**"
-    page.wait_for_url(ui_host_pattern, timeout=15000)
+    page.wait_for_url(ui_host_pattern, timeout=30000)
+    
+    # Verify the OAuth2 callback completed and cookies are set
+    _assert_callback_completed(page, context, ui_url)
     
     # Wait for page to fully load
     page.wait_for_load_state("networkidle")

--- a/tests/suites/ui/conftest.py
+++ b/tests/suites/ui/conftest.py
@@ -99,51 +99,76 @@ def keycloak_login_url(keycloak_config: KeycloakConfig) -> str:
 # =============================================================================
 
 
+def _login_context(
+    browser: Browser,
+    ui_url: str,
+    keycloak_config: KeycloakConfig,
+    username: str,
+    password: str,
+) -> BrowserContext:
+    """Create a browser context authenticated via Keycloak password grant."""
+    context = browser.new_context(
+        viewport={"width": 1920, "height": 1080},
+        ignore_https_errors=True,
+    )
+
+    page = context.new_page()
+    page.goto(ui_url)
+    page.wait_for_url(f"**/{keycloak_config.realm}/**", timeout=10000)
+
+    page.fill('input[name="username"]', username)
+    page.fill('input[name="password"]', password)
+    page.click('input[type="submit"], button[type="submit"]')
+
+    page.wait_for_url(f"{ui_url}**", timeout=15000)
+    page.close()
+    return context
+
+
 @pytest.fixture(scope="function")
 def authenticated_context(
     browser: Browser,
     ui_url: str,
     keycloak_config: KeycloakConfig,
 ) -> Generator[BrowserContext, None, None]:
-    """Create a browser context with authenticated session.
-    
-    Performs Keycloak login and stores the session for the test.
-    Uses test/test credentials by default (configurable via env vars).
+    """Browser context authenticated as admin (org-admin role).
+
+    Credentials default to admin/admin; override with TEST_UI_USERNAME /
+    TEST_UI_PASSWORD env vars.
     """
-    context = browser.new_context(
-        viewport={"width": 1920, "height": 1080},
-        ignore_https_errors=True,
-    )
-    
-    page = context.new_page()
-    
-    # Navigate to UI (will redirect to Keycloak)
-    page.goto(ui_url)
-    
-    # Wait for Keycloak login page
-    page.wait_for_url(f"**/{keycloak_config.realm}/**", timeout=10000)
-    
-    # Fill login form
     username = os.environ.get("TEST_UI_USERNAME", "admin")
     password = os.environ.get("TEST_UI_PASSWORD", "admin")
-    
-    page.fill('input[name="username"]', username)
-    page.fill('input[name="password"]', password)
-    page.click('input[type="submit"], button[type="submit"]')
-    
-    # Wait for redirect back to UI
-    page.wait_for_url(f"{ui_url}**", timeout=15000)
-    
-    page.close()
-    
+    context = _login_context(browser, ui_url, keycloak_config, username, password)
     yield context
     context.close()
 
 
 @pytest.fixture(scope="function")
 def authenticated_page(authenticated_context: BrowserContext) -> Generator[Page, None, None]:
-    """Create a page with authenticated session."""
+    """Create a page with authenticated (admin) session."""
     page = authenticated_context.new_page()
+    yield page
+    page.close()
+
+
+@pytest.fixture(scope="function")
+def non_admin_authenticated_context(
+    browser: Browser,
+    ui_url: str,
+    keycloak_config: KeycloakConfig,
+) -> Generator[BrowserContext, None, None]:
+    """Browser context authenticated as viewer (no org-admin role)."""
+    context = _login_context(browser, ui_url, keycloak_config, "viewer", "viewer")
+    yield context
+    context.close()
+
+
+@pytest.fixture(scope="function")
+def non_admin_authenticated_page(
+    non_admin_authenticated_context: BrowserContext,
+) -> Generator[Page, None, None]:
+    """Create a page with non-admin (viewer) session."""
+    page = non_admin_authenticated_context.new_page()
     yield page
     page.close()
 

--- a/tests/suites/ui/test_login_flow.py
+++ b/tests/suites/ui/test_login_flow.py
@@ -56,9 +56,12 @@ class TestLoginFlow:
         page.click('input[type="submit"], button[type="submit"]')
         
         # Should redirect back to UI
-        page.wait_for_url(f"{ui_url}**", timeout=15000)
+        page.wait_for_url(f"{ui_url}**", timeout=30000)
         
-        # Verify we're on the UI (not Keycloak)
+        # Verify we're on the UI (not Keycloak or stuck at OAuth2 callback)
+        assert "/oauth2/callback" not in page.url, (
+            f"OAuth2 callback did not complete. Page stuck at: {page.url}"
+        )
         expect(page).not_to_have_url(re.compile(f".*{keycloak_config.realm}.*"))
 
     def test_invalid_credentials_shows_error(self, page: Page, ui_url: str, keycloak_config):

--- a/tests/suites/ui/test_navigation.py
+++ b/tests/suites/ui/test_navigation.py
@@ -111,27 +111,25 @@ class TestPageNavigation:
         
         Parametrized for: Overview, OpenShift, Cost Explorer, Settings.
         """
-        # Navigate directly to the page
         authenticated_page.goto(f"{ui_url}{nav_page.path}")
         authenticated_page.wait_for_load_state("networkidle")
-        
-        # Check for common error indicators
-        error_indicators = [
-            "text=/error|failed|not found|500|503/i",
+
+        hard_error_selectors = [
             ".pf-v6-c-alert--danger",
             "[data-testid='error-state']",
         ]
-        
-        for indicator in error_indicators:
-            error_element = authenticated_page.locator(indicator)
-            # Allow for "No data" messages which are not errors
+        errors_found: list[str] = []
+        for selector in hard_error_selectors:
+            error_element = authenticated_page.locator(selector)
             if error_element.count() > 0:
-                # Check if it's actually an error vs just "no data"
-                text = error_element.first.text_content() or ""
-                if "no data" not in text.lower() and "empty" not in text.lower():
-                    # This might be a real error - log but don't fail
-                    # Some pages may legitimately show errors if not configured
-                    print(f"  ⚠️ Possible error on {nav_page.name}: {text[:100]}")
+                text = (error_element.first.text_content() or "").strip()
+                benign = ("no data" in text.lower() or "empty" in text.lower())
+                if not benign:
+                    errors_found.append(f"[{selector}] {text[:200]}")
+
+        assert not errors_found, (
+            f"Page {nav_page.name} has error indicators: {errors_found}"
+        )
 
 
 @pytest.mark.ui

--- a/tests/suites/ui/test_navigation.py
+++ b/tests/suites/ui/test_navigation.py
@@ -343,3 +343,34 @@ class TestSettingsPage:
         # Should have some main content area
         main_content = authenticated_page.locator("main, [role='main'], .pf-v6-c-page__main")
         expect(main_content).to_be_visible()
+
+    def test_admin_settings_page_shows_settings_content(
+        self, authenticated_page: Page, ui_url: str,
+    ):
+        """Admin (org-admin role) must see actual settings, not access-denied."""
+        authenticated_page.goto(f"{ui_url}/openshift/cost-management/settings")
+        authenticated_page.wait_for_load_state("networkidle")
+
+        access_denied = authenticated_page.locator(
+            "text=You do not have access to Settings in cost management"
+        )
+        expect(access_denied).not_to_be_visible()
+
+        main_content = authenticated_page.locator(
+            "main, [role='main'], .pf-v6-c-page__main"
+        )
+        expect(main_content).to_be_visible()
+
+    def test_non_admin_settings_page_shows_access_denied(
+        self, non_admin_authenticated_page: Page, ui_url: str,
+    ):
+        """Non-admin (viewer, no org-admin role) must see the access-denied state."""
+        non_admin_authenticated_page.goto(
+            f"{ui_url}/openshift/cost-management/settings"
+        )
+        non_admin_authenticated_page.wait_for_load_state("networkidle")
+
+        access_denied = non_admin_authenticated_page.locator(
+            "text=You do not have access to Settings in cost management"
+        )
+        expect(access_denied).to_be_visible(timeout=10000)


### PR DESCRIPTION
## Summary

- **Single source of truth**: replaces the static `orgAdminUsernames` list with Keycloak realm roles — the Envoy Lua filter now reads `realm_access.roles` from the JWT to set `is_org_admin` in `X-Rh-Identity`, making Keycloak the authoritative source for admin status
- **User provisioning**: `values.yaml` gains a structured `realmUsers` list (admin + viewer) with `orgAdmin` flag; `deploy-rhbk.sh` provisions these users into Keycloak with the `org-admin` realm role and adds `roles` to both clients' `defaultClientScopes` for forward-compatibility
- **Three-layer test coverage**: JWT claim tests (admin has `org-admin` in `realm_access.roles`, viewer does not), gateway identity propagation tests (admin gets `cost-management:*:*` from RBAC, viewer does not), and Playwright tests (admin sees Settings content, viewer sees "access denied")
- **Security fix**: sanitized `$VALUES_FILE` path in `deploy-rhbk.sh` to prevent shell injection

## Test plan

- [ ] Verify `deploy-rhbk.sh -f cost-onprem/values.yaml` provisions both admin (with org-admin role) and viewer (without) in Keycloak
- [ ] Verify admin/admin can access Settings page after deployment
- [ ] Verify viewer/viewer sees "You do not have access to Settings in cost management"
- [ ] Run `pytest -m auth` — JWT realm role and gateway identity tests pass
- [ ] Run `pytest -m ui` — Playwright Settings access tests pass
- [ ] Verify no regression on existing e2e/auth/sources test suites


Made with [Cursor](https://cursor.com)