### PR TITLE
[FLPATH-4296] Parameterize addressing_style in aws-config ConfigMap

### DIFF
--- a/cost-onprem/templates/_helpers.tpl
+++ b/cost-onprem/templates/_helpers.tpl
@@ -173,10 +173,10 @@ valkey
 
 {{/*
 Resolve object storage config from .Values.objectStorage.
-Returns a dict with keys: endpoint, port, useSSL, secretName, s3Region
+Returns a dict with keys: endpoint, port, useSSL, secretName, s3Region, s3AddressingStyle
 */}}
 {{- define "cost-onprem.storage.config" -}}
-  {{- $os := dict "endpoint" "" "port" 443 "useSSL" true "secretName" "" "s3Region" "onprem" -}}
+  {{- $os := dict "endpoint" "" "port" 443 "useSSL" true "secretName" "" "s3Region" "onprem" "s3AddressingStyle" "path" -}}
   {{- if .Values.objectStorage -}}
     {{- if and .Values.objectStorage.endpoint (ne .Values.objectStorage.endpoint "") -}}
       {{- $_ := set $os "endpoint" .Values.objectStorage.endpoint -}}
@@ -192,6 +192,9 @@ Returns a dict with keys: endpoint, port, useSSL, secretName, s3Region
     {{- end -}}
     {{- if and .Values.objectStorage.s3 .Values.objectStorage.s3.region -}}
       {{- $_ := set $os "s3Region" .Values.objectStorage.s3.region -}}
+    {{- end -}}
+    {{- if and .Values.objectStorage.s3 .Values.objectStorage.s3.addressingStyle -}}
+      {{- $_ := set $os "s3AddressingStyle" .Values.objectStorage.s3.addressingStyle -}}
     {{- end -}}
   {{- end -}}
   {{- $os | toJson -}}
@@ -277,6 +280,14 @@ S3 region for signature generation
 {{- define "cost-onprem.storage.s3Region" -}}
 {{- $cfg := include "cost-onprem.storage.config" . | fromJson -}}
 {{- $cfg.s3Region -}}
+{{- end }}
+
+{{/*
+S3 addressing style for bucket URL resolution (path, auto, or virtual)
+*/}}
+{{- define "cost-onprem.storage.s3AddressingStyle" -}}
+{{- $cfg := include "cost-onprem.storage.config" . | fromJson -}}
+{{- $cfg.s3AddressingStyle -}}
 {{- end }}
 
 {{/*

--- a/cost-onprem/templates/cost-management/configmap-aws-config.yaml
+++ b/cost-onprem/templates/cost-management/configmap-aws-config.yaml
@@ -10,4 +10,4 @@ data:
     region = {{ include "cost-onprem.storage.s3Region" . }}
     s3 =
       signature_version = s3v4
-      addressing_style = path
+      addressing_style = {{ include "cost-onprem.storage.s3AddressingStyle" . }}

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -926,6 +926,12 @@ objectStorage:
   # Override to AWS region (e.g., "us-east-1") if deploying to AWS S3
   s3:
     region: "onprem"
+    # S3 addressing style for bucket URL resolution:
+    #   "path"    - Path-style: endpoint/bucket (default, for on-prem S3-compatible backends)
+    #   "auto"    - SDK auto-detection: virtual-hosted when supported (recommended for AWS S3)
+    #   "virtual" - Virtual-hosted style: bucket.endpoint/object (AWS preferred, not supported by most on-prem backends)
+    # The install script sets this to "auto" for AWS S3 endpoints (*.amazonaws.com).
+    addressingStyle: "path"
 
 
 # -----------------------------------------------------------------------------

--- a/scripts/install-helm-chart.sh
+++ b/scripts/install-helm-chart.sh
@@ -1274,6 +1274,12 @@ deploy_helm_chart() {
             helm_cmd="$helm_cmd --set objectStorage.s3.region=\"${S3_REGION}\""
             echo_info "objectStorage.s3.region=${S3_REGION} (AWS S3 / SigV4)"
         fi
+        local deploy_s3_host
+        deploy_s3_host=$(parse_s3_host "${S3_ENDPOINT}")
+        if is_aws_s3_endpoint_host "$deploy_s3_host"; then
+            helm_cmd="$helm_cmd --set objectStorage.s3.addressingStyle=auto"
+            echo_info "objectStorage.s3.addressingStyle=auto (AWS S3 virtual-hosted style)"
+        fi
         echo_success "✓ S3 endpoint configured: ${S3_ENDPOINT} (port ${s3_port}, SSL=${s3_ssl})"
     elif kubectl get crd noobaas.noobaa.io >/dev/null 2>&1 && \
          kubectl get noobaa -n openshift-storage >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- The `aws-config` ConfigMap hardcoded `addressing_style = path` with no override — locking all pods (Koku, MASU, ingress, celery workers) to path-style S3 addressing regardless of backend type
- Added `objectStorage.s3.addressingStyle` parameter to `values.yaml` (default `"path"` for backward compat), templated it through `_helpers.tpl` and the ConfigMap following the existing `s3Region` pattern
- `deploy_helm_chart()` in the install script now auto-detects AWS S3 endpoints (via existing `is_aws_s3_endpoint_host()`) and injects `--set objectStorage.s3.addressingStyle=auto`

**Jira:** [FLPATH-4296](https://redhat.atlassian.net/browse/FLPATH-4296)

## Context

AWS path-style S3 addressing is [deprecated](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) (enforcement indefinitely delayed). On-prem backends (NooBaa, Ceph RGW, S4, MinIO) require `path`, but AWS S3 users need `auto` to let boto3 pick the optimal addressing per-bucket. The install script already detected AWS for bucket creation but didn't propagate `addressingStyle` to Helm.

**Note:** When users provide their own values file with `objectStorage.endpoint` set (`USER_S3_CONFIGURED=true`), the script skips all `--set` overrides. Those users must add `objectStorage.s3.addressingStyle: auto` in their values file manually. This is consistent with how the script handles user-managed config.

## Verification

```bash
# Default renders path (backward compat)
helm template cost-onprem ./cost-onprem | grep addressing_style
#   addressing_style = path

# Override renders auto
helm template cost-onprem ./cost-onprem --set objectStorage.s3.addressingStyle=auto | grep addressing_style
#   addressing_style = auto

# Lint passes
helm lint ./cost-onprem
```

## Test plan

- [x] `helm template` with default values renders `addressing_style = path`
- [x] `helm template` with `--set objectStorage.s3.addressingStyle=auto` renders `addressing_style = auto`
- [x] `helm lint` passes
- [x] Existing CI test suite passes (no test changes needed — tests don't assert on ConfigMap content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)