### PR TITLE
fix(ui): serve RBAC MFE assets under /rbac/ (FLPATH-4164)

### DIFF
--- a/cost-onprem/templates/ui/nginx-config.yaml
+++ b/cost-onprem/templates/ui/nginx-config.yaml
@@ -64,6 +64,14 @@ data:
       add_header Referrer-Policy "strict-origin-when-cross-origin";
     }
 
+    location /rbac/ {
+      alias /opt/app-root/src/rbac/;
+      try_files $uri $uri/ /index.html;
+      add_header X-Frame-Options "SAMEORIGIN";
+      add_header X-Content-Type-Options "nosniff";
+      add_header Referrer-Policy "strict-origin-when-cross-origin";
+    }
+
     location = /logout {
       absolute_redirect off;
       return 302 /oauth2/sign_out?rd=/oauth2/start;


### PR DESCRIPTION
## Summary

Adds nginx `location /rbac/` in the UI sidecar so federated RBAC IAM MFE static assets are served in production clusters.

Required companion to the koku-ui on-prem POC: dev-proxy serves `/rbac/` locally, but cluster deployments need this chart change for `plugin-manifest.json` and remote chunks.

**Jira:** [FLPATH-4164](https://redhat.atlassian.net/browse/FLPATH-4164)
**Related:** [project-koku/koku-ui#5207](https://github.com/project-koku/koku-ui/pull/5207)
**API route dependency:** [FLPATH-4073](https://redhat.atlassian.net/browse/FLPATH-4073) Envoy `/api/rbac/` (separate from this static-asset change)

## Change

- `cost-onprem/templates/ui/nginx-config.yaml` — `location /rbac/` block

## Test plan

- [ ] `helm template` renders nginx config with `/rbac/` location
- [ ] After UI image + chart upgrade: in-pod `curl http://127.0.0.1:8080/rbac/plugin-manifest.json` → **200**

Either this PR or koku-ui #5207 can merge first; full cluster POC needs both.


Made with [Cursor](https://cursor.com)