### PR TITLE
feat(install): opt-in HELM_FORCE_CONFLICTS for SSA upgrade conflicts

### DIFF
--- a/scripts/install-helm-chart.sh
+++ b/scripts/install-helm-chart.sh
@@ -22,6 +22,8 @@
 #   S3_BUCKET_INGRESS / S3_BUCKET_KOKU / S3_BUCKET_ROS - Override individual bucket names (override prefix)
 #   SKIP_S3_SETUP   - Skip S3 bucket creation entirely (default: false)
 #   S3_CLI_IMAGE    - Container image with AWS CLI for bucket creation (default: amazon/aws-cli:latest)
+#   HELM_FORCE_CONFLICTS - When true, pass --force-conflicts to helm upgrade (SSA field ownership;
+#                          use after kubectl set / oc set image on chart-managed resources)
 #
 # Examples:
 #   # Default (clean output with successes/warnings/errors only)
@@ -1302,6 +1304,12 @@ deploy_helm_chart() {
     if [ ${#HELM_EXTRA_ARGS[@]} -gt 0 ]; then
         echo_info "Adding additional Helm arguments: ${HELM_EXTRA_ARGS[*]}"
         helm_cmd="$helm_cmd ${HELM_EXTRA_ARGS[*]}"
+    fi
+
+    # Reconcile server-side apply conflicts (e.g. after oc set image on deployments)
+    if [ "${HELM_FORCE_CONFLICTS:-false}" = "true" ]; then
+        helm_cmd="$helm_cmd --force-conflicts"
+        echo_info "Helm upgrade: --force-conflicts (server-side apply)"
     fi
 
     echo_info "Executing: $helm_cmd"


### PR DESCRIPTION
## Summary

Adds opt-in `HELM_FORCE_CONFLICTS=true` to `scripts/install-helm-chart.sh`, passing `--force-conflicts` to `helm upgrade` when server-side apply (SSA) field-ownership conflicts block the upgrade.

**RFE — not tied to FLPATH-4164.** Improves operability after emergency patches outside Helm (e.g. `oc set image` / `kubectl set` on chart-managed Deployments).

## Motivation

During on-prem UI image rollouts, `helm upgrade` failed with SSA conflicts on `cost-onprem-ui` after an emergency `oc set image` deployment. The workaround bypassed Helm values; subsequent upgrades could not reclaim chart-owned fields without `--force-conflicts`.

The cluster-image rollout skill already sets `HELM_FORCE_CONFLICTS=true` in `rollout-ui-image.sh`; this change exposes the same escape hatch for manual `install-helm-chart.sh` runs.

## Change

- `scripts/install-helm-chart.sh` — document and honor `HELM_FORCE_CONFLICTS` env var

## Test plan

- [x] `HELM_FORCE_CONFLICTS=true ./scripts/install-helm-chart.sh` passes `--force-conflicts` to helm upgrade (dry-run or log inspection)
- [x] Default behavior unchanged when env var unset


Made with [Cursor](https://cursor.com)