### PR TITLE
chore: update OWNERS file to include new approvers and reviewers from COST

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@ approvers:
   - ELK4N4
   - jordigilh
   - lcouzens
+  - martinpovolny
   - myersCody
   - testetson22
 
@@ -11,5 +12,6 @@ reviewers:
   - ELK4N4
   - jordigilh
   - lcouzens
+  - martinpovolny
   - myersCody
   - testetson22

--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,15 @@
 approvers:
-  - jordigilh    # Jordi Gil <jgil@redhat.com>
-  - masayag      # Moti Asayag <masayag@redhat.com>
-  - testetson22  # Thomas Stetson
-  - ELK4N4       # Elkana
-
+  - chadcrum
+  - ELK4N4
+  - jordigilh
+  - lcouzens
+  - myersCody
+  - testetson22
 
 reviewers:
-  - jordigilh    # Jordi Gil <jgil@redhat.com>
-  - masayag      # Moti Asayag <masayag@redhat.com>
-  - testetson22  # Thomas Stetson
-  - ELK4N4       # Elkana
+  - chadcrum
+  - ELK4N4
+  - jordigilh
+  - lcouzens
+  - myersCody
+  - testetson22


### PR DESCRIPTION
Added chadcrum, lcouzens, and myersCody to both approvers and reviewers sections.

Also removed Moti. If we want to add others we can; just keeping it narrow to start