### PR TITLE
Fix recommend-tests workflow

### DIFF
--- a/.github/workflows/recommend-tests.yml
+++ b/.github/workflows/recommend-tests.yml
@@ -4,11 +4,15 @@
 # Only comments when changes map to extended/stable/full profiles.
 # Smoke-only changes (UI, init containers, auth proxy) are silent.
 # Uses [TEST-ADVISOR] prefix for idempotent comment updates.
+#
+# NOTE: Uses pull_request_target (not pull_request) to enable comment posting
+# on PRs from forks. This is safe because we only run scripts from the base
+# branch and only analyze the PR diff (no code execution from the PR).
 
 name: Recommend IQE Test Profile
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
       - 'cost-onprem/**'
@@ -27,15 +31,22 @@ jobs:
     timeout-minutes: 2
 
     steps:
-      - name: Checkout
+      - name: Checkout base branch
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Fetch PR head
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          echo "PR_HEAD_SHA=$(git rev-parse pr-head)" >> "$GITHUB_ENV"
 
       - name: Analyze diff
         id: analyze
         env:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ env.PR_HEAD_SHA }}
         run: ./scripts/qe/recommend-tests.sh
 
       - name: Comment recommendation

--- a/scripts/qe/recommend-tests.sh
+++ b/scripts/qe/recommend-tests.sh
@@ -320,10 +320,6 @@ if [[ "$max_profile" != "smoke" ]]; then
     needs_deeper="true"
 fi
 
-# TODO: TEMPORARY - force deeper testing to validate workflow fix (remove after testing)
-needs_deeper="true"
-max_profile="${max_profile:-extended}"
-
 output_var "suggested_profile" "$max_profile"
 output_var "needs_deeper_testing" "$needs_deeper"
 

--- a/scripts/qe/recommend-tests.sh
+++ b/scripts/qe/recommend-tests.sh
@@ -6,6 +6,10 @@
 #
 # Usage: BASE_BRANCH=main ./recommend-tests.sh
 #
+# Environment variables:
+#   BASE_BRANCH   - Branch to diff against (default: main)
+#   PR_HEAD_SHA   - PR head commit SHA (for pull_request_target workflows)
+#
 # Outputs (via GITHUB_OUTPUT if set):
 #   suggested_profile, component_table, needs_deeper_testing
 #
@@ -22,6 +26,8 @@ readonly DEFAULT_BASE_BRANCH="main"
 # Allow overrides via environment variables
 IMPACT_MAP="${IMPACT_MAP:-${DEFAULT_IMPACT_MAP}}"
 BASE_BRANCH="${BASE_BRANCH:-${DEFAULT_BASE_BRANCH}}"
+# PR_HEAD_SHA: when running under pull_request_target, this is the PR's head commit
+PR_HEAD="${PR_HEAD_SHA:-HEAD}"
 
 # --- Logging helpers -------------------------------------------------------
 
@@ -225,7 +231,7 @@ max_profile="smoke"
 component_rows=""
 has_component=false
 
-changed_files=$(git diff --name-only "${BASE_BRANCH}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+changed_files=$(git diff --name-only "${BASE_BRANCH}...${PR_HEAD}" 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
 
 if [[ -z "$changed_files" ]]; then
     info "No changed files detected"
@@ -237,7 +243,7 @@ fi
 # 1) Check values.yaml for image tag changes — look up each in components map
 #    Parse the diff hunk-by-hunk so each added tag: line binds to the
 #    repository: that appears in the same hunk context (not a global search).
-values_diff=$(git diff "${BASE_BRANCH}...HEAD" -- cost-onprem/values.yaml 2>/dev/null || echo "")
+values_diff=$(git diff "${BASE_BRANCH}...${PR_HEAD}" -- cost-onprem/values.yaml 2>/dev/null || echo "")
 
 if [[ -n "$values_diff" ]]; then
     # Extract (repository, tag) pairs from diff hunks:
@@ -313,6 +319,10 @@ needs_deeper="false"
 if [[ "$max_profile" != "smoke" ]]; then
     needs_deeper="true"
 fi
+
+# TODO: TEMPORARY - force deeper testing to validate workflow fix (remove after testing)
+needs_deeper="true"
+max_profile="${max_profile:-extended}"
 
 output_var "suggested_profile" "$max_profile"
 output_var "needs_deeper_testing" "$needs_deeper"

--- a/scripts/qe/test-impact-map.yaml
+++ b/scripts/qe/test-impact-map.yaml
@@ -86,10 +86,10 @@ paths:
     description: "Helm templates — affects all deployed resources"
 
   deploy-scripts:
-    pattern: "^scripts/(deploy|run-iqe)"
-    profile: extended
-    impact: medium
-    description: "Deployment/test scripts"
+    pattern: "^scripts/(deploy|install|run-iqe|run-pytest|setup)"
+    profile: smoke
+    impact: low
+    description: "Deployment and test scripts — smoke tests catch most breakage"
 
   values-structural:
     # Triggered by values.yaml changes to resource limits, replicas, or toggles


### PR DESCRIPTION
### Problems

- The GITHUB_TOKEN lacks write permissions on PRs from forks, causing the "Resource not accessible by integration" error when trying to post comments.
- Filter was too strict triggering recommendations of simple changes

### Solutions
#### Changed the workflow to use pull_request_target event and updated the diff analysis to work correctly:

##### recommend-tests.yml changes:

- Changed pull_request → pull_request_target (runs with base repo permissions)
- Added step to fetch PR head commit
- Pass PR_HEAD_SHA to the analysis script
##### recommend-tests.sh changes:
- Added PR_HEAD_SHA environment variable support
- Changed git diff commands to use ${PR_HEAD} instead of HEAD

#### Adjusted impact map to be less strict:
##### test-impact-map.yaml changes:

- deploy-scripts rule: Reduced from extended → smoke profile and medium → low impact
- Pattern broadened to include install, run-pytest, and setup scripts
- Rationale: Script changes (flag additions, help text, etc.) don't typically require deeper IQE testing — smoke tests catch most breakage. This prevents unnecessary test advisor comments on routine script PRs like #168.
- The test advisor will now only recommend deeper testing for high-impact changes: component image updates, Helm template changes, and resource/replica modifications.

**Security note:** This should be safe because the workflow only runs scripts from the base branch (not the PR) and only analyzes the git diff output without executing any code from the PR. If not deemed safe, we'll design another solution.

We can't test this fix without merging to main, but it should be benign, if not a solution for the problem.