### PR TITLE
test(rbac): gateway JWT, security boundaries, and lab Keycloak hardening

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,21 @@ class S3Config:
 
 
 @pytest.fixture(scope="session")
+def rbac_gateway_test_user_password() -> str:
+    """Password for synthetic RBAC gateway test users (Keycloak + password grant).
+
+    Uses ``RBAC_GATEWAY_TEST_USER_PASSWORD`` when set. Otherwise generates a
+    unique ephemeral secret per session (no hardcoded fallback on real clusters).
+    """
+    pw = os.environ.get("RBAC_GATEWAY_TEST_USER_PASSWORD", "").strip()
+    if pw:
+        return pw
+    import secrets
+
+    return secrets.token_urlsafe(24)
+
+
+@pytest.fixture(scope="session")
 def cluster_config() -> ClusterConfig:
     """Get cluster configuration from environment variables."""
     return ClusterConfig(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,15 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 _DEFAULT_ORG_ID = "org1234567"
 _DEFAULT_ACCOUNT_NUMBER = "7890123"
 
+# OAuth ``scope`` string for password grant. Do **not** include the literal token
+# ``roles`` here on many Keycloak builds: it is a *client scope name*, not an
+# OIDC scope, and triggers ``invalid_scope``. Realm roles still appear in JWTs
+# when the ``roles`` *client scope* is attached as a default scope on the UI
+# client (see ``ensure_password_grant_lab_users_with_org_admin``).
+OIDC_PASSWORD_GRANT_SCOPE = os.environ.get(
+    "OIDC_PASSWORD_GRANT_SCOPE", "openid profile email"
+)
+
 
 def decode_jwt_payload(access_token: str) -> dict:
     """Decode the payload section of a JWT without signature verification."""
@@ -338,6 +347,11 @@ def obtain_password_grant_token(
 
     Use for gateway calls where RBAC expects a normal ``User`` identity (not a
     service-account ``preferred_username``).
+
+    Sends ``OIDC_PASSWORD_GRANT_SCOPE`` when non-empty (default ``openid profile
+    email``). The ``roles`` Keycloak *client scope* must be a **default** scope on
+    ``cost-management-ui`` so ``realm_access.roles`` is populated; requesting
+    ``roles`` in the OAuth ``scope`` parameter often returns ``invalid_scope``.
     """
     ui_client_id = "cost-management-ui"
     ui_client_secret = get_secret_value(
@@ -348,15 +362,20 @@ def obtain_password_grant_token(
     if not ui_client_secret:
         pytest.fail("Could not find cost-management-ui client secret for password grant")
 
+    data: dict = {
+        "grant_type": "password",
+        "client_id": ui_client_id,
+        "client_secret": ui_client_secret,
+        "username": username,
+        "password": password,
+    }
+    _scope = OIDC_PASSWORD_GRANT_SCOPE.strip()
+    if _scope:
+        data["scope"] = _scope
+
     response = requests.post(
         keycloak_config.token_url,
-        data={
-            "grant_type": "password",
-            "client_id": ui_client_id,
-            "client_secret": ui_client_secret,
-            "username": username,
-            "password": password,
-        },
+        data=data,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         verify=False,
         timeout=30,
@@ -893,6 +912,39 @@ def org_id(cluster_config: ClusterConfig, keycloak_config: KeycloakConfig) -> st
         return _DEFAULT_ORG_ID
     except Exception:
         return _DEFAULT_ORG_ID
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _ensure_keycloak_password_grant_lab_users(
+    cluster_config: ClusterConfig,
+    keycloak_config: KeycloakConfig,
+    org_id: str,
+) -> None:
+    """Keep ``admin`` / ``viewer`` and the ``org-admin`` realm role aligned with tests.
+
+    Ephemeral lab clusters can drift (missing realm role on admin, wrong viewer
+    password). Provisioning runs once per session after ``org_id`` is resolved.
+    """
+    log = logging.getLogger(__name__)
+    try:
+        from rbac_keycloak_users import ensure_password_grant_lab_users_with_org_admin
+
+        ensure_password_grant_lab_users_with_org_admin(
+            keycloak_base_url=keycloak_config.url,
+            keycloak_namespace=cluster_config.keycloak_namespace,
+            realm=keycloak_config.realm,
+            org_id=org_id,
+            account_number=os.environ.get("TEST_ACCOUNT_NUMBER", _DEFAULT_ACCOUNT_NUMBER),
+            admin_username=os.environ.get("TEST_USERNAME", "admin"),
+            admin_password=os.environ.get("TEST_PASSWORD", "admin"),
+            viewer_username=os.environ.get("VIEWER_USERNAME", "viewer"),
+            viewer_password=os.environ.get("VIEWER_PASSWORD", "viewer"),
+        )
+    except Exception as exc:
+        log.warning(
+            "Keycloak lab user sync failed (org-admin / viewer tests may fail): %s",
+            exc,
+        )
 
 
 # =============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,17 +328,16 @@ def jwt_token(keycloak_config: KeycloakConfig) -> JWTToken:
     return obtain_jwt_token(keycloak_config)
 
 
-def obtain_user_jwt_token_for(
+def obtain_password_grant_token(
+    username: str,
+    password: str,
     keycloak_config: KeycloakConfig,
-    cluster_config,
-    username: str = "admin",
-    password: str = "admin",
+    cluster_config: ClusterConfig,
 ) -> JWTToken:
-    """Obtain a JWT token via password grant for the given user.
+    """Obtain a JWT via resource-owner password grant (confidential UI client).
 
-    The cost-management-operator SA token has a ``service-account-*`` username
-    that RBAC rejects with 400 ("Invalid format for a Service Account username").
-    API tests that go through the gateway must use a regular user token instead.
+    Use for gateway calls where RBAC expects a normal ``User`` identity (not a
+    service-account ``preferred_username``).
     """
     ui_client_id = "cost-management-ui"
     ui_client_secret = get_secret_value(
@@ -378,9 +377,29 @@ def obtain_user_jwt_token_for(
     )
 
 
+def obtain_user_jwt_token_for(
+    keycloak_config: KeycloakConfig,
+    cluster_config: ClusterConfig,
+    username: str = "admin",
+    password: str = "admin",
+) -> JWTToken:
+    """Obtain a JWT token via password grant for the given user."""
+    return obtain_password_grant_token(username, password, keycloak_config, cluster_config)
+
+
 def obtain_user_jwt_token(keycloak_config: KeycloakConfig, cluster_config) -> JWTToken:
-    """Obtain a JWT token via password grant for the admin user."""
-    return obtain_user_jwt_token_for(keycloak_config, cluster_config)
+    """Obtain a JWT token via password grant for the admin user.
+
+    The cost-management-operator SA token has a ``service-account-*`` username
+    that RBAC rejects with 400 ("Invalid format for a Service Account username").
+    API tests that go through the gateway must use a regular user token instead.
+    """
+    return obtain_password_grant_token(
+        os.environ.get("TEST_USERNAME", "admin"),
+        os.environ.get("TEST_PASSWORD", "admin"),
+        keycloak_config,
+        cluster_config,
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/e2e_helpers.py
+++ b/tests/e2e_helpers.py
@@ -465,6 +465,18 @@ def get_application_type_id(
     return None
 
 
+def _is_transient_rbac_dependency_error(response_body: str) -> bool:
+    """True when Koku returns 424 because RBAC was briefly unreachable (rollout, etc.)."""
+    lower = response_body.lower()
+    return (
+        "rbac unavailable" in lower
+        or "failed dependency" in lower
+        or "cost-onprem-rbac-api" in lower
+        or "connection refused" in lower
+        or "max retries exceeded" in lower
+    )
+
+
 def register_source(
     namespace: str,
     pod: str,
@@ -475,7 +487,7 @@ def register_source(
     source_name: Optional[str] = None,
     bucket: str = DEFAULT_S3_BUCKET,
     container: str = "ingress",
-    max_retries: int = 5,
+    max_retries: int = 8,
     initial_retry_delay: int = 5,
 ) -> SourceRegistration:
     """Register a source in Koku Sources API.
@@ -497,7 +509,7 @@ def register_source(
         source_name: Optional custom source name (defaults to e2e-source-{cluster_id[-8:]})
         bucket: S3 bucket name
         container: Container name in the pod (default: "ingress")
-        max_retries: Maximum number of retry attempts (default: 5)
+        max_retries: Maximum number of retry attempts (default: 8)
         initial_retry_delay: Initial delay between retries in seconds (default: 5)
     
     Returns:
@@ -565,7 +577,10 @@ def register_source(
             # 5xx errors might be transient, retry
             if http_code.startswith("5"):
                 continue
-            # 4xx errors are not retryable - break and fail
+            # 424 Failed Dependency (e.g. RBAC pod restarting) is transient in lab CI.
+            if http_code == "424" and _is_transient_rbac_dependency_error(result):
+                continue
+            # Other 4xx errors are not retryable - break and fail
             break
         
         try:

--- a/tests/jwt_forge.py
+++ b/tests/jwt_forge.py
@@ -1,0 +1,65 @@
+"""Forge JWTs with an ephemeral RSA key for gateway rejection tests.
+
+Envoy must reject these tokens (invalid signature and/or expired claims) before
+backend services run. Used by ``TestRBACSecurityBoundaries`` in
+``test_rbac_gateway.py``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jose import jwt
+
+_PRIVATE_KEY: Optional[Any] = None
+
+
+def _private_key():
+    global _PRIVATE_KEY
+    if _PRIVATE_KEY is None:
+        _PRIVATE_KEY = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend(),
+        )
+    return _PRIVATE_KEY
+
+
+def forge_jwt(claims: Dict[str, Any], *, algorithm: str = "RS256") -> str:
+    """Return a signed JWT that Keycloak did not issue."""
+    return jwt.encode(claims, _private_key(), algorithm=algorithm)
+
+
+def forge_expired_jwt(
+    *,
+    sub: str = "forge-expired",
+    org_id: str = "org1234567",
+    account_number: str = "7890123",
+    skew_seconds: int = 3600,
+) -> str:
+    """JWT with ``exp`` in the past."""
+    return forge_jwt(
+        {
+            "sub": sub,
+            "exp": int(time.time()) - skew_seconds,
+            "org_id": org_id,
+            "account_number": account_number,
+        }
+    )
+
+
+def forge_jwt_missing_sub(
+    *,
+    org_id: str = "org1234567",
+    ttl_seconds: int = 300,
+) -> str:
+    """JWT without ``sub`` (and without other required identity claims)."""
+    return forge_jwt(
+        {
+            "org_id": org_id,
+            "exp": int(time.time()) + ttl_seconds,
+        }
+    )

--- a/tests/rbac_bootstrap_scripts.py
+++ b/tests/rbac_bootstrap_scripts.py
@@ -229,3 +229,61 @@ except urllib.error.HTTPError as e:
 except Exception as e:
     print(f"DIAG KOKU-DIRECT: /cost-models/ error: {{e}}")
 """
+
+
+def render_rbac_iam_reader_bootstrap_script(org_id: str, username: str) -> str:
+    """Grant ``username`` a minimal insights-rbac IAM role (list groups).
+
+    Requires ``manage.py seeds`` to have created ``application=rbac`` permissions.
+    Executed inside the rbac-api pod via ``manage.py shell -c``.
+    """
+    return f"""
+from api.models import Tenant
+from management.models import Group, Policy, Role, Principal, Access, Permission
+from django.core.cache import cache
+
+org_id = {repr(org_id)}
+username = {repr(username)}
+public = Tenant.objects.get(tenant_name="public")
+tenant = Tenant.objects.get(org_id=org_id)
+
+perm = (
+    Permission.objects.filter(
+        application="rbac", resource_type="group", verb="read"
+    ).first()
+    or Permission.objects.filter(application="rbac").first()
+)
+if not perm:
+    raise SystemExit("no_rbac_permissions_seeded")
+
+role, _ = Role.objects.get_or_create(
+    name="Gateway RBAC IAM Reader",
+    tenant=public,
+    defaults={{
+        "description": "Chart test: RBAC IAM read for gateway tests",
+        "system": False,
+        "version": 2,
+    }},
+)
+Access.objects.get_or_create(role=role, permission=perm, tenant=public)
+
+grp, _ = Group.objects.get_or_create(
+    name="Gateway RBAC IAM Readers",
+    tenant=tenant,
+    defaults={{"description": "Chart gateway IAM test group"}},
+)
+pol, _ = Policy.objects.get_or_create(
+    name="Gateway RBAC IAM Readers Policy",
+    tenant=tenant,
+    group=grp,
+)
+pol.roles.clear()
+pol.roles.add(role)
+
+principal, _ = Principal.objects.get_or_create(
+    username=username, tenant=tenant, defaults={{"type": "user"}}
+)
+grp.principals.add(principal)
+cache.clear()
+print("gateway_rbac_iam_bootstrap_ok", perm.permission)
+"""

--- a/tests/rbac_bootstrap_scripts.py
+++ b/tests/rbac_bootstrap_scripts.py
@@ -289,3 +289,104 @@ grp.principals.add(principal)
 cache.clear()
 print("gateway_rbac_iam_bootstrap_ok", perm.permission)
 """
+
+
+def render_rbac_gateway_permission_revoke_script(username: str) -> str:
+    """Remove group bindings and sever platform-default RBAC IAM read paths.
+
+    On-prem RBAC grants ``rbac:principal:read`` via the platform-default group
+    ``Default access`` (role ``User Access principal viewer``), not only via
+    explicit group membership. Revoke removes membership, detaches those roles
+    from platform-default group policies, and clears ``role.platform_default``.
+    """
+    return f"""
+from management.models import Group, Policy, Principal, Role, Access
+from django.db.models import Q
+from django.core.cache import cache
+
+username = {repr(username)}
+
+rbac_iam_read = (
+    Q(
+        permission__application="rbac",
+        permission__resource_type="group",
+        permission__verb="read",
+    )
+    | Q(permission__permission="rbac:principal:read")
+    | Q(permission__permission="rbac:group:read")
+)
+
+principal = Principal.objects.filter(username=username).first()
+group_count = 0
+if principal:
+    for group in list(Group.objects.filter(principals=principal)):
+        group.principals.remove(principal)
+        group_count += 1
+else:
+    print("principal_not_found")
+
+detached = []
+for group in Group.objects.filter(platform_default=True):
+    for policy in Policy.objects.filter(group=group):
+        for role in list(policy.roles.all()):
+            if Access.objects.filter(role=role).filter(rbac_iam_read).exists():
+                policy.roles.remove(role)
+                detached.append(f"{{group.name}}:{{role.name}}")
+
+disabled = []
+for role in Role.objects.filter(platform_default=True).distinct():
+    if Access.objects.filter(role=role).filter(rbac_iam_read).exists():
+        role.platform_default = False
+        role.save(update_fields=["platform_default"])
+        disabled.append(role.name)
+
+cache.clear()
+print(
+    f"revoked: groups={{group_count}} detached={{detached}} "
+    f"disabled_platform_default={{disabled}}"
+)
+"""
+
+
+def render_rbac_gateway_permission_restore_script(org_id: str, username: str) -> str:
+    """Re-run IAM reader bootstrap and restore seeded platform-default RBAC IAM read."""
+    bootstrap = render_rbac_iam_reader_bootstrap_script(org_id, username)
+    return (
+        bootstrap
+        + """
+from management.models import Group, Policy, Role, Access
+from django.db.models import Q
+from django.core.cache import cache
+
+rbac_iam_read = (
+    Q(
+        permission__application="rbac",
+        permission__resource_type="group",
+        permission__verb="read",
+    )
+    | Q(permission__permission="rbac:principal:read")
+    | Q(permission__permission="rbac:group:read")
+)
+
+SEEDED_PLATFORM_DEFAULT_RBAC_ROLES = ("User Access principal viewer",)
+
+reattached = []
+for group in Group.objects.filter(platform_default=True):
+    for policy in Policy.objects.filter(group=group):
+        for role in Role.objects.filter(name__in=SEEDED_PLATFORM_DEFAULT_RBAC_ROLES):
+            if not Access.objects.filter(role=role).filter(rbac_iam_read).exists():
+                continue
+            policy.roles.add(role)
+            reattached.append(f"{group.name}:{role.name}")
+
+restored_flags = []
+for role in Role.objects.filter(name__in=SEEDED_PLATFORM_DEFAULT_RBAC_ROLES):
+    if not role.platform_default:
+        role.platform_default = True
+        role.save(update_fields=["platform_default"])
+        restored_flags.append(role.name)
+
+cache.clear()
+print(f"reattached={reattached} restored_platform_default={restored_flags}")
+"""
+    )

--- a/tests/rbac_bootstrap_scripts.py
+++ b/tests/rbac_bootstrap_scripts.py
@@ -232,10 +232,10 @@ except Exception as e:
 
 
 def render_rbac_iam_reader_bootstrap_script(org_id: str, username: str) -> str:
-    """Grant ``username`` a minimal insights-rbac IAM role (list groups).
+    """Grant ``username`` a minimal insights-rbac IAM role (read-only).
 
-    Requires ``manage.py seeds`` to have created ``application=rbac`` permissions.
-    Executed inside the rbac-api pod via ``manage.py shell -c``.
+    Prefer ``rbac:group:read`` when seeded; otherwise use ``rbac:principal:read``
+    (some on-prem RBAC images only ship wildcard + principal read).
     """
     return f"""
 from api.models import Tenant
@@ -247,14 +247,15 @@ username = {repr(username)}
 public = Tenant.objects.get(tenant_name="public")
 tenant = Tenant.objects.get(org_id=org_id)
 
-perm = (
-    Permission.objects.filter(
-        application="rbac", resource_type="group", verb="read"
-    ).first()
-    or Permission.objects.filter(application="rbac").first()
-)
+perm = Permission.objects.filter(
+    application="rbac", resource_type="group", verb="read"
+).first()
 if not perm:
-    raise SystemExit("no_rbac_permissions_seeded")
+    perm = Permission.objects.filter(
+        application="rbac", permission="rbac:principal:read"
+    ).first()
+if not perm:
+    raise SystemExit("no_rbac_iam_read_permission")
 
 role, _ = Role.objects.get_or_create(
     name="Gateway RBAC IAM Reader",
@@ -265,7 +266,8 @@ role, _ = Role.objects.get_or_create(
         "version": 2,
     }},
 )
-Access.objects.get_or_create(role=role, permission=perm, tenant=public)
+Access.objects.filter(role=role).delete()
+Access.objects.create(role=role, permission=perm, tenant=public)
 
 grp, _ = Group.objects.get_or_create(
     name="Gateway RBAC IAM Readers",

--- a/tests/rbac_keycloak_users.py
+++ b/tests/rbac_keycloak_users.py
@@ -183,3 +183,336 @@ def ensure_rbac_gateway_persona_users(
             account_number=account_number,
             email=f"{uname}@rbac-gateway.test",
         )
+
+
+def _get_or_create_realm_role(
+    base: str,
+    realm: str,
+    admin_token: str,
+    role_name: str,
+) -> dict:
+    """Return Keycloak realm role representation, creating a simple realm role if missing."""
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "Content-Type": "application/json",
+    }
+    r = requests.get(
+        f"{base}/admin/realms/{realm}/roles/{role_name}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        verify=False,
+        timeout=30,
+    )
+    if r.status_code == 200:
+        return r.json()
+    if r.status_code != 404:
+        raise RuntimeError(
+            f"Keycloak GET realm role {role_name!r} failed: {r.status_code} {r.text[:300]}"
+        )
+    cr = requests.post(
+        f"{base}/admin/realms/{realm}/roles",
+        json={"name": role_name, "description": "Realm role for cost-onprem chart tests"},
+        headers=headers,
+        verify=False,
+        timeout=30,
+    )
+    if cr.status_code not in (201, 204):
+        raise RuntimeError(
+            f"Keycloak create realm role {role_name!r} failed: {cr.status_code} {cr.text[:300]}"
+        )
+    r2 = requests.get(
+        f"{base}/admin/realms/{realm}/roles/{role_name}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        verify=False,
+        timeout=30,
+    )
+    if r2.status_code != 200:
+        raise RuntimeError(
+            f"Keycloak re-fetch realm role {role_name!r} failed: {r2.status_code} {r2.text[:300]}"
+        )
+    return r2.json()
+
+
+def _list_user_realm_roles(
+    base: str,
+    realm: str,
+    admin_token: str,
+    user_id: str,
+) -> list[dict]:
+    r = requests.get(
+        f"{base}/admin/realms/{realm}/users/{user_id}/role-mappings/realm",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        verify=False,
+        timeout=30,
+    )
+    if r.status_code != 200:
+        raise RuntimeError(
+            f"Keycloak list realm roles for user failed: {r.status_code} {r.text[:300]}"
+        )
+    return r.json()
+
+
+def _set_user_has_realm_role(
+    base: str,
+    realm: str,
+    admin_token: str,
+    user_id: str,
+    role_rep: dict,
+    want: bool,
+) -> None:
+    """Add or remove a single realm role on a user."""
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "Content-Type": "application/json",
+    }
+    body = [{"id": role_rep["id"], "name": role_rep["name"]}]
+    if want:
+        r = requests.post(
+            f"{base}/admin/realms/{realm}/users/{user_id}/role-mappings/realm",
+            json=body,
+            headers=headers,
+            verify=False,
+            timeout=30,
+        )
+        if r.status_code not in (204, 200):
+            raise RuntimeError(
+                f"Keycloak add realm role {role_rep['name']!r}: {r.status_code} {r.text[:300]}"
+            )
+        return
+    current = _list_user_realm_roles(base, realm, admin_token, user_id)
+    names = {x.get("name") for x in current}
+    if role_rep["name"] not in names:
+        return
+    r = requests.delete(
+        f"{base}/admin/realms/{realm}/users/{user_id}/role-mappings/realm",
+        json=body,
+        headers=headers,
+        verify=False,
+        timeout=30,
+    )
+    if r.status_code not in (204, 200):
+        raise RuntimeError(
+            f"Keycloak remove realm role {role_rep['name']!r}: {r.status_code} {r.text[:300]}"
+        )
+
+
+def _find_keycloak_ui_client_internal_id(
+    base: str,
+    realm: str,
+    admin_token: str,
+    ui_client_id: str,
+) -> tuple[Optional[str], str]:
+    """Return (internal UUID, diagnostic). internal UUID is None on failure."""
+    r = requests.get(
+        f"{base}/admin/realms/{realm}/clients",
+        params={"clientId": ui_client_id, "max": 1},
+        headers={"Authorization": f"Bearer {admin_token}"},
+        verify=False,
+        timeout=30,
+    )
+    if r.status_code != 200:
+        return None, (
+            f"GET /admin/realms/{realm}/clients?clientId={ui_client_id!r} "
+            f"→ HTTP {r.status_code}: {r.text[:400]!r}"
+        )
+    clients = r.json()
+    if not clients:
+        return None, (
+            f"GET clients returned 200 but empty list for clientId={ui_client_id!r} "
+            f"(realm={realm!r})"
+        )
+    cid = clients[0].get("id")
+    if not cid:
+        snippet = repr(clients[0])[:400]
+        return None, f"client record missing 'id': {snippet}"
+    return cid, "ok"
+
+
+def _find_roles_client_scope_id(
+    base: str,
+    realm: str,
+    admin_token: str,
+) -> tuple[Optional[str], str]:
+    """Return (scope internal id for name ``roles``, diagnostic)."""
+    r = requests.get(
+        f"{base}/admin/realms/{realm}/client-scopes",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        verify=False,
+        timeout=30,
+    )
+    if r.status_code != 200:
+        return None, (
+            f"GET /admin/realms/{realm}/client-scopes "
+            f"→ HTTP {r.status_code}: {r.text[:400]!r}"
+        )
+    rows = r.json()
+    names = sorted({row.get("name") for row in rows if row.get("name")})
+    for row in rows:
+        if row.get("name") == "roles":
+            sid = row.get("id")
+            if sid:
+                return sid, "ok"
+            return None, "client-scope named 'roles' exists but has no 'id' field"
+    hints = sorted(n for n in names if "role" in n.lower())[:30]
+    return None, (
+        f"no client-scope named exactly 'roles' (realm has {len(names)} scopes: {names!r}); "
+        f"names containing 'role' (case-insensitive, max 30): {hints!r}"
+    )
+
+
+def ensure_cost_management_ui_roles_default_client_scope(
+    keycloak_base_url: str,
+    realm: str,
+    admin_token: str,
+    ui_client_id: str = "cost-management-ui",
+) -> bool:
+    """Attach the realm ``roles`` *client scope* as a default scope on the UI client.
+
+    Password-grant tokens then include ``realm_access.roles`` without passing a
+    literal ``roles`` value in the OAuth ``scope`` query string (Keycloak often
+    rejects that with ``invalid_scope``).
+
+    Logs a distinct ``[Keycloak UI default scope 'roles']`` prefix on each outcome
+    so CI/lab logs show which Admin API step failed.
+    """
+    log_pfx = "[Keycloak UI default scope 'roles']"
+    base = keycloak_base_url.rstrip("/")
+
+    internal_id, diag = _find_keycloak_ui_client_internal_id(
+        base, realm, admin_token, ui_client_id,
+    )
+    if not internal_id:
+        logger.warning("%s resolve UI client %r → %s", log_pfx, ui_client_id, diag)
+        return False
+
+    roles_sid, diag = _find_roles_client_scope_id(base, realm, admin_token)
+    if not roles_sid:
+        logger.warning("%s resolve client-scope 'roles' → %s", log_pfx, diag)
+        return False
+
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    r = requests.get(
+        f"{base}/admin/realms/{realm}/clients/{internal_id}/default-client-scopes",
+        headers=headers,
+        verify=False,
+        timeout=30,
+    )
+    if r.status_code != 200:
+        logger.warning(
+            "%s GET default-client-scopes for client_uuid=%s → HTTP %s: %s",
+            log_pfx,
+            internal_id,
+            r.status_code,
+            repr(r.text[:400]) if r.text else "",
+        )
+        return False
+    current = r.json()
+    if any(s.get("id") == roles_sid for s in current):
+        linked = [s.get("name") for s in current if s.get("id") == roles_sid]
+        logger.info(
+            "%s already linked: clientId=%r client_uuid=%s scope=%r",
+            log_pfx,
+            ui_client_id,
+            internal_id,
+            linked[0] if linked else roles_sid,
+        )
+        return True
+
+    pr = requests.put(
+        f"{base}/admin/realms/{realm}/clients/{internal_id}/default-client-scopes/{roles_sid}",
+        headers=headers,
+        verify=False,
+        timeout=30,
+    )
+    if pr.status_code not in (200, 204):
+        logger.warning(
+            "%s PUT …/clients/%s/default-client-scopes/%s → HTTP %s: %s",
+            log_pfx,
+            internal_id,
+            roles_sid,
+            pr.status_code,
+            repr(pr.text[:400]) if pr.text else "",
+        )
+        return False
+    logger.info(
+        "%s linked scope 'roles' to clientId=%r client_uuid=%s",
+        log_pfx,
+        ui_client_id,
+        internal_id,
+    )
+    return True
+
+
+def ensure_password_grant_lab_users_with_org_admin(
+    *,
+    keycloak_base_url: str,
+    keycloak_namespace: str,
+    realm: str,
+    org_id: str,
+    account_number: str,
+    admin_username: str = "admin",
+    admin_password: str = "admin",
+    viewer_username: str = "viewer",
+    viewer_password: str = "viewer",
+) -> None:
+    """Ensure admin/viewer exist for UI password grant and org-admin realm role is correct.
+
+    Lab clusters sometimes lose Keycloak realm role mappings after restores or
+    partial installs. Tests expect ``admin`` to carry the ``org-admin`` realm role
+    and ``viewer`` to authenticate with password ``viewer`` without that role.
+    """
+    token = fetch_keycloak_master_admin_token(keycloak_base_url, keycloak_namespace)
+    if not token:
+        raise RuntimeError("Could not obtain Keycloak master admin token")
+
+    # Ensures JWT realm_access.roles for org-admin tests (see module docstring).
+    ensure_cost_management_ui_roles_default_client_scope(
+        keycloak_base_url, realm, token,
+    )
+
+    base = keycloak_base_url.rstrip("/")
+    admin_uid = _realm_user_id(base, realm, token, admin_username)
+    if admin_uid:
+        ur = requests.get(
+            f"{base}/admin/realms/{realm}/users/{admin_uid}",
+            headers={"Authorization": f"Bearer {token}"},
+            verify=False,
+            timeout=30,
+        )
+        if ur.status_code == 200:
+            attrs = ur.json().get("attributes") or {}
+            oid = (attrs.get("org_id") or [None])[0]
+            acct = (attrs.get("account_number") or [None])[0]
+            if oid:
+                org_id = oid
+            if acct:
+                account_number = acct
+
+    ensure_realm_user_with_password(
+        keycloak_base_url=keycloak_base_url,
+        realm=realm,
+        admin_token=token,
+        username=admin_username,
+        password=admin_password,
+        org_id=org_id,
+        account_number=account_number,
+        email=f"{admin_username}@cost-onprem-chart.test",
+    )
+    ensure_realm_user_with_password(
+        keycloak_base_url=keycloak_base_url,
+        realm=realm,
+        admin_token=token,
+        username=viewer_username,
+        password=viewer_password,
+        org_id=org_id,
+        account_number=account_number,
+        email=f"{viewer_username}@cost-onprem-chart.test",
+    )
+
+    admin_uid = _realm_user_id(base, realm, token, admin_username)
+    viewer_uid = _realm_user_id(base, realm, token, viewer_username)
+    if not admin_uid or not viewer_uid:
+        raise RuntimeError("Could not resolve Keycloak user ids after provisioning")
+
+    org_admin_role = _get_or_create_realm_role(base, realm, token, "org-admin")
+    _set_user_has_realm_role(base, realm, token, admin_uid, org_admin_role, want=True)
+    _set_user_has_realm_role(base, realm, token, viewer_uid, org_admin_role, want=False)

--- a/tests/rbac_keycloak_users.py
+++ b/tests/rbac_keycloak_users.py
@@ -1,0 +1,185 @@
+"""Keycloak Admin API helpers for RBAC-related tests.
+
+Creates ephemeral realm users that match RBAC principal names so JWTs
+obtained via password grant exercise the same Envoy → Koku/ROS path as real
+clients. Intended for CI / lab clusters only (see deploy-rhbk.sh).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+
+from utils import get_secret_value
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_keycloak_master_admin_token(
+    keycloak_base_url: str,
+    keycloak_namespace: str,
+) -> Optional[str]:
+    """Return a bearer token for the Keycloak master realm admin-cli user."""
+    admin_password = get_secret_value(
+        keycloak_namespace, "keycloak-initial-admin", "password"
+    )
+    admin_username = (
+        get_secret_value(keycloak_namespace, "keycloak-initial-admin", "username")
+        or "admin"
+    )
+    if not admin_password:
+        logger.warning("Keycloak initial-admin password secret not found")
+        return None
+
+    base = keycloak_base_url.rstrip("/")
+    resp = requests.post(
+        f"{base}/realms/master/protocol/openid-connect/token",
+        data={
+            "client_id": "admin-cli",
+            "grant_type": "password",
+            "username": admin_username,
+            "password": admin_password,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        verify=False,
+        timeout=30,
+    )
+    if resp.status_code != 200:
+        logger.warning(
+            "Master realm token failed: %s %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return None
+    return resp.json().get("access_token")
+
+
+def _realm_user_id(
+    base: str,
+    realm: str,
+    admin_token: str,
+    username: str,
+) -> Optional[str]:
+    r = requests.get(
+        f"{base}/admin/realms/{realm}/users",
+        params={"username": username, "exact": "true"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+        verify=False,
+        timeout=30,
+    )
+    if r.status_code != 200:
+        return None
+    users = r.json()
+    return users[0]["id"] if users else None
+
+
+def ensure_realm_user_with_password(
+    *,
+    keycloak_base_url: str,
+    realm: str,
+    admin_token: str,
+    username: str,
+    password: str,
+    org_id: str,
+    account_number: str,
+    email: str,
+) -> None:
+    """Create or update a realm user with org_id / account_number attributes."""
+    base = keycloak_base_url.rstrip("/")
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "Content-Type": "application/json",
+    }
+
+    user_id = _realm_user_id(base, realm, admin_token, username)
+    body = {
+        "username": username,
+        "enabled": True,
+        "email": email,
+        "emailVerified": True,
+        "attributes": {
+            "org_id": [org_id],
+            "account_number": [account_number],
+        },
+        "credentials": [
+            {"type": "password", "value": password, "temporary": False},
+        ],
+    }
+
+    if user_id:
+        put_body = {k: v for k, v in body.items() if k != "credentials"}
+        r = requests.put(
+            f"{base}/admin/realms/{realm}/users/{user_id}",
+            json=put_body,
+            headers=headers,
+            verify=False,
+            timeout=30,
+        )
+        if r.status_code not in (204, 200):
+            raise RuntimeError(
+                f"Keycloak PUT user {username} failed: {r.status_code} {r.text[:300]}"
+            )
+    else:
+        r = requests.post(
+            f"{base}/admin/realms/{realm}/users",
+            json=body,
+            headers=headers,
+            verify=False,
+            timeout=30,
+        )
+        if r.status_code not in (201, 204) and r.status_code != 409:
+            raise RuntimeError(
+                f"Keycloak POST user {username} failed: {r.status_code} {r.text[:300]}"
+            )
+
+    if not user_id:
+        user_id = _realm_user_id(base, realm, admin_token, username)
+    if not user_id:
+        raise RuntimeError(f"Could not resolve Keycloak user id for {username}")
+
+    pr = requests.put(
+        f"{base}/admin/realms/{realm}/users/{user_id}/reset-password",
+        json={"type": "password", "value": password, "temporary": False},
+        headers=headers,
+        verify=False,
+        timeout=30,
+    )
+    if pr.status_code not in (204, 200):
+        raise RuntimeError(
+            f"Keycloak reset-password for {username} failed: "
+            f"{pr.status_code} {pr.text[:300]}"
+        )
+
+
+def ensure_rbac_gateway_persona_users(
+    keycloak_base_url: str,
+    keycloak_namespace: str,
+    realm: str,
+    org_id: str,
+    account_number: str,
+    *,
+    password: str,
+    extra_users: Optional[list[str]] = None,
+) -> None:
+    """Provision Keycloak users whose usernames match RBAC E2E principals."""
+    token = fetch_keycloak_master_admin_token(keycloak_base_url, keycloak_namespace)
+    if not token:
+        raise RuntimeError("Could not obtain Keycloak master admin token")
+
+    users = ["alice", "bob", "carol", "nobody-unassigned"]
+    if extra_users:
+        users = list(dict.fromkeys(users + list(extra_users)))
+
+    for uname in users:
+        ensure_realm_user_with_password(
+            keycloak_base_url=keycloak_base_url,
+            realm=realm,
+            admin_token=token,
+            username=uname,
+            password=password,
+            org_id=org_id,
+            account_number=account_number,
+            email=f"{uname}@rbac-gateway.test",
+        )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,6 +8,10 @@ pytest-html>=4.0.0
 requests>=2.28.0
 urllib3>=1.26.0
 
+# JWT forging for gateway security-boundary tests (invalid signature / claims)
+python-jose[cryptography]>=3.3.0
+cryptography>=41.0.0
+
 # YAML parsing (for Helm chart validation)
 PyYAML>=6.0
 

--- a/tests/suites/auth/RBAC_SECURITY_TESTS.md
+++ b/tests/suites/auth/RBAC_SECURITY_TESTS.md
@@ -1,288 +1,78 @@
-# RBAC Security Boundary Tests
+# RBAC gateway tests
 
-**Added:** 2026-05-14  
-**Location:** `tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries`  
-**Purpose:** Validate security boundaries, fail-closed behavior, and tenant isolation for RBAC authorization
+**Module:** `tests/suites/auth/test_rbac_gateway.py`  
+**Markers:** `auth`, `integration`  
+**Flow:** Keycloak password grant → Envoy gateway → Koku / ROS / insights-rbac
 
----
-
-## Overview
-
-These tests complement the existing RBAC functional tests by focusing on **security boundaries** and **failure modes**. They validate that the system fails securely when components are unavailable, rejects malicious inputs, and prevents privilege escalation.
-
-### Philosophy: Fail-Closed > Fail-Open
-
-The most critical security property: **when authorization fails, deny access**. A 424 (Failed Dependency) is acceptable only if it denies data; returning 200 with data when RBAC is down is a P0 security bug.
+Complements `tests/suites/e2e/test_rbac_access.py` (in-cluster `X-Rh-Identity`).
 
 ---
 
-## Test Suite
+## Fixtures and setup
 
-### ✅ Implemented & Runnable
+| Fixture | Scope | Role |
+|---------|-------|------|
+| `rbac_gateway_test_user_password` | session | From `RBAC_GATEWAY_TEST_USER_PASSWORD`, or a random ephemeral secret per session (no hardcoded default) |
+| `_provision_gateway_nobody_user` | module | Keycloak `nobody-unassigned` |
+| `_provision_rbac_iam_reader_gateway` | module | Keycloak `rbac-iam-admin` + in-cluster IAM reader bootstrap |
+| `gateway_nobody_user_jwt` / `gateway_rbac_iam_user_jwt` | function | Password-grant JWTs |
 
-| Test | Priority | What It Validates |
-|------|----------|-------------------|
-| **test_rbac_service_unavailable_denies_access_fail_closed** | **P0** | When RBAC API is down (scaled to 0), authenticated requests MUST fail-closed (403/424/503), not return 200 with data |
-| **test_permission_revocation_honored_after_cache_clear** | **P1** | After removing user from RBAC group + cache clear, new tokens receive 403 (validates cache invalidation) |
-| **test_rbac_iam_reader_cannot_modify_own_permissions** | **P1** | Read-only IAM user cannot escalate by adding self to privileged groups (POST/PUT to groups must return 403) |
-| **test_concurrent_jwt_sessions_no_resource_exhaustion** | **P2** | 10 concurrent sessions for same user don't cause 500 errors (load handling) |
-| **test_rbac_cache_ttl_configuration_exists** | **P2** | RBAC deployment has `ACCESS_CACHE_ENABLED=true` (operational security check) |
-
-### ⚠️ Documented as `pytest.skip()` with TODO
-
-These tests document **expected behavior** but require infrastructure not available in current test environment:
-
-| Test | Priority | Blocker | Expected Behavior |
-|------|----------|---------|-------------------|
-| **test_expired_jwt_rejected** | **P1** | Requires JWT forging or 5+ min wait | Envoy MUST reject JWTs with `exp` claim in the past with 401 |
-| **test_jwt_without_required_claims_rejected** | **P1** | Requires JWT forging | Envoy MUST reject JWTs missing `org_id`, `account_number`, or `sub` claims with 401 |
-| **test_org_id_tenant_isolation_boundary_cases** | **P1** | Requires in-cluster pod or JWT forging | System MUST reject malicious `org_id` values (empty, SQL injection, overflow) |
+Helpers: `tests/jwt_forge.py` (forged JWTs for 401 tests), `tests/rbac_keycloak_users.py`.
 
 ---
 
-## Test Details
+## `TestRBACGateway`
 
-### 1. RBAC Service Failure (Fail-Closed) — **P0**
-
-**Test:** `test_rbac_service_unavailable_denies_access_fail_closed`
-
-**Scenario:**
-1. Scale RBAC API deployment to 0 replicas (simulate outage)
-2. Send authenticated request to `/cost-management/v1/reports/`
-3. Assert response is NOT 200 (fail-closed)
-4. Restore RBAC service
-
-**Critical Assertion:**
-```python
-assert response.status_code != 200, (
-    "SECURITY VIOLATION: RBAC service down but request succeeded. "
-    "This is fail-open behavior and exposes data without authz checks."
-)
-```
-
-**Why It Matters:**  
-If RBAC is unreachable, the system MUST deny access. A 200 response with data means fail-open → **tenant isolation breach**.
+| Test | Request | Auth | Expected |
+|------|---------|------|----------|
+| `test_gateway_openshift_costs_unauthenticated_returns_401` | `GET …/reports/openshift/costs/` | none | `401` |
+| `test_gateway_rbac_status_unauthenticated_returns_401` | `GET …/rbac/v1/status/` | none | `401` |
+| `test_gateway_openshift_costs_user_without_rbac_returns_403` | `GET …/reports/openshift/costs/` | `nobody-unassigned` | `403` or `424` |
+| `test_gateway_rbac_groups_unauthenticated_returns_401` | `GET …/rbac/v1/groups/` | none | `401` |
+| `test_gateway_rbac_groups_user_without_iam_returns_403` | `GET …/rbac/v1/groups/` | `nobody-unassigned` | `403` or `424` |
+| `test_gateway_rbac_principals_iam_reader_returns_200` | `GET …/rbac/v1/principals/` | `rbac-iam-admin` | `200` |
+| `test_gateway_rbac_groups_post_iam_reader_forbidden` | `POST …/rbac/v1/groups/` | `rbac-iam-admin` | `403` or `400` |
+| `test_gateway_ros_recommendations_unauthenticated_returns_401` | `GET …/recommendations/openshift` | none | `401` |
+| `test_gateway_ros_recommendations_user_without_rbac_returns_403` | `GET …/recommendations/openshift` | `nobody-unassigned` | `403` or `424` |
 
 ---
 
-### 2. Permission Revocation Propagation — **P1**
+## `test_rbac_migration_job_completed`
 
-**Test:** `test_permission_revocation_honored_after_cache_clear`
-
-**Scenario:**
-1. User has RBAC IAM read permissions (baseline: GET /principals/ → 200)
-2. Remove user from RBAC group via Django ORM + `cache.clear()`
-3. Obtain NEW JWT (old token might be cached)
-4. Assert GET /principals/ → 403
-
-**Why It Matters:**  
-Validates that permission changes propagate through cache layer. Without cache clear, changes take 5+ minutes (cache TTL).
+Helm `rbac-migration` Job `succeeded == 1` in the chart namespace (skips if missing).
 
 ---
 
-### 3. Privilege Escalation Prevention — **P1**
+## `TestRBACSecurityBoundaries`
 
-**Test:** `test_rbac_iam_reader_cannot_modify_own_permissions`
-
-**Scenario:**
-1. User has `rbac:group:read` (can list groups)
-2. Attempt POST `/rbac/v1/groups/{uuid}/principals/` to add self
-3. Assert 403 (forbidden)
-4. Attempt PUT `/rbac/v1/groups/{uuid}/` to modify group
-5. Assert 403
-
-**Why It Matters:**  
-Read-only IAM users must not escalate to admin by modifying group membership.
-
----
-
-### 4. Concurrent Sessions — **P2**
-
-**Test:** `test_concurrent_jwt_sessions_no_resource_exhaustion`
-
-**Scenario:**
-1. Generate 10 JWTs for same user
-2. Fire 10 concurrent requests to `/rbac/v1/principals/`
-3. Assert no 500 errors
-4. Assert ≥50% success rate (allows rate limiting)
-
-**Why It Matters:**  
-Users might have multiple active sessions (browser, mobile, CLI). System must handle without crashing.
+| Test | What it does | Assertions |
+|------|----------------|------------|
+| `test_rbac_service_unavailable_denies_access_fail_closed` | Scale `rbac-api` to 0, `GET` cost report, restore replicas | Not `200`; in `403`, `424`, `503`, `504` |
+| `test_expired_jwt_rejected` | Forged JWT with past `exp` | `401` on `GET …/status/` |
+| `test_jwt_without_required_claims_rejected` | Forged JWT without `sub` | `401` |
+| `test_org_id_tenant_isolation_boundary_cases` | Keycloak user per case with malicious `org_id` attribute, real password-grant JWT, `GET` cost report | Not `200`; status in expected set (`400`/`403`/`424`) — parametrized: `empty`, `overflow`, `path-traversal`, `sql-injection`, `wrong-tenant` |
+| `test_permission_revocation_honored_after_cache_clear` | Revoke IAM reader from groups, detach `rbac:principal:read` roles from platform-default groups (e.g. `Default access`), disable `role.platform_default`, `cache.clear()`, new token | `403` or `424`; **`finally`** re-runs IAM reader bootstrap and restores seeded platform-default IAM read |
+| `test_rbac_iam_reader_cannot_modify_own_permissions` | IAM reader `POST`/`PUT` on groups | `403`, `405`, or `400` |
+| `test_concurrent_jwt_sessions_no_resource_exhaustion` | 6 tokens, warm-up, 3 workers, staggered `GET`s | No `500`; **≥4** of 6 return `200` |
+| `test_rbac_cache_ttl_configuration_exists` | Read `rbac-api` deployment env | `ACCESS_CACHE_ENABLED=true` |
 
 ---
 
-### 5. RBAC Cache Configuration — **P2**
-
-**Test:** `test_rbac_cache_ttl_configuration_exists`
-
-**Checks:**
-- RBAC API deployment has `ACCESS_CACHE_ENABLED=true` env var
-- Documents cache TTL implications (5 min delay for permission changes)
-
-**Why It Matters:**  
-Operational awareness: revoked permissions take up to 5 minutes to propagate unless `cache.clear()` is called.
-
----
-
-## Tests Requiring Additional Infrastructure
-
-### Expired JWT Rejection — **P1** ⚠️
-
-**Current Status:** `pytest.skip()` with TODO
-
-**What's Needed:**
-- **Option A:** JWT forging library (python-jose + RSA key pair)
-- **Option B:** Keycloak test realm with 10s token lifetime
-- **Option C:** Wait 5+ minutes for production token to expire
-
-**Expected Behavior:**
-```python
-# JWT with exp=1609459200 (Jan 1, 2021)
-response = http_session.get(url, headers={"Authorization": f"Bearer {expired_jwt}"})
-assert response.status_code == 401
-```
-
-**Implementation Path:**
-```bash
-# Generate test RSA key
-openssl genrsa -out test-key.pem 2048
-
-# Forge JWT with past exp claim using python-jose
-from jose import jwt
-token = jwt.encode(
-    {"sub": "test", "exp": 1609459200},  # 2021
-    open("test-key.pem").read(),
-    algorithm="RS256"
-)
-```
-
----
-
-### JWT Claim Validation — **P1** ⚠️
-
-**Current Status:** `pytest.skip()` with TODO
-
-**What's Needed:** Forge JWTs missing required claims
-
-**Expected Behavior:**
-```python
-# JWT without org_id claim
-jwt_no_org = forge_jwt({"sub": "test", "account_number": "123"})
-response = http_session.get(url, headers={"Authorization": f"Bearer {jwt_no_org}"})
-assert response.status_code == 401  # Envoy Lua filter rejects
-```
-
----
-
-### org_id Boundary Cases — **P1** ⚠️
-
-**Current Status:** Parametrized test with `pytest.skip()` for each case
-
-**Malicious Inputs Tested:**
-1. Empty string: `org_id=""`
-2. Integer overflow: `org_id="999999999999999999999999"`
-3. Path traversal: `org_id="../../../etc/passwd"`
-4. SQL injection: `org_id="1' OR '1'='1"`
-5. Wrong tenant: `org_id="other-tenant-org-id"`
-
-**What's Needed:**
-- **Option A:** In-cluster pod that can POST to Koku with crafted `X-Rh-Identity` header (bypass Envoy)
-- **Option B:** Forge JWTs with malicious `org_id` claims
-
-**Expected Behavior:** All variants MUST return 400/403 (validation/authz failure), never 200.
-
-**Implementation Path:**
-```python
-# In-cluster approach (bypasses Envoy JWT validation)
-koku_url = "http://cost-onprem-api.cost-onprem.svc.cluster.local:8000"
-malicious_identity = base64.b64encode(json.dumps({
-    "org_id": "1' OR '1'='1",  # SQL injection attempt
-    "identity": {"account_number": "123", "type": "User", "user": {...}}
-}).encode()).decode()
-
-response = requests.get(
-    f"{koku_url}/api/cost-management/v1/reports/openshift/costs/",
-    headers={"X-Rh-Identity": malicious_identity}
-)
-assert response.status_code in (400, 403), "System must reject malicious org_id"
-```
-
----
-
-## Running the Tests
+## Running
 
 ```bash
-# Run all security boundary tests
+pytest tests/suites/auth/test_rbac_gateway.py -v
 pytest tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries -v
-
-# Run specific test
-pytest tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries::test_rbac_service_unavailable_denies_access_fail_closed -v
-
-# Run only implemented tests (skip TODOs)
-pytest tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries -v -k "not expired and not org_id and not jwt_without"
 ```
 
----
-
-## Coverage Gap Analysis
-
-| Security Boundary | Tested | Priority | Blocker |
-|-------------------|--------|----------|---------|
-| **Fail-closed on RBAC outage** | ✅ | P0 | None |
-| **Permission revocation** | ✅ | P1 | None |
-| **Privilege escalation** | ✅ | P1 | None |
-| **Concurrent sessions** | ✅ | P2 | None |
-| **Cache configuration** | ✅ | P2 | None |
-| **Expired JWT** | ⚠️ TODO | P1 | JWT forging |
-| **Missing JWT claims** | ⚠️ TODO | P1 | JWT forging |
-| **Malicious org_id** | ⚠️ TODO | P1 | In-cluster pod or JWT forging |
-| **Token refresh** | ❌ | P2 | Not implemented |
-| **Rate limiting** | ❌ | P2 | Not implemented |
-| **RBAC DB timeout** | ❌ | P2 | Not implemented |
+Requires deployed chart, Keycloak (`deploy-rhbk.sh` with `roles` client scope on `cost-management-ui`), `python-jose[cryptography]` from `tests/requirements.txt`, and `oc` (cluster-admin for fail-closed scale test).
 
 ---
 
-## Next Steps
+## Related code
 
-### Short Term (This Sprint)
-
-1. **Run implemented tests in CI** — verify fail-closed behavior on real cluster
-2. **Add JWT forging helper** — use python-jose to forge tokens for exp/claim tests
-3. **Create in-cluster test pod** — kubectl exec to test direct Koku access with crafted identities
-
-### Medium Term (Next Sprint)
-
-4. **Implement org_id boundary tests** — validate SQL injection prevention
-5. **Add rate limiting tests** — 100 req/s to unauthenticated endpoints
-6. **RBAC DB failure simulation** — test timeout/circuit breaker behavior
-
-### Long Term (Backlog)
-
-7. **Token refresh flow** — validate rotation without service interruption
-8. **Load testing** — 1000 concurrent users, measure RBAC latency
-9. **Chaos engineering** — random RBAC pod kills during active requests
-
----
-
-## References
-
-- **Original Analysis:** Senior QE persona review (2026-05-14)
-- **PR Context:** [#146 - RBAC v1 integration](https://github.com/insights-onprem/cost-onprem-chart/pull/146)
-- **RBAC Docs:** `docs/operations/rbac-setup.md`
-- **Related Tests:** `tests/suites/e2e/test_rbac_access.py` (persona-based data isolation)
-
----
-
-## Key Findings Summary
-
-**Strengths:**
-- ✅ Fail-closed behavior validated
-- ✅ Permission revocation tested end-to-end
-- ✅ Privilege escalation prevented
-
-**Critical Gaps (Require Infrastructure):**
-- ⚠️ Expired JWT handling (needs forging)
-- ⚠️ Malicious claim validation (needs forging)
-- ⚠️ org_id tenant isolation (needs in-cluster pod)
-
-**Recommendation:** Merge implemented tests now. Create follow-up tickets for JWT forging infrastructure and in-cluster test pod setup.
+| Path | Purpose |
+|------|---------|
+| `tests/jwt_forge.py` | `forge_jwt`, `forge_expired_jwt`, `forge_jwt_missing_sub` |
+| `tests/rbac_keycloak_users.py` | Keycloak Admin API helpers |
+| `tests/suites/e2e/test_rbac_access.py` | Persona isolation (in-cluster + gateway JWT) |

--- a/tests/suites/auth/RBAC_SECURITY_TESTS.md
+++ b/tests/suites/auth/RBAC_SECURITY_TESTS.md
@@ -1,0 +1,288 @@
+# RBAC Security Boundary Tests
+
+**Added:** 2026-05-14  
+**Location:** `tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries`  
+**Purpose:** Validate security boundaries, fail-closed behavior, and tenant isolation for RBAC authorization
+
+---
+
+## Overview
+
+These tests complement the existing RBAC functional tests by focusing on **security boundaries** and **failure modes**. They validate that the system fails securely when components are unavailable, rejects malicious inputs, and prevents privilege escalation.
+
+### Philosophy: Fail-Closed > Fail-Open
+
+The most critical security property: **when authorization fails, deny access**. A 424 (Failed Dependency) is acceptable only if it denies data; returning 200 with data when RBAC is down is a P0 security bug.
+
+---
+
+## Test Suite
+
+### ✅ Implemented & Runnable
+
+| Test | Priority | What It Validates |
+|------|----------|-------------------|
+| **test_rbac_service_unavailable_denies_access_fail_closed** | **P0** | When RBAC API is down (scaled to 0), authenticated requests MUST fail-closed (403/424/503), not return 200 with data |
+| **test_permission_revocation_honored_after_cache_clear** | **P1** | After removing user from RBAC group + cache clear, new tokens receive 403 (validates cache invalidation) |
+| **test_rbac_iam_reader_cannot_modify_own_permissions** | **P1** | Read-only IAM user cannot escalate by adding self to privileged groups (POST/PUT to groups must return 403) |
+| **test_concurrent_jwt_sessions_no_resource_exhaustion** | **P2** | 10 concurrent sessions for same user don't cause 500 errors (load handling) |
+| **test_rbac_cache_ttl_configuration_exists** | **P2** | RBAC deployment has `ACCESS_CACHE_ENABLED=true` (operational security check) |
+
+### ⚠️ Documented as `pytest.skip()` with TODO
+
+These tests document **expected behavior** but require infrastructure not available in current test environment:
+
+| Test | Priority | Blocker | Expected Behavior |
+|------|----------|---------|-------------------|
+| **test_expired_jwt_rejected** | **P1** | Requires JWT forging or 5+ min wait | Envoy MUST reject JWTs with `exp` claim in the past with 401 |
+| **test_jwt_without_required_claims_rejected** | **P1** | Requires JWT forging | Envoy MUST reject JWTs missing `org_id`, `account_number`, or `sub` claims with 401 |
+| **test_org_id_tenant_isolation_boundary_cases** | **P1** | Requires in-cluster pod or JWT forging | System MUST reject malicious `org_id` values (empty, SQL injection, overflow) |
+
+---
+
+## Test Details
+
+### 1. RBAC Service Failure (Fail-Closed) — **P0**
+
+**Test:** `test_rbac_service_unavailable_denies_access_fail_closed`
+
+**Scenario:**
+1. Scale RBAC API deployment to 0 replicas (simulate outage)
+2. Send authenticated request to `/cost-management/v1/reports/`
+3. Assert response is NOT 200 (fail-closed)
+4. Restore RBAC service
+
+**Critical Assertion:**
+```python
+assert response.status_code != 200, (
+    "SECURITY VIOLATION: RBAC service down but request succeeded. "
+    "This is fail-open behavior and exposes data without authz checks."
+)
+```
+
+**Why It Matters:**  
+If RBAC is unreachable, the system MUST deny access. A 200 response with data means fail-open → **tenant isolation breach**.
+
+---
+
+### 2. Permission Revocation Propagation — **P1**
+
+**Test:** `test_permission_revocation_honored_after_cache_clear`
+
+**Scenario:**
+1. User has RBAC IAM read permissions (baseline: GET /principals/ → 200)
+2. Remove user from RBAC group via Django ORM + `cache.clear()`
+3. Obtain NEW JWT (old token might be cached)
+4. Assert GET /principals/ → 403
+
+**Why It Matters:**  
+Validates that permission changes propagate through cache layer. Without cache clear, changes take 5+ minutes (cache TTL).
+
+---
+
+### 3. Privilege Escalation Prevention — **P1**
+
+**Test:** `test_rbac_iam_reader_cannot_modify_own_permissions`
+
+**Scenario:**
+1. User has `rbac:group:read` (can list groups)
+2. Attempt POST `/rbac/v1/groups/{uuid}/principals/` to add self
+3. Assert 403 (forbidden)
+4. Attempt PUT `/rbac/v1/groups/{uuid}/` to modify group
+5. Assert 403
+
+**Why It Matters:**  
+Read-only IAM users must not escalate to admin by modifying group membership.
+
+---
+
+### 4. Concurrent Sessions — **P2**
+
+**Test:** `test_concurrent_jwt_sessions_no_resource_exhaustion`
+
+**Scenario:**
+1. Generate 10 JWTs for same user
+2. Fire 10 concurrent requests to `/rbac/v1/principals/`
+3. Assert no 500 errors
+4. Assert ≥50% success rate (allows rate limiting)
+
+**Why It Matters:**  
+Users might have multiple active sessions (browser, mobile, CLI). System must handle without crashing.
+
+---
+
+### 5. RBAC Cache Configuration — **P2**
+
+**Test:** `test_rbac_cache_ttl_configuration_exists`
+
+**Checks:**
+- RBAC API deployment has `ACCESS_CACHE_ENABLED=true` env var
+- Documents cache TTL implications (5 min delay for permission changes)
+
+**Why It Matters:**  
+Operational awareness: revoked permissions take up to 5 minutes to propagate unless `cache.clear()` is called.
+
+---
+
+## Tests Requiring Additional Infrastructure
+
+### Expired JWT Rejection — **P1** ⚠️
+
+**Current Status:** `pytest.skip()` with TODO
+
+**What's Needed:**
+- **Option A:** JWT forging library (python-jose + RSA key pair)
+- **Option B:** Keycloak test realm with 10s token lifetime
+- **Option C:** Wait 5+ minutes for production token to expire
+
+**Expected Behavior:**
+```python
+# JWT with exp=1609459200 (Jan 1, 2021)
+response = http_session.get(url, headers={"Authorization": f"Bearer {expired_jwt}"})
+assert response.status_code == 401
+```
+
+**Implementation Path:**
+```bash
+# Generate test RSA key
+openssl genrsa -out test-key.pem 2048
+
+# Forge JWT with past exp claim using python-jose
+from jose import jwt
+token = jwt.encode(
+    {"sub": "test", "exp": 1609459200},  # 2021
+    open("test-key.pem").read(),
+    algorithm="RS256"
+)
+```
+
+---
+
+### JWT Claim Validation — **P1** ⚠️
+
+**Current Status:** `pytest.skip()` with TODO
+
+**What's Needed:** Forge JWTs missing required claims
+
+**Expected Behavior:**
+```python
+# JWT without org_id claim
+jwt_no_org = forge_jwt({"sub": "test", "account_number": "123"})
+response = http_session.get(url, headers={"Authorization": f"Bearer {jwt_no_org}"})
+assert response.status_code == 401  # Envoy Lua filter rejects
+```
+
+---
+
+### org_id Boundary Cases — **P1** ⚠️
+
+**Current Status:** Parametrized test with `pytest.skip()` for each case
+
+**Malicious Inputs Tested:**
+1. Empty string: `org_id=""`
+2. Integer overflow: `org_id="999999999999999999999999"`
+3. Path traversal: `org_id="../../../etc/passwd"`
+4. SQL injection: `org_id="1' OR '1'='1"`
+5. Wrong tenant: `org_id="other-tenant-org-id"`
+
+**What's Needed:**
+- **Option A:** In-cluster pod that can POST to Koku with crafted `X-Rh-Identity` header (bypass Envoy)
+- **Option B:** Forge JWTs with malicious `org_id` claims
+
+**Expected Behavior:** All variants MUST return 400/403 (validation/authz failure), never 200.
+
+**Implementation Path:**
+```python
+# In-cluster approach (bypasses Envoy JWT validation)
+koku_url = "http://cost-onprem-api.cost-onprem.svc.cluster.local:8000"
+malicious_identity = base64.b64encode(json.dumps({
+    "org_id": "1' OR '1'='1",  # SQL injection attempt
+    "identity": {"account_number": "123", "type": "User", "user": {...}}
+}).encode()).decode()
+
+response = requests.get(
+    f"{koku_url}/api/cost-management/v1/reports/openshift/costs/",
+    headers={"X-Rh-Identity": malicious_identity}
+)
+assert response.status_code in (400, 403), "System must reject malicious org_id"
+```
+
+---
+
+## Running the Tests
+
+```bash
+# Run all security boundary tests
+pytest tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries -v
+
+# Run specific test
+pytest tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries::test_rbac_service_unavailable_denies_access_fail_closed -v
+
+# Run only implemented tests (skip TODOs)
+pytest tests/suites/auth/test_rbac_gateway.py::TestRBACSecurityBoundaries -v -k "not expired and not org_id and not jwt_without"
+```
+
+---
+
+## Coverage Gap Analysis
+
+| Security Boundary | Tested | Priority | Blocker |
+|-------------------|--------|----------|---------|
+| **Fail-closed on RBAC outage** | ✅ | P0 | None |
+| **Permission revocation** | ✅ | P1 | None |
+| **Privilege escalation** | ✅ | P1 | None |
+| **Concurrent sessions** | ✅ | P2 | None |
+| **Cache configuration** | ✅ | P2 | None |
+| **Expired JWT** | ⚠️ TODO | P1 | JWT forging |
+| **Missing JWT claims** | ⚠️ TODO | P1 | JWT forging |
+| **Malicious org_id** | ⚠️ TODO | P1 | In-cluster pod or JWT forging |
+| **Token refresh** | ❌ | P2 | Not implemented |
+| **Rate limiting** | ❌ | P2 | Not implemented |
+| **RBAC DB timeout** | ❌ | P2 | Not implemented |
+
+---
+
+## Next Steps
+
+### Short Term (This Sprint)
+
+1. **Run implemented tests in CI** — verify fail-closed behavior on real cluster
+2. **Add JWT forging helper** — use python-jose to forge tokens for exp/claim tests
+3. **Create in-cluster test pod** — kubectl exec to test direct Koku access with crafted identities
+
+### Medium Term (Next Sprint)
+
+4. **Implement org_id boundary tests** — validate SQL injection prevention
+5. **Add rate limiting tests** — 100 req/s to unauthenticated endpoints
+6. **RBAC DB failure simulation** — test timeout/circuit breaker behavior
+
+### Long Term (Backlog)
+
+7. **Token refresh flow** — validate rotation without service interruption
+8. **Load testing** — 1000 concurrent users, measure RBAC latency
+9. **Chaos engineering** — random RBAC pod kills during active requests
+
+---
+
+## References
+
+- **Original Analysis:** Senior QE persona review (2026-05-14)
+- **PR Context:** [#146 - RBAC v1 integration](https://github.com/insights-onprem/cost-onprem-chart/pull/146)
+- **RBAC Docs:** `docs/operations/rbac-setup.md`
+- **Related Tests:** `tests/suites/e2e/test_rbac_access.py` (persona-based data isolation)
+
+---
+
+## Key Findings Summary
+
+**Strengths:**
+- ✅ Fail-closed behavior validated
+- ✅ Permission revocation tested end-to-end
+- ✅ Privilege escalation prevented
+
+**Critical Gaps (Require Infrastructure):**
+- ⚠️ Expired JWT handling (needs forging)
+- ⚠️ Malicious claim validation (needs forging)
+- ⚠️ org_id tenant isolation (needs in-cluster pod)
+
+**Recommendation:** Merge implemented tests now. Create follow-up tickets for JWT forging infrastructure and in-cluster test pod setup.

--- a/tests/suites/auth/test_rbac_gateway.py
+++ b/tests/suites/auth/test_rbac_gateway.py
@@ -87,7 +87,7 @@ def _provision_rbac_iam_reader_gateway(
     org_id: str,
     rbac_gateway_test_user_password: str,
 ):
-    """Keycloak user + RBAC group binding with minimal ``rbac:group:read`` (or first rbac perm)."""
+    """Keycloak user + RBAC group binding with read-only rbac IAM (group or principal read)."""
     admin_token = fetch_keycloak_master_admin_token(
         keycloak_config.url,
         cluster_config.keycloak_namespace,
@@ -129,7 +129,7 @@ def _provision_rbac_iam_reader_gateway(
         timeout=120,
     )
     out = (result.stdout or "") + (result.stderr or "")
-    if result.returncode != 0 or "no_rbac_permissions_seeded" in out:
+    if result.returncode != 0 or "no_rbac_iam_read_permission" in out:
         pytest.skip(
             f"RBAC IAM bootstrap skipped (returncode={result.returncode}): {out[:600]}"
         )
@@ -242,17 +242,17 @@ class TestRBACGateway:
             f"got {response.status_code}: {response.text[:300]}"
         )
 
-    def test_gateway_rbac_groups_iam_reader_returns_200(
+    def test_gateway_rbac_principals_iam_reader_returns_200(
         self,
         gateway_url: str,
         http_session: requests.Session,
         gateway_rbac_iam_user_jwt,
     ):
-        """User with ``rbac:group:read`` (or equivalent) can list groups via gateway."""
+        """User with minimal ``rbac`` read permission can list principals via gateway."""
         if not _check_gateway_reachable(gateway_url, http_session):
             pytest.skip("Gateway service not available")
 
-        url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/?limit=5"
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/principals/?limit=5"
         response = http_session.get(
             url,
             headers=gateway_rbac_iam_user_jwt.authorization_header,
@@ -260,12 +260,12 @@ class TestRBACGateway:
             verify=False,
         )
         assert response.status_code == 200, (
-            f"Expected 200 listing groups with IAM read role, "
+            f"Expected 200 listing principals with IAM read role, "
             f"got {response.status_code}: {response.text[:400]}"
         )
         payload = response.json()
         assert "data" in payload or "meta" in payload, (
-            f"Unexpected RBAC groups JSON shape: {list(payload.keys())[:10]}"
+            f"Unexpected RBAC principals JSON shape: {list(payload.keys())[:10]}"
         )
 
     def test_gateway_rbac_groups_post_iam_reader_forbidden(

--- a/tests/suites/auth/test_rbac_gateway.py
+++ b/tests/suites/auth/test_rbac_gateway.py
@@ -355,3 +355,587 @@ def test_rbac_migration_job_completed(cluster_config):
     assert status.get("succeeded") == 1, (
         f"Expected rbac-migration job succeeded=1, got: {json.dumps(status)[:800]}"
     )
+
+
+@pytest.mark.auth
+@pytest.mark.integration
+class TestRBACSecurityBoundaries:
+    """Security boundary tests for RBAC authorization enforcement.
+
+    These tests validate fail-closed behavior, token validation, and tenant
+    isolation to prevent authorization bypass and data leakage.
+    """
+
+    def test_rbac_service_unavailable_denies_access_fail_closed(
+        self,
+        cluster_config,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_rbac_iam_user_jwt,
+    ):
+        """CRITICAL: When RBAC API is down, requests MUST fail-closed (deny access).
+
+        This validates that the system fails securely when the authorization
+        backend is unreachable. A 424 (Failed Dependency) or 503 is acceptable
+        only if it denies data access. A 200 with data would be a P0 security bug.
+        """
+        from utils import run_oc_command
+
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        # Scale RBAC deployment to 0 to simulate service outage
+        scale_result = run_oc_command(
+            [
+                "scale",
+                "deployment",
+                "-n",
+                cluster_config.namespace,
+                "-l",
+                "app.kubernetes.io/component=rbac-api",
+                "--replicas=0",
+            ],
+            check=False,
+        )
+        if scale_result.returncode != 0:
+            pytest.skip(f"Could not scale RBAC deployment: {scale_result.stderr}")
+
+        try:
+            # Wait for pods to terminate
+            import time
+            time.sleep(10)
+
+            # Attempt authenticated request - should fail-closed
+            url = f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
+            response = http_session.get(
+                url,
+                headers=gateway_rbac_iam_user_jwt.authorization_header,
+                timeout=60,
+                verify=False,
+            )
+
+            # CRITICAL: Must NOT return 200 with data
+            assert response.status_code != 200, (
+                f"SECURITY VIOLATION: RBAC service down but request succeeded "
+                f"with status {response.status_code}. This is fail-open behavior "
+                f"and exposes data without authorization checks. Response: {response.text[:400]}"
+            )
+
+            # Expected: 424 (Failed Dependency), 503 (Service Unavailable), or 403 (Forbidden)
+            assert response.status_code in (403, 424, 503, 504), (
+                f"Expected fail-closed response (403/424/503/504) when RBAC down, "
+                f"got {response.status_code}: {response.text[:300]}"
+            )
+
+        finally:
+            # Restore RBAC service
+            run_oc_command(
+                [
+                    "scale",
+                    "deployment",
+                    "-n",
+                    cluster_config.namespace,
+                    "-l",
+                    "app.kubernetes.io/component=rbac-api",
+                    "--replicas=1",
+                ],
+                check=False,
+            )
+            # Wait for RBAC to be ready again
+            import time
+            time.sleep(15)
+
+    def test_expired_jwt_rejected(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        keycloak_config,
+        cluster_config,
+        rbac_gateway_test_user_password: str,
+        _provision_rbac_iam_reader_gateway,
+    ):
+        """Expired JWTs (exp claim in the past) MUST be rejected with 401.
+
+        Tests that the gateway enforces JWT expiration to prevent session
+        hijacking with stale credentials.
+        """
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        # Obtain a fresh token first
+        fresh_token = obtain_password_grant_token(
+            RBAC_IAM_GATEWAY_USERNAME,
+            rbac_gateway_test_user_password,
+            keycloak_config,
+            cluster_config,
+        )
+
+        # Extract token parts and decode payload to check structure
+        import base64
+        token_parts = fresh_token.access_token.split(".")
+        if len(token_parts) != 3:
+            pytest.skip("JWT not in expected 3-part format")
+
+        # Decode payload (add padding if needed)
+        payload_b64 = token_parts[1]
+        padding = 4 - len(payload_b64) % 4
+        if padding != 4:
+            payload_b64 += "=" * padding
+
+        try:
+            payload_json = base64.urlsafe_b64decode(payload_b64)
+            payload = json.loads(payload_json)
+        except Exception as e:
+            pytest.skip(f"Could not decode JWT payload: {e}")
+
+        # Check if token has expiration
+        if "exp" not in payload:
+            pytest.skip("JWT does not contain exp claim")
+
+        # Create an expired token by requesting with very short lifetime
+        # (We can't forge tokens, so we wait for a short-lived one to expire)
+        # Alternative: Test that a token created yesterday fails
+        # For this test, we'll verify the gateway checks exp by using the token
+        # after waiting for it to expire
+
+        # Most Keycloak configs have 5min token lifetime - we can't wait that long
+        # Instead, verify the Envoy config would reject expired tokens by
+        # checking the current token is accepted, then document the expected behavior
+
+        url = f"{gateway_url.rstrip('/')}/cost-management/v1/status/"
+
+        # First verify fresh token works
+        response_fresh = http_session.get(
+            url,
+            headers=fresh_token.authorization_header,
+            timeout=30,
+            verify=False,
+        )
+        assert response_fresh.status_code == 200, (
+            f"Fresh token should work, got {response_fresh.status_code}"
+        )
+
+        # Document expected behavior for expired tokens
+        # (Full test requires either: time-travel, token forging, or waiting 5+ minutes)
+        # For now, we validate the gateway is configured to check exp claim
+        # by confirming Envoy JWT filter is present in the config
+
+        pytest.skip(
+            "Expired token test requires either: (a) forging JWTs with past exp, "
+            "(b) Keycloak config for 10s token lifetime, or (c) 5+ minute wait. "
+            "Gateway JWT filter configuration verified separately. "
+            "TODO: Implement with JWT forging or short-lived Keycloak test realm."
+        )
+
+    @pytest.mark.parametrize(
+        "malicious_org_id,expected_status",
+        [
+            ("", 400),  # Empty org_id should be rejected by validation
+            ("999999999999999999999999", 403),  # Numeric overflow - wrong tenant
+            ("../../../etc/passwd", 403),  # Path traversal attempt
+            ("1' OR '1'='1", 403),  # SQL injection attempt
+            ("other-tenant-org-id", 403),  # Different tenant
+        ],
+        ids=["empty", "overflow", "path-traversal", "sql-injection", "wrong-tenant"],
+    )
+    def test_org_id_tenant_isolation_boundary_cases(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_rbac_iam_user_jwt,
+        malicious_org_id: str,
+        expected_status: int,
+    ):
+        """Malicious or malformed org_id values cannot bypass tenant isolation.
+
+        Tests that the system validates and sanitizes org_id to prevent:
+        - SQL injection via org_id in RBAC queries
+        - Path traversal in schema lookup
+        - Integer overflow in tenant identifiers
+        - Cross-tenant data access
+        """
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        # Note: We can't directly manipulate X-Rh-Identity (Envoy generates it from JWT)
+        # This test validates backend defense-in-depth by attempting requests
+        # The org_id comes from the JWT, so malicious values would need to be
+        # injected at Keycloak or via JWT forgery
+
+        # For this test, we verify that:
+        # 1. Normal authenticated requests work (baseline)
+        # 2. Document expected behavior for malformed org_id
+
+        url = f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
+        response = http_session.get(
+            url,
+            headers=gateway_rbac_iam_user_jwt.authorization_header,
+            timeout=90,
+            verify=False,
+        )
+
+        # We can't inject malicious org_id through the JWT path without forging tokens
+        # This test documents the expected validation behavior
+        # Real implementation would require:
+        # - Direct POST to Koku with crafted X-Rh-Identity header (bypassing gateway)
+        # - OR forging JWTs with malicious org_id claims
+
+        pytest.skip(
+            f"org_id boundary test for '{malicious_org_id}' requires either: "
+            f"(a) direct in-cluster access to bypass Envoy, or "
+            f"(b) forging JWTs with malicious claims. "
+            f"Expected behavior: system MUST reject with {expected_status}. "
+            f"TODO: Implement via in-cluster pod with crafted X-Rh-Identity header."
+        )
+
+    def test_permission_revocation_honored_after_cache_clear(
+        self,
+        cluster_config,
+        gateway_url: str,
+        http_session: requests.Session,
+        keycloak_config,
+        rbac_gateway_test_user_password: str,
+        _provision_rbac_iam_reader_gateway,
+    ):
+        """Revoked RBAC permissions are honored after cache TTL expires.
+
+        Tests that permission changes propagate through the RBAC cache layer
+        and that users lose access within an acceptable time window.
+        """
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        # Get fresh token
+        user_token = obtain_password_grant_token(
+            RBAC_IAM_GATEWAY_USERNAME,
+            rbac_gateway_test_user_password,
+            keycloak_config,
+            cluster_config,
+        )
+
+        # Verify user can access RBAC principals (baseline)
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/principals/?limit=5"
+        response_before = http_session.get(
+            url,
+            headers=user_token.authorization_header,
+            timeout=60,
+            verify=False,
+        )
+
+        if response_before.status_code != 200:
+            pytest.skip(
+                f"User doesn't have initial access (status {response_before.status_code}), "
+                f"cannot test revocation"
+            )
+
+        # Remove user from RBAC group
+        from utils import exec_in_pod_raw, get_pod_by_label
+
+        rbac_pod = get_pod_by_label(
+            cluster_config.namespace, "app.kubernetes.io/component=rbac-api"
+        )
+        if not rbac_pod:
+            pytest.skip("RBAC API pod not found")
+
+        # Script to remove principal from group
+        revoke_script = f"""
+from management.models import Group, Principal
+from django.core.cache import cache
+
+principal = Principal.objects.filter(username="{RBAC_IAM_GATEWAY_USERNAME}").first()
+if principal:
+    groups = Group.objects.filter(principals=principal)
+    for group in groups:
+        group.principals.remove(principal)
+    cache.clear()
+    print(f"Revoked: removed from {{groups.count()}} groups")
+else:
+    print("Principal not found")
+"""
+
+        result = exec_in_pod_raw(
+            cluster_config.namespace,
+            rbac_pod,
+            [
+                "python",
+                "/opt/rbac/rbac/manage.py",
+                "shell",
+                "-c",
+                revoke_script,
+            ],
+            timeout=60,
+        )
+
+        if result.returncode != 0:
+            pytest.skip(f"Could not revoke permissions: {result.stderr}")
+
+        # Cache was cleared explicitly, so check immediately
+        import time
+        time.sleep(2)  # Small delay for cache propagation
+
+        # Get NEW token (old token might be cached in Koku)
+        revoked_token = obtain_password_grant_token(
+            RBAC_IAM_GATEWAY_USERNAME,
+            rbac_gateway_test_user_password,
+            keycloak_config,
+            cluster_config,
+        )
+
+        # Verify user now gets 403
+        response_after = http_session.get(
+            url,
+            headers=revoked_token.authorization_header,
+            timeout=60,
+            verify=False,
+        )
+
+        assert response_after.status_code in (403, 424), (
+            f"Expected 403/424 after permission revocation, "
+            f"got {response_after.status_code}: {response_after.text[:300]}"
+        )
+
+    def test_rbac_iam_reader_cannot_modify_own_permissions(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_rbac_iam_user_jwt,
+        org_id: str,
+    ):
+        """Read-only RBAC IAM user cannot escalate privileges by modifying groups.
+
+        Tests that users with rbac:group:read cannot grant themselves
+        admin permissions by adding themselves to privileged groups.
+        """
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        # Attempt to add self to a group (privilege escalation)
+        # First, try to list groups to find one
+        groups_url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/?limit=10"
+        groups_response = http_session.get(
+            groups_url,
+            headers=gateway_rbac_iam_user_jwt.authorization_header,
+            timeout=60,
+            verify=False,
+        )
+
+        if groups_response.status_code != 200:
+            pytest.skip(f"Cannot list groups: {groups_response.status_code}")
+
+        groups_data = groups_response.json()
+        groups = groups_data.get("data", [])
+        if not groups:
+            pytest.skip("No groups found to test privilege escalation")
+
+        # Pick first group UUID
+        target_group_uuid = groups[0].get("uuid")
+        if not target_group_uuid:
+            pytest.skip("Group UUID not found in response")
+
+        # Attempt to add self to group via PATCH
+        principals_url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/{target_group_uuid}/principals/"
+        escalation_response = http_session.post(
+            principals_url,
+            headers={
+                **gateway_rbac_iam_user_jwt.authorization_header,
+                "Content-Type": "application/json",
+            },
+            json={"principals": [{"username": RBAC_IAM_GATEWAY_USERNAME}]},
+            timeout=60,
+            verify=False,
+        )
+
+        # Must be rejected with 403 (forbidden) or 405 (method not allowed)
+        assert escalation_response.status_code in (403, 405, 400), (
+            f"Expected 403/405/400 when read-only user tries to modify group, "
+            f"got {escalation_response.status_code}: {escalation_response.text[:400]}"
+        )
+
+        # Also test direct group modification (if they somehow got a group UUID)
+        group_modify_url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/{target_group_uuid}/"
+        modify_response = http_session.put(
+            group_modify_url,
+            headers={
+                **gateway_rbac_iam_user_jwt.authorization_header,
+                "Content-Type": "application/json",
+            },
+            json={"name": "hacked-group", "description": "privilege escalation attempt"},
+            timeout=60,
+            verify=False,
+        )
+
+        assert modify_response.status_code in (403, 405, 400), (
+            f"Expected 403/405/400 when read-only user tries to modify group name, "
+            f"got {modify_response.status_code}: {modify_response.text[:400]}"
+        )
+
+    def test_concurrent_jwt_sessions_no_resource_exhaustion(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        keycloak_config,
+        cluster_config,
+        rbac_gateway_test_user_password: str,
+        _provision_rbac_iam_reader_gateway,
+    ):
+        """Multiple concurrent sessions for same user must not cause resource exhaustion.
+
+        Light parallel load against the gateway (lab-tuned): verifies no 500s and
+        that several distinct JWTs for the same user can reach RBAC concurrently.
+        Transient 503s under burst are retried; success bar is modest for CI/lab.
+        """
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        import concurrent.futures
+        import time
+
+        num_concurrent = 6
+        min_success = 2
+        max_workers = 3
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/principals/?limit=1"
+        tokens = []
+
+        for i in range(num_concurrent):
+            try:
+                token = obtain_password_grant_token(
+                    RBAC_IAM_GATEWAY_USERNAME,
+                    rbac_gateway_test_user_password,
+                    keycloak_config,
+                    cluster_config,
+                )
+                tokens.append(token)
+                time.sleep(0.12)
+            except Exception as e:
+                pytest.skip(f"Could not generate {num_concurrent} tokens: {e}")
+
+        if len(tokens) < num_concurrent:
+            pytest.skip(f"Only generated {len(tokens)}/{num_concurrent} tokens")
+
+        def get_with_retries(headers: dict, *, attempts: int = 6) -> int:
+            backoff = 0.35
+            for attempt in range(attempts):
+                try:
+                    resp = requests.get(
+                        url, headers=headers, timeout=60, verify=False,
+                    )
+                    if resp.status_code == 200:
+                        return 200
+                    if resp.status_code in (502, 503, 504) and attempt < attempts - 1:
+                        time.sleep(backoff * (2**attempt))
+                        continue
+                    return resp.status_code
+                except Exception as e:
+                    if attempt < attempts - 1:
+                        time.sleep(backoff * (2**attempt))
+                        continue
+                    return str(e)
+            return 503
+
+        warmed = get_with_retries(tokens[0].authorization_header)
+        if warmed != 200:
+            pytest.skip(
+                f"Gateway/RBAC not ready for concurrent probe (warm-up got {warmed})",
+            )
+
+        def make_request(job):
+            token_obj, stagger_s = job
+            if stagger_s:
+                time.sleep(stagger_s)
+            return get_with_retries(token_obj.authorization_header)
+
+        jobs = [(tok, i * 0.15) for i, tok in enumerate(tokens)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(make_request, job) for job in jobs]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+        success_count = sum(1 for r in results if r == 200)
+        error_500_count = sum(1 for r in results if r == 500)
+
+        assert error_500_count == 0, (
+            f"Got {error_500_count} internal server errors out of {num_concurrent} "
+            f"concurrent requests. Results: {results}"
+        )
+        assert success_count >= min_success, (
+            f"Only {success_count}/{num_concurrent} requests succeeded "
+            f"(need >={min_success}). Results: {results}"
+        )
+
+    def test_jwt_without_required_claims_rejected(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+    ):
+        """JWTs missing required claims (org_id, account_number) must be rejected.
+
+        Tests that the Envoy Lua filter validates required claims before
+        constructing X-Rh-Identity.
+        """
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        # This test would require forging JWTs with missing claims
+        # For now, document expected behavior and verify with valid token
+        # Real implementation requires:
+        # - OpenSSL to generate RSA key pair
+        # - Crafting JWT with missing org_id or account_number
+        # - Signing with fake key
+
+        pytest.skip(
+            "JWT claim validation test requires forging tokens with missing claims. "
+            "Expected behavior: Envoy MUST reject JWTs without org_id, account_number, "
+            "or sub claims with 401 before reaching backend. "
+            "Gateway Lua filter implementation should validate these claims. "
+            "TODO: Implement with JWT forging using openssl/python-jose."
+        )
+
+    def test_rbac_cache_ttl_configuration_exists(self, cluster_config):
+        """Verify RBAC deployment has cache TTL configured (operational security).
+
+        Ensures the RBAC service has cache enabled and a reasonable TTL
+        so permission changes propagate within acceptable time.
+        """
+        from utils import run_oc_command
+
+        result = run_oc_command(
+            [
+                "get",
+                "deployment",
+                "-n",
+                cluster_config.namespace,
+                "-l",
+                "app.kubernetes.io/component=rbac-api",
+                "-o",
+                "json",
+            ],
+            check=False,
+        )
+
+        if result.returncode != 0:
+            pytest.skip(f"Could not get RBAC deployment: {result.stderr}")
+
+        data = json.loads(result.stdout or "{}")
+        items = data.get("items", [])
+        if not items:
+            pytest.skip("RBAC API deployment not found")
+
+        # Check environment variables for cache configuration
+        spec = items[0].get("spec", {})
+        template = spec.get("template", {})
+        containers = template.get("spec", {}).get("containers", [])
+
+        env_vars = {}
+        for container in containers:
+            for env in container.get("env", []):
+                env_vars[env.get("name")] = env.get("value")
+
+        # Verify ACCESS_CACHE_ENABLED is true
+        cache_enabled = env_vars.get("ACCESS_CACHE_ENABLED", "").lower()
+        assert cache_enabled == "true", (
+            f"RBAC cache should be enabled (ACCESS_CACHE_ENABLED=true), "
+            f"got: {cache_enabled}"
+        )
+
+        # Document that cache is enabled (good for performance, but needs monitoring)
+        # Cache TTL is typically 300s (5 minutes) in insights-rbac
+        # This means permission changes take up to 5 minutes to propagate

--- a/tests/suites/auth/test_rbac_gateway.py
+++ b/tests/suites/auth/test_rbac_gateway.py
@@ -1,0 +1,193 @@
+"""
+RBAC behavior through the public API gateway (Envoy + Keycloak JWT).
+
+Complements suites/e2e/test_rbac_access.py (which uses in-cluster X-Rh-Identity)
+by exercising real JWT → Envoy → Koku/ROS → insights-rbac flows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+import requests
+
+from conftest import obtain_password_grant_token
+from rbac_keycloak_users import (
+    ensure_realm_user_with_password,
+    fetch_keycloak_master_admin_token,
+)
+from suites.auth.test_gateway_auth import _check_gateway_reachable
+from utils import get_route_url, run_oc_command
+
+
+@pytest.fixture(scope="session")
+def rbac_gateway_test_user_password() -> str:
+    """Password for synthetic RBAC gateway test users (Keycloak + password grant)."""
+    return os.environ.get("RBAC_GATEWAY_TEST_USER_PASSWORD", "RbacGwTest1!")
+
+
+@pytest.fixture(scope="module")
+def _provision_gateway_nobody_user(
+    cluster_config,
+    keycloak_config,
+    org_id: str,
+    rbac_gateway_test_user_password: str,
+):
+    """Ensure ``nobody-unassigned`` exists in Keycloak (no RBAC group membership)."""
+    admin_token = fetch_keycloak_master_admin_token(
+        keycloak_config.url,
+        cluster_config.keycloak_namespace,
+    )
+    if not admin_token:
+        pytest.skip("Could not obtain Keycloak master admin token (secret or API)")
+
+    try:
+        ensure_realm_user_with_password(
+            keycloak_base_url=keycloak_config.url,
+            realm=keycloak_config.realm,
+            admin_token=admin_token,
+            username="nobody-unassigned",
+            password=rbac_gateway_test_user_password,
+            org_id=org_id,
+            account_number="7890123",
+            email="nobody-unassigned@rbac-gateway.test",
+        )
+    except RuntimeError as exc:
+        pytest.skip(f"Keycloak user provisioning failed: {exc}")
+
+    yield
+
+
+@pytest.fixture
+def gateway_nobody_user_jwt(
+    cluster_config,
+    keycloak_config,
+    rbac_gateway_test_user_password: str,
+    _provision_gateway_nobody_user,
+):
+    """Fresh password-grant JWT for ``nobody-unassigned``."""
+    return obtain_password_grant_token(
+        "nobody-unassigned",
+        rbac_gateway_test_user_password,
+        keycloak_config,
+        cluster_config,
+    )
+
+
+@pytest.mark.auth
+@pytest.mark.integration
+class TestRBACGateway:
+    """RBAC enforcement on routes reached through the Envoy gateway."""
+
+    def test_gateway_openshift_costs_unauthenticated_returns_401(
+        self, gateway_url: str, http_session: requests.Session
+    ):
+        """Protected Koku route rejects missing JWT."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
+        response = http_session.get(url, timeout=20)
+        assert response.status_code == 401, (
+            f"Expected 401 without Authorization, got {response.status_code}: "
+            f"{response.text[:200]}"
+        )
+
+    def test_gateway_rbac_status_unauthenticated_returns_401(
+        self, gateway_url: str, http_session: requests.Session
+    ):
+        """RBAC admin API is JWT-gated at the gateway."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/status/"
+        response = http_session.get(url, timeout=20)
+        assert response.status_code == 401, (
+            f"Expected 401 without Authorization on RBAC status, got "
+            f"{response.status_code}: {response.text[:200]}"
+        )
+
+    def test_gateway_openshift_costs_user_without_rbac_returns_403(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_nobody_user_jwt,
+    ):
+        """Authenticated user with no cost-management permissions receives 403."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
+        response = http_session.get(
+            url,
+            headers=gateway_nobody_user_jwt.authorization_header,
+            timeout=90,
+        )
+        assert response.status_code in (403, 424), (
+            f"Expected 403 (RBAC deny) or 424 (RBAC dependency failure), "
+            f"got {response.status_code}: {response.text[:300]}"
+        )
+
+    def test_gateway_ros_recommendations_user_without_rbac_returns_403(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_nobody_user_jwt,
+    ):
+        """ROS recommendations require the same cost-management permissions as Koku."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/cost-management/v1/recommendations/openshift"
+        response = http_session.get(
+            url,
+            headers=gateway_nobody_user_jwt.authorization_header,
+            timeout=90,
+        )
+        assert response.status_code in (403, 424), (
+            f"Expected 403 or 424 from ROS without RBAC permissions, "
+            f"got {response.status_code}: {response.text[:300]}"
+        )
+
+
+@pytest.mark.auth
+@pytest.mark.integration
+def test_rbac_migration_job_completed(cluster_config):
+    """RBAC Helm hook migration job finished successfully (cluster sanity)."""
+    gateway_route = f"{cluster_config.helm_release_name}-api"
+    if not get_route_url(cluster_config.namespace, gateway_route):
+        pytest.skip("API route not found — cluster not deployed for this suite")
+
+    result = run_oc_command(
+        [
+            "get",
+            "jobs",
+            "-n",
+            cluster_config.namespace,
+            "-l",
+            "app.kubernetes.io/component=rbac-migration",
+            "-o",
+            "json",
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"oc get jobs failed: {result.stderr}")
+
+    data = json.loads(result.stdout or "{}")
+    items = data.get("items") or []
+    if not items:
+        pytest.skip("No rbac-migration job found (chart without RBAC or hook removed)")
+
+    status = items[0].get("status") or {}
+    if status.get("active"):
+        pytest.skip("rbac-migration job still running")
+    if status.get("failed"):
+        pytest.fail(
+            f"rbac-migration job failed: {json.dumps(status, indent=2)[:800]}"
+        )
+    assert status.get("succeeded") == 1, (
+        f"Expected rbac-migration job succeeded=1, got: {json.dumps(status)[:800]}"
+    )

--- a/tests/suites/auth/test_rbac_gateway.py
+++ b/tests/suites/auth/test_rbac_gateway.py
@@ -9,27 +9,33 @@ from __future__ import annotations
 
 import json
 import os
+import time
 
 import pytest
 import requests
 
-from conftest import obtain_password_grant_token
-from rbac_bootstrap_scripts import render_rbac_iam_reader_bootstrap_script
+from conftest import _DEFAULT_ACCOUNT_NUMBER, obtain_password_grant_token
+from jwt_forge import forge_expired_jwt, forge_jwt_missing_sub
+from rbac_bootstrap_scripts import (
+    render_rbac_gateway_permission_restore_script,
+    render_rbac_gateway_permission_revoke_script,
+    render_rbac_iam_reader_bootstrap_script,
+)
 from rbac_keycloak_users import (
     ensure_realm_user_with_password,
     fetch_keycloak_master_admin_token,
 )
 from suites.auth.test_gateway_auth import _check_gateway_reachable
-from utils import exec_in_pod_raw, get_pod_by_label, get_route_url, run_oc_command
+from utils import (
+    exec_in_pod_raw,
+    get_pod_by_label,
+    get_route_url,
+    run_oc_command,
+    wait_for_deployment_replicas,
+)
 
 
 RBAC_IAM_GATEWAY_USERNAME = "rbac-iam-admin"
-
-
-@pytest.fixture(scope="session")
-def rbac_gateway_test_user_password() -> str:
-    """Password for synthetic RBAC gateway test users (Keycloak + password grant)."""
-    return os.environ.get("RBAC_GATEWAY_TEST_USER_PASSWORD", "RbacGwTest1!")
 
 
 @pytest.fixture(scope="module")
@@ -294,6 +300,20 @@ class TestRBACGateway:
             f"groups without write, got {response.status_code}: {response.text[:400]}"
         )
 
+    def test_gateway_ros_recommendations_unauthenticated_returns_401(
+        self, gateway_url: str, http_session: requests.Session
+    ):
+        """ROS recommendations route requires JWT at the gateway."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/cost-management/v1/recommendations/openshift"
+        response = http_session.get(url, timeout=20)
+        assert response.status_code == 401, (
+            f"Expected 401 without Authorization on ROS recommendations, got "
+            f"{response.status_code}: {response.text[:200]}"
+        )
+
     def test_gateway_ros_recommendations_user_without_rbac_returns_403(
         self,
         gateway_url: str,
@@ -379,8 +399,6 @@ class TestRBACSecurityBoundaries:
         backend is unreachable. A 424 (Failed Dependency) or 503 is acceptable
         only if it denies data access. A 200 with data would be a P0 security bug.
         """
-        from utils import run_oc_command
-
         if not _check_gateway_reachable(gateway_url, http_session):
             pytest.skip("Gateway service not available")
 
@@ -400,10 +418,14 @@ class TestRBACSecurityBoundaries:
         if scale_result.returncode != 0:
             pytest.skip(f"Could not scale RBAC deployment: {scale_result.stderr}")
 
+        rbac_label = "app.kubernetes.io/component=rbac-api"
+
         try:
-            # Wait for pods to terminate
-            import time
-            time.sleep(10)
+            # Wait for replicas to reach 0 (pods terminated)
+            if not wait_for_deployment_replicas(
+                cluster_config.namespace, rbac_label, expected_replicas=0, timeout=30
+            ):
+                pytest.skip("RBAC deployment did not scale to 0 within timeout")
 
             # Attempt authenticated request - should fail-closed
             url = f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
@@ -429,102 +451,45 @@ class TestRBACSecurityBoundaries:
 
         finally:
             # Restore RBAC service
-            run_oc_command(
+            restore_result = run_oc_command(
                 [
                     "scale",
                     "deployment",
                     "-n",
                     cluster_config.namespace,
                     "-l",
-                    "app.kubernetes.io/component=rbac-api",
+                    rbac_label,
                     "--replicas=1",
                 ],
                 check=False,
             )
-            # Wait for RBAC to be ready again
-            import time
-            time.sleep(15)
+            # Wait for RBAC to be ready again (readyReplicas=1)
+            if restore_result.returncode == 0:
+                wait_for_deployment_replicas(
+                    cluster_config.namespace, rbac_label, expected_replicas=1, timeout=60
+                )
 
     def test_expired_jwt_rejected(
         self,
         gateway_url: str,
         http_session: requests.Session,
-        keycloak_config,
-        cluster_config,
-        rbac_gateway_test_user_password: str,
-        _provision_rbac_iam_reader_gateway,
+        org_id: str,
     ):
-        """Expired JWTs (exp claim in the past) MUST be rejected with 401.
-
-        Tests that the gateway enforces JWT expiration to prevent session
-        hijacking with stale credentials.
-        """
+        """Expired JWTs (exp claim in the past) MUST be rejected with 401."""
         if not _check_gateway_reachable(gateway_url, http_session):
             pytest.skip("Gateway service not available")
 
-        # Obtain a fresh token first
-        fresh_token = obtain_password_grant_token(
-            RBAC_IAM_GATEWAY_USERNAME,
-            rbac_gateway_test_user_password,
-            keycloak_config,
-            cluster_config,
-        )
-
-        # Extract token parts and decode payload to check structure
-        import base64
-        token_parts = fresh_token.access_token.split(".")
-        if len(token_parts) != 3:
-            pytest.skip("JWT not in expected 3-part format")
-
-        # Decode payload (add padding if needed)
-        payload_b64 = token_parts[1]
-        padding = 4 - len(payload_b64) % 4
-        if padding != 4:
-            payload_b64 += "=" * padding
-
-        try:
-            payload_json = base64.urlsafe_b64decode(payload_b64)
-            payload = json.loads(payload_json)
-        except Exception as e:
-            pytest.skip(f"Could not decode JWT payload: {e}")
-
-        # Check if token has expiration
-        if "exp" not in payload:
-            pytest.skip("JWT does not contain exp claim")
-
-        # Create an expired token by requesting with very short lifetime
-        # (We can't forge tokens, so we wait for a short-lived one to expire)
-        # Alternative: Test that a token created yesterday fails
-        # For this test, we'll verify the gateway checks exp by using the token
-        # after waiting for it to expire
-
-        # Most Keycloak configs have 5min token lifetime - we can't wait that long
-        # Instead, verify the Envoy config would reject expired tokens by
-        # checking the current token is accepted, then document the expected behavior
-
         url = f"{gateway_url.rstrip('/')}/cost-management/v1/status/"
-
-        # First verify fresh token works
-        response_fresh = http_session.get(
+        expired_jwt = forge_expired_jwt(org_id=org_id)
+        response = http_session.get(
             url,
-            headers=fresh_token.authorization_header,
+            headers={"Authorization": f"Bearer {expired_jwt}"},
             timeout=30,
             verify=False,
         )
-        assert response_fresh.status_code == 200, (
-            f"Fresh token should work, got {response_fresh.status_code}"
-        )
-
-        # Document expected behavior for expired tokens
-        # (Full test requires either: time-travel, token forging, or waiting 5+ minutes)
-        # For now, we validate the gateway is configured to check exp claim
-        # by confirming Envoy JWT filter is present in the config
-
-        pytest.skip(
-            "Expired token test requires either: (a) forging JWTs with past exp, "
-            "(b) Keycloak config for 10s token lifetime, or (c) 5+ minute wait. "
-            "Gateway JWT filter configuration verified separately. "
-            "TODO: Implement with JWT forging or short-lived Keycloak test realm."
+        assert response.status_code == 401, (
+            f"Expected 401 for expired/forged JWT, got {response.status_code}: "
+            f"{response.text[:200]}"
         )
 
     @pytest.mark.parametrize(
@@ -542,50 +507,66 @@ class TestRBACSecurityBoundaries:
         self,
         gateway_url: str,
         http_session: requests.Session,
-        gateway_rbac_iam_user_jwt,
+        cluster_config,
+        keycloak_config,
+        rbac_gateway_test_user_password: str,
         malicious_org_id: str,
         expected_status: int,
+        request,
     ):
-        """Malicious or malformed org_id values cannot bypass tenant isolation.
+        """Malicious org_id in a valid Keycloak JWT must not yield cost report data.
 
-        Tests that the system validates and sanitizes org_id to prevent:
-        - SQL injection via org_id in RBAC queries
-        - Path traversal in schema lookup
-        - Integer overflow in tenant identifiers
-        - Cross-tenant data access
+        Envoy accepts the JWT (valid signature); Lua embeds org_id into
+        ``X-Rh-Identity``; Koku/RBAC must reject the request.
         """
         if not _check_gateway_reachable(gateway_url, http_session):
             pytest.skip("Gateway service not available")
 
-        # Note: We can't directly manipulate X-Rh-Identity (Envoy generates it from JWT)
-        # This test validates backend defense-in-depth by attempting requests
-        # The org_id comes from the JWT, so malicious values would need to be
-        # injected at Keycloak or via JWT forgery
+        param_id = request.node.callspec.id
+        username = f"orgid-test-{param_id}"
+        admin_token = fetch_keycloak_master_admin_token(
+            keycloak_config.url,
+            cluster_config.keycloak_namespace,
+        )
+        if not admin_token:
+            pytest.skip("Could not obtain Keycloak master admin token")
 
-        # For this test, we verify that:
-        # 1. Normal authenticated requests work (baseline)
-        # 2. Document expected behavior for malformed org_id
+        account_number = os.environ.get("TEST_ACCOUNT_NUMBER", _DEFAULT_ACCOUNT_NUMBER)
+        try:
+            ensure_realm_user_with_password(
+                keycloak_base_url=keycloak_config.url,
+                realm=keycloak_config.realm,
+                admin_token=admin_token,
+                username=username,
+                password=rbac_gateway_test_user_password,
+                org_id=malicious_org_id,
+                account_number=account_number,
+                email=f"{username}@rbac-gateway.test",
+            )
+        except RuntimeError as exc:
+            pytest.skip(f"Keycloak user for org_id case {param_id!r}: {exc}")
 
+        token = obtain_password_grant_token(
+            username,
+            rbac_gateway_test_user_password,
+            keycloak_config,
+            cluster_config,
+        )
         url = f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
         response = http_session.get(
             url,
-            headers=gateway_rbac_iam_user_jwt.authorization_header,
+            headers=token.authorization_header,
             timeout=90,
             verify=False,
         )
-
-        # We can't inject malicious org_id through the JWT path without forging tokens
-        # This test documents the expected validation behavior
-        # Real implementation would require:
-        # - Direct POST to Koku with crafted X-Rh-Identity header (bypassing gateway)
-        # - OR forging JWTs with malicious org_id claims
-
-        pytest.skip(
-            f"org_id boundary test for '{malicious_org_id}' requires either: "
-            f"(a) direct in-cluster access to bypass Envoy, or "
-            f"(b) forging JWTs with malicious claims. "
-            f"Expected behavior: system MUST reject with {expected_status}. "
-            f"TODO: Implement via in-cluster pod with crafted X-Rh-Identity header."
+        # 401 = Envoy/Lua rejects bad org_id before Koku; 400/403/424 = backend deny
+        allowed = {expected_status, 400, 401, 403, 424}
+        assert response.status_code in allowed, (
+            f"org_id case {param_id!r} ({malicious_org_id!r}): expected one of "
+            f"{sorted(allowed)}, got {response.status_code}: {response.text[:300]}"
+        )
+        assert response.status_code != 200, (
+            f"SECURITY: malicious org_id {malicious_org_id!r} must not return 200"
         )
 
     def test_permission_revocation_honored_after_cache_clear(
@@ -594,13 +575,15 @@ class TestRBACSecurityBoundaries:
         gateway_url: str,
         http_session: requests.Session,
         keycloak_config,
+        org_id: str,
         rbac_gateway_test_user_password: str,
         _provision_rbac_iam_reader_gateway,
     ):
-        """Revoked RBAC permissions are honored after cache TTL expires.
+        """Revoked RBAC permissions are honored after cache clear.
 
-        Tests that permission changes propagate through the RBAC cache layer
-        and that users lose access within an acceptable time window.
+        Removes group membership and temporarily disables platform-default roles
+        that grant ``rbac:principal:read`` / ``rbac:group:read`` (e.g. seeded
+        ``User Access principal viewer``), so denial is not masked by defaults.
         """
         if not _check_gateway_reachable(gateway_url, http_session):
             pytest.skip("Gateway service not available")
@@ -637,62 +620,64 @@ class TestRBACSecurityBoundaries:
         if not rbac_pod:
             pytest.skip("RBAC API pod not found")
 
-        # Script to remove principal from group
-        revoke_script = f"""
-from management.models import Group, Principal
-from django.core.cache import cache
-
-principal = Principal.objects.filter(username="{RBAC_IAM_GATEWAY_USERNAME}").first()
-if principal:
-    groups = Group.objects.filter(principals=principal)
-    for group in groups:
-        group.principals.remove(principal)
-    cache.clear()
-    print(f"Revoked: removed from {{groups.count()}} groups")
-else:
-    print("Principal not found")
-"""
-
-        result = exec_in_pod_raw(
-            cluster_config.namespace,
-            rbac_pod,
-            [
-                "python",
-                "/opt/rbac/rbac/manage.py",
-                "shell",
-                "-c",
-                revoke_script,
-            ],
-            timeout=60,
+        restore_script = render_rbac_gateway_permission_restore_script(
+            org_id, RBAC_IAM_GATEWAY_USERNAME
         )
 
-        if result.returncode != 0:
-            pytest.skip(f"Could not revoke permissions: {result.stderr}")
+        try:
+            revoke_script = render_rbac_gateway_permission_revoke_script(
+                RBAC_IAM_GATEWAY_USERNAME
+            )
 
-        # Cache was cleared explicitly, so check immediately
-        import time
-        time.sleep(2)  # Small delay for cache propagation
+            result = exec_in_pod_raw(
+                cluster_config.namespace,
+                rbac_pod,
+                [
+                    "python",
+                    "/opt/rbac/rbac/manage.py",
+                    "shell",
+                    "-c",
+                    revoke_script,
+                ],
+                timeout=60,
+            )
 
-        # Get NEW token (old token might be cached in Koku)
-        revoked_token = obtain_password_grant_token(
-            RBAC_IAM_GATEWAY_USERNAME,
-            rbac_gateway_test_user_password,
-            keycloak_config,
-            cluster_config,
-        )
+            if result.returncode != 0:
+                pytest.skip(f"Could not revoke permissions: {result.stderr}")
 
-        # Verify user now gets 403
-        response_after = http_session.get(
-            url,
-            headers=revoked_token.authorization_header,
-            timeout=60,
-            verify=False,
-        )
+            time.sleep(2)
 
-        assert response_after.status_code in (403, 424), (
-            f"Expected 403/424 after permission revocation, "
-            f"got {response_after.status_code}: {response_after.text[:300]}"
-        )
+            revoked_token = obtain_password_grant_token(
+                RBAC_IAM_GATEWAY_USERNAME,
+                rbac_gateway_test_user_password,
+                keycloak_config,
+                cluster_config,
+            )
+
+            response_after = http_session.get(
+                url,
+                headers=revoked_token.authorization_header,
+                timeout=60,
+                verify=False,
+            )
+
+            assert response_after.status_code in (403, 424), (
+                f"Expected 403/424 after permission revocation, "
+                f"got {response_after.status_code}: {response_after.text[:300]}"
+            )
+        finally:
+            exec_in_pod_raw(
+                cluster_config.namespace,
+                rbac_pod,
+                [
+                    "python",
+                    "/opt/rbac/rbac/manage.py",
+                    "shell",
+                    "-c",
+                    restore_script,
+                ],
+                timeout=120,
+            )
 
     def test_rbac_iam_reader_cannot_modify_own_permissions(
         self,
@@ -791,7 +776,7 @@ else:
         import time
 
         num_concurrent = 6
-        min_success = 2
+        min_success = 4
         max_workers = 3
         url = f"{gateway_url.rstrip('/')}/rbac/v1/principals/?limit=1"
         tokens = []
@@ -865,28 +850,23 @@ else:
         self,
         gateway_url: str,
         http_session: requests.Session,
+        org_id: str,
     ):
-        """JWTs missing required claims (org_id, account_number) must be rejected.
-
-        Tests that the Envoy Lua filter validates required claims before
-        constructing X-Rh-Identity.
-        """
+        """JWTs missing required claims (e.g. sub) must be rejected with 401."""
         if not _check_gateway_reachable(gateway_url, http_session):
             pytest.skip("Gateway service not available")
 
-        # This test would require forging JWTs with missing claims
-        # For now, document expected behavior and verify with valid token
-        # Real implementation requires:
-        # - OpenSSL to generate RSA key pair
-        # - Crafting JWT with missing org_id or account_number
-        # - Signing with fake key
-
-        pytest.skip(
-            "JWT claim validation test requires forging tokens with missing claims. "
-            "Expected behavior: Envoy MUST reject JWTs without org_id, account_number, "
-            "or sub claims with 401 before reaching backend. "
-            "Gateway Lua filter implementation should validate these claims. "
-            "TODO: Implement with JWT forging using openssl/python-jose."
+        url = f"{gateway_url.rstrip('/')}/cost-management/v1/status/"
+        no_sub_jwt = forge_jwt_missing_sub(org_id=org_id)
+        response = http_session.get(
+            url,
+            headers={"Authorization": f"Bearer {no_sub_jwt}"},
+            timeout=30,
+            verify=False,
+        )
+        assert response.status_code == 401, (
+            f"Expected 401 for JWT missing sub, got {response.status_code}: "
+            f"{response.text[:200]}"
         )
 
     def test_rbac_cache_ttl_configuration_exists(self, cluster_config):

--- a/tests/suites/auth/test_rbac_gateway.py
+++ b/tests/suites/auth/test_rbac_gateway.py
@@ -14,12 +14,16 @@ import pytest
 import requests
 
 from conftest import obtain_password_grant_token
+from rbac_bootstrap_scripts import render_rbac_iam_reader_bootstrap_script
 from rbac_keycloak_users import (
     ensure_realm_user_with_password,
     fetch_keycloak_master_admin_token,
 )
 from suites.auth.test_gateway_auth import _check_gateway_reachable
-from utils import get_route_url, run_oc_command
+from utils import exec_in_pod_raw, get_pod_by_label, get_route_url, run_oc_command
+
+
+RBAC_IAM_GATEWAY_USERNAME = "rbac-iam-admin"
 
 
 @pytest.fixture(scope="session")
@@ -70,6 +74,79 @@ def gateway_nobody_user_jwt(
     """Fresh password-grant JWT for ``nobody-unassigned``."""
     return obtain_password_grant_token(
         "nobody-unassigned",
+        rbac_gateway_test_user_password,
+        keycloak_config,
+        cluster_config,
+    )
+
+
+@pytest.fixture(scope="module")
+def _provision_rbac_iam_reader_gateway(
+    cluster_config,
+    keycloak_config,
+    org_id: str,
+    rbac_gateway_test_user_password: str,
+):
+    """Keycloak user + RBAC group binding with minimal ``rbac:group:read`` (or first rbac perm)."""
+    admin_token = fetch_keycloak_master_admin_token(
+        keycloak_config.url,
+        cluster_config.keycloak_namespace,
+    )
+    if not admin_token:
+        pytest.skip("Could not obtain Keycloak master admin token (secret or API)")
+
+    try:
+        ensure_realm_user_with_password(
+            keycloak_base_url=keycloak_config.url,
+            realm=keycloak_config.realm,
+            admin_token=admin_token,
+            username=RBAC_IAM_GATEWAY_USERNAME,
+            password=rbac_gateway_test_user_password,
+            org_id=org_id,
+            account_number="7890123",
+            email="rbac-iam-admin@rbac-gateway.test",
+        )
+    except RuntimeError as exc:
+        pytest.skip(f"Keycloak IAM test user provisioning failed: {exc}")
+
+    rbac_pod = get_pod_by_label(
+        cluster_config.namespace, "app.kubernetes.io/component=rbac-api"
+    )
+    if not rbac_pod:
+        pytest.skip("RBAC API pod not found")
+
+    script = render_rbac_iam_reader_bootstrap_script(org_id, RBAC_IAM_GATEWAY_USERNAME)
+    result = exec_in_pod_raw(
+        cluster_config.namespace,
+        rbac_pod,
+        [
+            "python",
+            "/opt/rbac/rbac/manage.py",
+            "shell",
+            "-c",
+            script,
+        ],
+        timeout=120,
+    )
+    out = (result.stdout or "") + (result.stderr or "")
+    if result.returncode != 0 or "no_rbac_permissions_seeded" in out:
+        pytest.skip(
+            f"RBAC IAM bootstrap skipped (returncode={result.returncode}): {out[:600]}"
+        )
+
+    yield
+
+
+@pytest.fixture
+def gateway_rbac_iam_user_jwt(
+    cluster_config,
+    keycloak_config,
+    rbac_gateway_test_user_password: str,
+    _provision_rbac_iam_reader_gateway,
+):
+    """JWT for user with insights-rbac IAM read (groups list)."""
+    return obtain_password_grant_token(
+        RBAC_IAM_GATEWAY_USERNAME,
         rbac_gateway_test_user_password,
         keycloak_config,
         cluster_config,
@@ -128,6 +205,93 @@ class TestRBACGateway:
         assert response.status_code in (403, 424), (
             f"Expected 403 (RBAC deny) or 424 (RBAC dependency failure), "
             f"got {response.status_code}: {response.text[:300]}"
+        )
+
+    def test_gateway_rbac_groups_unauthenticated_returns_401(
+        self, gateway_url: str, http_session: requests.Session
+    ):
+        """RBAC IAM ``/groups/`` requires JWT at the gateway."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/?limit=1"
+        response = http_session.get(url, timeout=20)
+        assert response.status_code == 401, (
+            f"Expected 401 without Authorization on RBAC groups, got "
+            f"{response.status_code}: {response.text[:200]}"
+        )
+
+    def test_gateway_rbac_groups_user_without_iam_returns_403(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_nobody_user_jwt,
+    ):
+        """User with no ``rbac`` application permissions cannot list groups."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/?limit=1"
+        response = http_session.get(
+            url,
+            headers=gateway_nobody_user_jwt.authorization_header,
+            timeout=60,
+        )
+        assert response.status_code in (403, 424), (
+            f"Expected 403 or 424 for RBAC groups without IAM perms, "
+            f"got {response.status_code}: {response.text[:300]}"
+        )
+
+    def test_gateway_rbac_groups_iam_reader_returns_200(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_rbac_iam_user_jwt,
+    ):
+        """User with ``rbac:group:read`` (or equivalent) can list groups via gateway."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/?limit=5"
+        response = http_session.get(
+            url,
+            headers=gateway_rbac_iam_user_jwt.authorization_header,
+            timeout=60,
+            verify=False,
+        )
+        assert response.status_code == 200, (
+            f"Expected 200 listing groups with IAM read role, "
+            f"got {response.status_code}: {response.text[:400]}"
+        )
+        payload = response.json()
+        assert "data" in payload or "meta" in payload, (
+            f"Unexpected RBAC groups JSON shape: {list(payload.keys())[:10]}"
+        )
+
+    def test_gateway_rbac_groups_post_iam_reader_forbidden(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        gateway_rbac_iam_user_jwt,
+    ):
+        """Read-only IAM role must not allow creating groups."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        url = f"{gateway_url.rstrip('/')}/rbac/v1/groups/"
+        response = http_session.post(
+            url,
+            headers={
+                **gateway_rbac_iam_user_jwt.authorization_header,
+                "Content-Type": "application/json",
+            },
+            json={"name": "pytest-rbac-iam-write-deny"},
+            timeout=60,
+            verify=False,
+        )
+        assert response.status_code in (403, 400), (
+            f"Expected 403 (forbidden) or 400 (validation before authz) for POST "
+            f"groups without write, got {response.status_code}: {response.text[:400]}"
         )
 
     def test_gateway_ros_recommendations_user_without_rbac_returns_403(

--- a/tests/suites/auth/test_ui_oauth.py
+++ b/tests/suites/auth/test_ui_oauth.py
@@ -10,7 +10,7 @@ import re
 import pytest
 import requests
 
-from conftest import decode_jwt_payload
+from conftest import OIDC_PASSWORD_GRANT_SCOPE, decode_jwt_payload
 from utils import run_oc_command, get_route_url
 
 
@@ -21,7 +21,7 @@ def _obtain_token(http_session, keycloak_config, ui_client_config, credentials):
         "password": credentials["password"],
         "grant_type": "password",
         "client_id": ui_client_config["client_id"],
-        "scope": "openid profile email",
+        "scope": OIDC_PASSWORD_GRANT_SCOPE,
     }
     if ui_client_config.get("client_secret"):
         data["client_secret"] = ui_client_config["client_secret"]
@@ -104,7 +104,7 @@ class TestUIOAuthFlow:
             "password": test_user_credentials["password"],
             "grant_type": "password",
             "client_id": ui_client_config["client_id"],
-            "scope": "openid profile email",
+            "scope": OIDC_PASSWORD_GRANT_SCOPE,
         }
         if ui_client_config.get("client_secret"):
             data["client_secret"] = ui_client_config["client_secret"]
@@ -138,7 +138,7 @@ class TestUIOAuthFlow:
             "password": test_user_credentials["password"],
             "grant_type": "password",
             "client_id": ui_client_config["client_id"],
-            "scope": "openid profile email",
+            "scope": OIDC_PASSWORD_GRANT_SCOPE,
         }
         if ui_client_config.get("client_secret"):
             data["client_secret"] = ui_client_config["client_secret"]

--- a/tests/suites/e2e/test_rbac_access.py
+++ b/tests/suites/e2e/test_rbac_access.py
@@ -551,9 +551,9 @@ def rbac_gateway_jwt_password(
     keycloak_config: KeycloakConfig,
     org_id: str,
     rbac_access_setup,
+    rbac_gateway_test_user_password: str,
 ):
-    """Create Keycloak users matching RBAC principals; yield password for grants."""
-    pwd = os.environ.get("RBAC_GATEWAY_TEST_USER_PASSWORD", "RbacGwTest1!")
+    """Create Keycloak users matching RBAC principals; yield session password."""
     try:
         ensure_rbac_gateway_persona_users(
             keycloak_config.url,
@@ -561,11 +561,11 @@ def rbac_gateway_jwt_password(
             keycloak_config.realm,
             org_id,
             "7890123",
-            password=pwd,
+            password=rbac_gateway_test_user_password,
         )
     except RuntimeError as exc:
         pytest.skip(f"Keycloak RBAC gateway persona provisioning failed: {exc}")
-    yield pwd
+    yield rbac_gateway_test_user_password
 
 
 # =============================================================================
@@ -648,10 +648,12 @@ class TestRBACAccessControl:
                 if proj:
                     projects_seen.add(proj)
 
-        if projects_seen:
-            assert projects_seen == {"payment"}, (
-                f"Alice should only see 'payment' but saw: {projects_seen}"
-            )
+        assert len(projects_seen) > 0, (
+            "Alice returned 200 but no project data — RBAC fixture may not have seeded data"
+        )
+        assert projects_seen == {"payment"}, (
+            f"Alice should only see 'payment' but saw: {projects_seen}"
+        )
 
     def test_bob_unfiltered_sees_only_alpha(
         self, cluster_config, test_runner_pod, org_id, rbac_access_setup, rbac_cluster_data
@@ -671,10 +673,12 @@ class TestRBACAccessControl:
                 if cid:
                     clusters_seen.add(cid)
 
-        if clusters_seen:
-            assert clusters_seen == {alpha_id}, (
-                f"Bob should only see cluster-alpha ({alpha_id}) but saw: {clusters_seen}"
-            )
+        assert len(clusters_seen) > 0, (
+            "Bob returned 200 but no cluster data — RBAC fixture may not have seeded data"
+        )
+        assert clusters_seen == {alpha_id}, (
+            f"Bob should only see cluster-alpha ({alpha_id}) but saw: {clusters_seen}"
+        )
 
     def test_carol_unfiltered_sees_everything(
         self, cluster_config, test_runner_pod, org_id, rbac_access_setup, rbac_cluster_data
@@ -694,12 +698,12 @@ class TestRBACAccessControl:
                     clusters_seen.add(cid)
 
         expected_clusters = set(rbac_cluster_data["cluster_ids"].values())
-        if clusters_seen:
-            # Carol has full access -- verify all 3 test clusters are present
-            # (there may also be leftover clusters from prior runs)
-            assert expected_clusters.issubset(clusters_seen), (
-                f"Carol should see at least {expected_clusters} but saw: {clusters_seen}"
-            )
+        assert len(clusters_seen) > 0, (
+            "Carol returned 200 but no cluster data — RBAC fixture may not have seeded data"
+        )
+        assert expected_clusters.issubset(clusters_seen), (
+            f"Carol should see at least {expected_clusters} but saw: {clusters_seen}"
+        )
 
     # =========================================================================
     # Explicit Filter -- Allowed (200 with data)
@@ -832,10 +836,13 @@ class TestRBACAccessControl:
                 proj = project_group.get("project")
                 if proj:
                     projects_seen.add(proj)
-        if projects_seen:
-            assert projects_seen == {"payment"}, (
-                f"Alice gateway should only see 'payment' but saw: {projects_seen}"
-            )
+        assert len(projects_seen) > 0, (
+            "Alice (gateway) returned 200 but no project data — "
+            "RBAC fixture may not have seeded data"
+        )
+        assert projects_seen == {"payment"}, (
+            f"Alice gateway should only see 'payment' but saw: {projects_seen}"
+        )
 
     def test_bob_password_grant_via_gateway_sees_only_alpha(
         self,
@@ -875,10 +882,13 @@ class TestRBACAccessControl:
                 cid = cluster_group.get("cluster")
                 if cid:
                     clusters_seen.add(cid)
-        if clusters_seen:
-            assert clusters_seen == {alpha_id}, (
-                f"Bob gateway should only see alpha ({alpha_id}) but saw: {clusters_seen}"
-            )
+        assert len(clusters_seen) > 0, (
+            "Bob (gateway) returned 200 but no cluster data — "
+            "RBAC fixture may not have seeded data"
+        )
+        assert clusters_seen == {alpha_id}, (
+            f"Bob gateway should only see alpha ({alpha_id}) but saw: {clusters_seen}"
+        )
 
     def test_carol_password_grant_via_gateway_sees_all_test_clusters(
         self,
@@ -918,11 +928,14 @@ class TestRBACAccessControl:
                 if cid:
                     clusters_seen.add(cid)
         expected_clusters = set(rbac_cluster_data["cluster_ids"].values())
-        if clusters_seen:
-            assert expected_clusters.issubset(clusters_seen), (
-                f"Carol gateway should see at least {expected_clusters} "
-                f"but saw: {clusters_seen}"
-            )
+        assert len(clusters_seen) > 0, (
+            "Carol (gateway) returned 200 but no cluster data — "
+            "RBAC fixture may not have seeded data"
+        )
+        assert expected_clusters.issubset(clusters_seen), (
+            f"Carol gateway should see at least {expected_clusters} "
+            f"but saw: {clusters_seen}"
+        )
 
     def test_alice_password_grant_via_gateway_ros_recommendations_ok(
         self,

--- a/tests/suites/e2e/test_rbac_access.py
+++ b/tests/suites/e2e/test_rbac_access.py
@@ -34,7 +34,12 @@ from typing import Dict
 import pytest
 import requests
 
-from conftest import ClusterConfig, KeycloakConfig, obtain_jwt_token
+from conftest import (
+    ClusterConfig,
+    KeycloakConfig,
+    obtain_jwt_token,
+    obtain_password_grant_token,
+)
 from e2e_helpers import (
     get_koku_api_url,
     register_source,
@@ -42,6 +47,8 @@ from e2e_helpers import (
     wait_for_provider,
     wait_for_summary_tables,
 )
+from rbac_keycloak_users import ensure_rbac_gateway_persona_users
+from suites.auth.test_gateway_auth import _check_gateway_reachable
 from suites.e2e.conftest import make_user_pod_session
 from utils import (
     create_pod_session,
@@ -538,6 +545,29 @@ def rbac_access_setup(
     }
 
 
+@pytest.fixture(scope="module")
+def rbac_gateway_jwt_password(
+    cluster_config: ClusterConfig,
+    keycloak_config: KeycloakConfig,
+    org_id: str,
+    rbac_access_setup,
+):
+    """Create Keycloak users matching RBAC principals; yield password for grants."""
+    pwd = os.environ.get("RBAC_GATEWAY_TEST_USER_PASSWORD", "RbacGwTest1!")
+    try:
+        ensure_rbac_gateway_persona_users(
+            keycloak_config.url,
+            cluster_config.keycloak_namespace,
+            keycloak_config.realm,
+            org_id,
+            "7890123",
+            password=pwd,
+        )
+    except RuntimeError as exc:
+        pytest.skip(f"Keycloak RBAC gateway persona provisioning failed: {exc}")
+    yield pwd
+
+
 # =============================================================================
 # Test Class
 # =============================================================================
@@ -760,3 +790,166 @@ class TestRBACAccessControl:
             assert gamma_id not in clusters_seen, (
                 f"Gamma ({gamma_id}) should NOT appear (no payment namespace)"
             )
+
+    # =========================================================================
+    # Gateway JWT path (Keycloak password grant → Envoy → Koku)
+    # =========================================================================
+
+    def test_alice_password_grant_via_gateway_sees_only_payment(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        cluster_config: ClusterConfig,
+        keycloak_config: KeycloakConfig,
+        rbac_access_setup,
+        rbac_cluster_data,
+        rbac_gateway_jwt_password: str,
+    ):
+        """Alice JWT through gateway matches in-cluster RBAC (payment only)."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        tok = obtain_password_grant_token(
+            "alice",
+            rbac_gateway_jwt_password,
+            keycloak_config,
+            cluster_config,
+        )
+        url = (
+            f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
+            "?group_by[project]=*"
+        )
+        response = http_session.get(
+            url, headers=tok.authorization_header, timeout=120, verify=False
+        )
+        assert response.status_code == 200, (
+            f"Alice (gateway) got {response.status_code}: {response.text[:400]}"
+        )
+        data = response.json()
+        projects_seen = set()
+        for day in data.get("data", []):
+            for project_group in day.get("projects", []):
+                proj = project_group.get("project")
+                if proj:
+                    projects_seen.add(proj)
+        if projects_seen:
+            assert projects_seen == {"payment"}, (
+                f"Alice gateway should only see 'payment' but saw: {projects_seen}"
+            )
+
+    def test_bob_password_grant_via_gateway_sees_only_alpha(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        cluster_config: ClusterConfig,
+        keycloak_config: KeycloakConfig,
+        rbac_access_setup,
+        rbac_cluster_data,
+        rbac_gateway_jwt_password: str,
+    ):
+        """Bob JWT through gateway is limited to cluster-alpha."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        tok = obtain_password_grant_token(
+            "bob",
+            rbac_gateway_jwt_password,
+            keycloak_config,
+            cluster_config,
+        )
+        alpha_id = rbac_cluster_data["cluster_ids"]["alpha"]
+        url = (
+            f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
+            "?group_by[cluster]=*"
+        )
+        response = http_session.get(
+            url, headers=tok.authorization_header, timeout=120, verify=False
+        )
+        assert response.status_code == 200, (
+            f"Bob (gateway) got {response.status_code}: {response.text[:400]}"
+        )
+        data = response.json()
+        clusters_seen = set()
+        for day in data.get("data", []):
+            for cluster_group in day.get("clusters", []):
+                cid = cluster_group.get("cluster")
+                if cid:
+                    clusters_seen.add(cid)
+        if clusters_seen:
+            assert clusters_seen == {alpha_id}, (
+                f"Bob gateway should only see alpha ({alpha_id}) but saw: {clusters_seen}"
+            )
+
+    def test_carol_password_grant_via_gateway_sees_all_test_clusters(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        cluster_config: ClusterConfig,
+        keycloak_config: KeycloakConfig,
+        rbac_access_setup,
+        rbac_cluster_data,
+        rbac_gateway_jwt_password: str,
+    ):
+        """Carol (Cost Administrator) via gateway sees all three RBAC test clusters."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        tok = obtain_password_grant_token(
+            "carol",
+            rbac_gateway_jwt_password,
+            keycloak_config,
+            cluster_config,
+        )
+        url = (
+            f"{gateway_url.rstrip('/')}/cost-management/v1/reports/openshift/costs/"
+            "?group_by[cluster]=*"
+        )
+        response = http_session.get(
+            url, headers=tok.authorization_header, timeout=120, verify=False
+        )
+        assert response.status_code == 200, (
+            f"Carol (gateway) got {response.status_code}: {response.text[:400]}"
+        )
+        data = response.json()
+        clusters_seen = set()
+        for day in data.get("data", []):
+            for cluster_group in day.get("clusters", []):
+                cid = cluster_group.get("cluster")
+                if cid:
+                    clusters_seen.add(cid)
+        expected_clusters = set(rbac_cluster_data["cluster_ids"].values())
+        if clusters_seen:
+            assert expected_clusters.issubset(clusters_seen), (
+                f"Carol gateway should see at least {expected_clusters} "
+                f"but saw: {clusters_seen}"
+            )
+
+    def test_alice_password_grant_via_gateway_ros_recommendations_ok(
+        self,
+        gateway_url: str,
+        http_session: requests.Session,
+        cluster_config: ClusterConfig,
+        keycloak_config: KeycloakConfig,
+        rbac_access_setup,
+        rbac_gateway_jwt_password: str,
+    ):
+        """Alice can reach ROS recommendations through gateway (same RBAC app)."""
+        if not _check_gateway_reachable(gateway_url, http_session):
+            pytest.skip("Gateway service not available")
+
+        tok = obtain_password_grant_token(
+            "alice",
+            rbac_gateway_jwt_password,
+            keycloak_config,
+            cluster_config,
+        )
+        url = (
+            f"{gateway_url.rstrip('/')}/cost-management/v1/recommendations/openshift"
+        )
+        response = http_session.get(
+            url, headers=tok.authorization_header, timeout=120, verify=False
+        )
+        assert response.status_code in (200, 404), (
+            f"Alice ROS (gateway) expected 200 or 404, got {response.status_code}: "
+            f"{response.text[:400]}"
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -853,21 +853,79 @@ def wait_for_condition(
     description: str = "condition",
 ) -> bool:
     """Wait for a condition to become true.
-    
+
     Args:
         check_func: Callable that returns True when condition is met
         timeout: Maximum wait time in seconds
         interval: Check interval in seconds
         description: Description for logging
-    
+
     Returns:
         True if condition was met, False if timeout
     """
     import time
-    
+
     start_time = time.time()
     while time.time() - start_time < timeout:
         if check_func():
             return True
         time.sleep(interval)
+    return False
+
+
+def wait_for_deployment_replicas(
+    namespace: str,
+    label_selector: str,
+    expected_replicas: int,
+    timeout: int = 60,
+    interval: int = 2,
+) -> bool:
+    """Wait for a deployment to reach the expected replica count.
+
+    Args:
+        namespace: Kubernetes namespace
+        label_selector: Label selector (e.g., "app.kubernetes.io/component=rbac-api")
+        expected_replicas: Expected number of ready replicas
+        timeout: Maximum wait time in seconds
+        interval: Check interval in seconds
+
+    Returns:
+        True if replicas reached expected count, False if timeout
+
+    Example:
+        # Wait for scale-down to 0
+        wait_for_deployment_replicas(ns, "app=rbac", 0, timeout=30)
+
+        # Wait for scale-up to 1
+        wait_for_deployment_replicas(ns, "app=rbac", 1, timeout=60)
+    """
+    import time
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            # Check ready replicas via deployment status
+            result = run_oc_command(
+                [
+                    "get", "deployment",
+                    "-n", namespace,
+                    "-l", label_selector,
+                    "-o", "jsonpath={.items[0].status.readyReplicas}",
+                ],
+                check=False,
+            )
+
+            ready_str = result.stdout.strip()
+            # If no readyReplicas field (deployment scaled to 0), treat as 0
+            ready_count = int(ready_str) if ready_str else 0
+
+            if ready_count == expected_replicas:
+                return True
+
+        except (subprocess.CalledProcessError, ValueError):
+            # Transient errors or missing deployment - keep polling
+            pass
+
+        time.sleep(interval)
+
     return False


### PR DESCRIPTION
## Summary

Adds chart tests that exercise RBAC through the public API gateway with real Keycloak JWTs (Envoy → Koku/ROS → insights-rbac), complementing existing in-cluster `X-Rh-Identity` coverage in `test_rbac_access.py`.

Adds to existing tests added in [FLPATH-4073](https://redhat.atlassian.net/browse/FLPATH-4073)

- **Gateway RBAC tests** (`test_rbac_gateway.py`): unauthenticated/403 paths, IAM reader vs writer, ROS/Koku denial for unassigned users, migration job presence, and security-boundary cases (tenant isolation, fail-closed, concurrent sessions).
- **E2E password-grant path** (`test_rbac_access.py`): alice/bob/carol gateway JWT tests aligned with RBAC principals.
- **Keycloak helpers** (`rbac_keycloak_users.py`): provision gateway persona users; session sync for `admin`/`viewer` and `org-admin` realm role; attach `roles` client scope to `cost-management-ui` via Admin API (avoids `invalid_scope` when requesting `roles` in the OAuth scope string).
- **Lab resilience**: retry `register_source` on transient HTTP 424 when RBAC is briefly unavailable; `OIDC_PASSWORD_GRANT_SCOPE` for password grant; IAM bootstrap fallback when `rbac:group:read` is not seeded.
- **Docs**: `RBAC_SECURITY_TESTS.md` describes coverage and gaps.

## Commits

1. `test(rbac): add gateway JWT and ops checks for RBAC flows`
2. `test(rbac): cover IAM management API via gateway JWT`
3. `fix(rbac): IAM bootstrap for images without rbac:group:read`
4. `test(rbac): harden gateway JWT suite for lab Keycloak and flaky RBAC`

## Test plan

- [x] Full chart suite on lab cluster (ocp-edge122): **295 passed**, 21 skipped (`deploy-test-cost-onprem.sh --skip-deploy`)
- [ ] CI / recommend-tests workflow on PR
- [ ] Verify Keycloak realm was deployed via `deploy-rhbk.sh` (needs `roles` client scope on `cost-management-ui` for `realm_access.roles` / org-admin assertions)
- [ ] Re-run auth + e2e markers: `pytest -m auth` and `pytest suites/e2e/test_rbac_access.py`


Made with [Cursor](https://cursor.com)