### PR TITLE
FLPATH-4184 Add --devel and --chart-version flags for RC/versioned chart testing

### DIFF
--- a/.github/workflows/validate-deploy-test-script.yml
+++ b/.github/workflows/validate-deploy-test-script.yml
@@ -122,6 +122,35 @@ jobs:
             fi
           }
 
+          # run_error_case NAME FLAGS EXPECTED_ERROR
+          run_error_case() {
+            local name="$1" flags="$2" expected_error="$3"
+
+            echo ""
+            echo "━━━ ${name} (expect error) ━━━"
+
+            local output exit_code
+            set +e
+            output=$(bash "$SCRIPT" --dry-run $flags 2>&1)
+            exit_code=$?
+            set -e
+
+            if [ "$exit_code" -eq 0 ]; then
+              echo "    ✗ Expected error but script succeeded"
+              failures=$((failures + 1))
+              return
+            fi
+
+            if echo "$output" | grep -qF "$expected_error"; then
+              echo "    ✓ Got expected error: ${expected_error}"
+              passed=$((passed + 1))
+            else
+              echo "    ✗ Wrong error message — expected '${expected_error}'"
+              echo "    Got: $(echo "$output" | tail -3)"
+              failures=$((failures + 1))
+            fi
+          }
+
           #                NAME                                        FLAGS                                      MODE                    DEPLOY  CHART  PERF   IQE
           run_case         "(defaults)"                                ""                                         "Full deployment"       true    true   false  false
           run_case         "--run-iqe"                                 "--run-iqe"                                "Full deployment"       true    true   false  true
@@ -137,6 +166,15 @@ jobs:
           run_case         "--perf-only --perf-profile small"          "--perf-only --perf-profile small"         "Performance-only"      false   false  true   false
           run_case         "--perf-only --perf-profile medium"         "--perf-only --perf-profile medium"        "Performance-only"      false   false  true   false
           run_case         "--perf-only --perf-profile large"          "--perf-only --perf-profile large"         "Performance-only"      false   false  true   false
+
+          # Chart version flags
+          run_case         "--devel"                                   "--devel"                                  "Full deployment"       true    true   false  false
+          run_case         "--chart-version 0.2.19"                    "--chart-version 0.2.19"                   "Full deployment"       true    true   false  false
+          run_case         "--devel --chart-version 0.2.20-rc1"        "--devel --chart-version 0.2.20-rc1"       "Full deployment"       true    true   false  false
+
+          # Invalid flag combinations (should fail)
+          run_error_case   "--use-local-chart --devel"                 "--use-local-chart --devel"                "Cannot use --devel with --use-local-chart"
+          run_error_case   "--use-local-chart --chart-version 0.2.19"  "--use-local-chart --chart-version 0.2.19" "Cannot use --chart-version with --use-local-chart"
 
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -33,6 +33,8 @@ set -euo pipefail
 #   --namespace NAME          Target namespace (default: cost-onprem)
 #   --image-tag TAG           Custom image tag for cost-onprem-ocp-backend services
 #   --use-local-chart         Use local Helm chart instead of GitHub release
+#   --devel                   Include pre-release (rc) charts in Helm installation
+#   --chart-version VERSION   Pin a specific Helm chart version (e.g., 0.2.9, 0.3.0-rc1)
 #
 #   Test options:
 #   --iqe-marker EXPR         Pytest marker for IQE tests (default: cost_ocp_on_prem)
@@ -109,6 +111,8 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # Default configuration
 NAMESPACE="${NAMESPACE:-cost-onprem}"
 USE_LOCAL_CHART="${USE_LOCAL_CHART:-false}"
+USE_HELM_DEVEL="${USE_HELM_DEVEL:-false}"
+CHART_VERSION="${CHART_VERSION:-}"
 VERBOSE="${VERBOSE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 TESTS_ONLY="${TESTS_ONLY:-false}"
@@ -552,6 +556,8 @@ deploy_helm_chart() {
     export NAMESPACE="${NAMESPACE}"
     export JWT_AUTH_ENABLED="true"
     export USE_LOCAL_CHART="${USE_LOCAL_CHART}"
+    export USE_HELM_DEVEL="${USE_HELM_DEVEL}"
+    [[ -n "${CHART_VERSION}" ]] && export CHART_VERSION="${CHART_VERSION}"
     # Note: S3 setup behavior depends on values.yaml configuration:
     # - If objectStorage.endpoint is set: Script skips S3 auto-detection and bucket creation
     # - If not set: Script auto-detects (S4, NooBaa, external OBC) and creates buckets
@@ -1104,6 +1110,8 @@ print_summary() {
     [[ "${DEPLOY_S4}" == "true" ]] && echo "  S4 Namespace:        ${S4_NAMESPACE}"
     [[ "${OPENSHIFT_VALUES_FILE}" != "openshift-values.yaml" ]] && echo "  Values File:         ${OPENSHIFT_VALUES_FILE}"
     echo "  Use Local Chart:     ${USE_LOCAL_CHART}"
+    [[ "${USE_HELM_DEVEL}" == "true" ]] && echo "  Include Pre-release: ${USE_HELM_DEVEL}"
+    [[ -n "${CHART_VERSION}" ]] && echo "  Chart Version:       ${CHART_VERSION}"
     echo ""
     log_info "Steps to execute:"
     [[ "${SKIP_RHBK}" == "false" ]] && echo "  ✓ Deploy Red Hat Build of Keycloak (RHBK)" || echo "  ✗ Deploy RHBK (SKIPPED)"
@@ -1188,6 +1196,14 @@ main() {
                 USE_LOCAL_CHART=true
                 shift
                 ;;
+            --devel)
+                USE_HELM_DEVEL=true
+                shift
+                ;;
+            --chart-version)
+                CHART_VERSION="$2"
+                shift 2
+                ;;
             --verbose)
                 VERBOSE=true
                 shift
@@ -1263,6 +1279,18 @@ main() {
                 ;;
         esac
     done
+
+    # Validate flag combinations
+    if [[ "${USE_LOCAL_CHART}" == "true" ]]; then
+        if [[ "${USE_HELM_DEVEL}" == "true" ]]; then
+            log_error "Cannot use --devel with --use-local-chart"
+            exit 1
+        fi
+        if [[ -n "${CHART_VERSION}" ]]; then
+            log_error "Cannot use --chart-version with --use-local-chart"
+            exit 1
+        fi
+    fi
 
     # In tests-only / skip-deploy mode, skip all deployment steps
     if [[ "${TESTS_ONLY}" == "true" ]]; then

--- a/scripts/install-helm-chart.sh
+++ b/scripts/install-helm-chart.sh
@@ -67,6 +67,7 @@ HELM_REPO_NAME="cost-onprem"
 HELM_REPO_URL="https://insights-onprem.github.io/cost-onprem-chart"
 CHART_VERSION=${CHART_VERSION:-}  # Empty = latest; set to pin a version (e.g., "0.2.9")
 USE_LOCAL_CHART=${USE_LOCAL_CHART:-false}  # Set to true to use local chart instead of Helm repository
+USE_HELM_DEVEL=${USE_HELM_DEVEL:-false}  # Set to true to include pre-release (rc) charts
 LOCAL_CHART_PATH=${LOCAL_CHART_PATH:-../cost-onprem}  # Path to local chart directory
 KAFKA_NAMESPACE=${KAFKA_NAMESPACE:-}  # If set, look for operator and Kafka cluster in this namespace
 
@@ -1159,6 +1160,12 @@ deploy_helm_chart() {
     if [ -n "$CHART_VERSION" ] && [ "$USE_LOCAL_CHART" != "true" ]; then
         helm_cmd="$helm_cmd --version \"$CHART_VERSION\""
         echo_info "Pinning chart version: $CHART_VERSION"
+    fi
+
+    # Include pre-release charts (e.g., rc versions) when --devel is enabled
+    if [ "$USE_HELM_DEVEL" = "true" ] && [ "$USE_LOCAL_CHART" != "true" ]; then
+        helm_cmd="$helm_cmd --devel"
+        echo_info "Including pre-release (--devel) charts"
     fi
 
     # Add values file if specified


### PR DESCRIPTION
- Add `--devel` flag to include pre-release (rc) charts in Helm installation
- Add `--chart-version` flag to pin specific Helm chart versions (e.g., `0.2.19`, `0.3.0-rc1`)
- Enables cleaner RC testing in CI without git checkout workaround

### Test plan

- [x] Verified `--devel --chart-version 0.2.20-rc4` correctly passes `--devel` and `--version` to Helm
- [x] Verified `--chart-version 0.2.19` deploys stable chart successfully
- [x] Verified flag validation rejects `--use-local-chart` combined with `--devel` or `--chart-version`
- [x] Verified CI compatibility - `e2e-commands.sh` already checks for `--devel` support and will use it automatically

### Changes

| File | Changes |
|------|---------|
| `scripts/deploy-test-cost-onprem.sh` | +28 lines - flag parsing, validation, exports, help text |
| `scripts/install-helm-chart.sh` | +7 lines - `USE_HELM_DEVEL` variable and `--devel` flag in helm command |

### Usage

```bash
# Install latest RC chart
./scripts/deploy-test-cost-onprem.sh --devel --namespace cost-onprem

# Install specific version
./scripts/deploy-test-cost-onprem.sh --chart-version 0.2.19 --namespace cost-onprem

# Install specific RC version
./scripts/deploy-test-cost-onprem.sh --devel --chart-version 0.2.20-rc4 --namespace cost-onprem
```