### PR TITLE
Bump version to 0.2.20-rc5 and update ingress image

### DIFF
--- a/cost-onprem/Chart.yaml
+++ b/cost-onprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cost-onprem
 description: Cost Management On-Premise solution for OpenShift
 type: application
-version: 0.2.20-rc4
-appVersion: "0.2.20-rc4"
+version: 0.2.20-rc5
+appVersion: "0.2.20-rc5"
 
 keywords:
   - cost-management

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -497,8 +497,8 @@ kruize:
 # Uses insights-ingress-go which requires INGRESS_* prefixed environment variables
 ingress:
   image:
-    repository: quay.io/redhat-user-workloads/hcc-integrations-tenant/ingress
-    tag: "c979ae6"
+    repository: quay.io/iop/ingress
+    tag: "master"
     pullPolicy: IfNotPresent
 
   # Server configuration


### PR DESCRIPTION
## Summary
- Bump chart version and appVersion to 0.2.20-rc5
- Update ingress image repository from `hcc-integrations-tenant` to `iop/ingress`
- Change ingress image tag from `c979ae6` to `master`

## Test plan
- [ ] Verify chart version is correctly updated in Chart.yaml
- [ ] Confirm ingress image repository and tag changes in values.yaml
- [ ] Deploy chart and validate ingress component functionality
- [ ] Run integration tests to ensure compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)