### PR TITLE
FLPATH-4091 Template or split out various chart config 

### DIFF
--- a/cost-onprem/templates/gateway/configmap-envoy.yaml
+++ b/cost-onprem/templates/gateway/configmap-envoy.yaml
@@ -41,7 +41,6 @@ data:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               stat_prefix: gateway_http
               codec_type: AUTO
-              request_timeout: 60s
               stream_idle_timeout: 300s
               max_request_headers_kb: 96
               common_http_protocol_options:
@@ -158,11 +157,11 @@ data:
                       prefix: "/api/ingress/"
                     route:
                       cluster: ingress-backend
-                      timeout: 30s
+                      timeout: {{ .Values.jwtAuth.envoy.ingressTimeout | default "30s" }}
                       retry_policy:
                         retry_on: 5xx,reset,connect-failure,refused-stream
                         num_retries: 2
-                        per_try_timeout: 10s
+                        per_try_timeout: {{ .Values.jwtAuth.envoy.ingressPerTryTimeout | default "10s" }}
 
               http_filters:
               # JWT authentication filter

--- a/cost-onprem/templates/gateway/deployment.yaml
+++ b/cost-onprem/templates/gateway/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: gateway
 spec:
-  replicas: {{ .Values.jwtAuth.envoy.replicas | default 1 }}
+  replicas: {{ .Values.jwtAuth.envoy.replicas | default 2 }}
   selector:
     matchLabels:
       {{- include "cost-onprem.selectorLabels" . | nindent 6 }}

--- a/cost-onprem/templates/gateway/deployment.yaml
+++ b/cost-onprem/templates/gateway/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: gateway
 spec:
-  replicas: {{ .Values.jwtAuth.envoy.replicas | default 2 }}
+  replicas: {{ .Values.jwtAuth.envoy.replicas }}
   selector:
     matchLabels:
       {{- include "cost-onprem.selectorLabels" . | nindent 6 }}

--- a/cost-onprem/templates/gateway/deployment.yaml
+++ b/cost-onprem/templates/gateway/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: gateway
 spec:
-  replicas: 2
+  replicas: {{ .Values.jwtAuth.envoy.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "cost-onprem.selectorLabels" . | nindent 6 }}

--- a/cost-onprem/templates/kruize/deployment.yaml
+++ b/cost-onprem/templates/kruize/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: ros-optimization
 spec:
-  replicas: {{ .Values.kruize.replicas | default 1 }}
+  replicas: {{ .Values.kruize.replicas }}
   selector:
     matchLabels:
       {{- include "cost-onprem.selectorLabels" . | nindent 6 }}

--- a/cost-onprem/templates/kruize/deployment.yaml
+++ b/cost-onprem/templates/kruize/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: ros-optimization
 spec:
-  replicas: 1
+  replicas: {{ .Values.kruize.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "cost-onprem.selectorLabels" . | nindent 6 }}

--- a/cost-onprem/templates/ros/processor/deployment.yaml
+++ b/cost-onprem/templates/ros/processor/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: ros-processor
 spec:
-  replicas: {{ .Values.ros.processor.replicas | default 1 }}
+  replicas: {{ .Values.ros.processor.replicas }}
   selector:
     matchLabels:
       {{- include "cost-onprem.selectorLabels" . | nindent 6 }}

--- a/cost-onprem/templates/ros/processor/deployment.yaml
+++ b/cost-onprem/templates/ros/processor/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cost-onprem.labels" . | nindent 4 }}
     app.kubernetes.io/component: ros-processor
 spec:
-  replicas: 1
+  replicas: {{ .Values.ros.processor.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "cost-onprem.selectorLabels" . | nindent 6 }}
@@ -125,7 +125,7 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 5
           resources:
-            {{- toYaml .Values.resources.application | nindent 12 }}
+            {{- toYaml .Values.resources.rosProcessor | nindent 12 }}
       volumes:
         - name: cdapp-config
           configMap:

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -241,6 +241,7 @@ costManagement:
   # ---------------------------------------------------------------------------
   listener:
     enabled: true
+    # On-prem: 1 replica to fit cluster constraints (SaaS uses 2)
     replicas: 1
     resources:
       # Aligned with SaaS Clowder configuration
@@ -947,7 +948,7 @@ jwtAuth:
       tag: "2.6"
       pullPolicy: IfNotPresent
 
-    replicas: 1
+    replicas: 2
     port: 9080
 
     # Route-level timeouts for the ingress (file upload) endpoint.

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -240,7 +240,6 @@ costManagement:
   # ---------------------------------------------------------------------------
   listener:
     enabled: true
-    # On-prem: 1 replica to fit cluster constraints (SaaS uses 2)
     replicas: 1
     resources:
       # Aligned with SaaS Clowder configuration
@@ -945,7 +944,12 @@ jwtAuth:
       tag: "2.6"
       pullPolicy: IfNotPresent
 
+    replicas: 1
     port: 9080
+
+    # Route-level timeouts for the ingress (file upload) endpoint.
+    ingressTimeout: "30s"
+    ingressPerTryTimeout: "10s"
     servicePort: 80  # Service port exposed to other components (nginx, etc.)
     adminPort: 9901
     logLevel: info

--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -70,6 +70,7 @@ ros:
 
   # Processor Component - Processes uploaded data
   processor:
+    replicas: 1
     metricsPort: 9000
     logLevel: INFO
     serviceName: ros-processor
@@ -437,6 +438,8 @@ costManagement:
 # -----------------------------------------------------------------------------
 # Kruize is used exclusively by ROS for workload optimization recommendations
 kruize:
+  replicas: 1
+
   image:
     repository: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune
     tag: "5eeae99"
@@ -1109,9 +1112,18 @@ resources:
       memory: "512Mi"
       cpu: "500m"
 
-  # Standard application services (ROS API, Processor, Poller, Housekeeper)
+  # Standard application services (ROS API, Ingress, Poller, Housekeeper)
   # Aligned with SaaS Clowder configuration (ros-ocp-backend/clowdapp.yaml)
   application:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
+
+  # ROS Processor needs more memory than other application services.
+  rosProcessor:
     requests:
       memory: "1Gi"
       cpu: "500m"


### PR DESCRIPTION
This is the first of a few PRs that enables and/or enhances performance testing with larger scale profiles. If the chart persists after the operator is done, this will be generally useful for tuning a deployment, I'd expect. 

Verbose findings, rightsizing, and issues will follow in subsequent PRs.

- **Template Envoy gateway configuration**: Remove the redundant global `request_timeout` (which silently capped all requests at 60s, conflicting with `stream_idle_timeout: 300s`), and make the ingress route `timeout` and `per_try_timeout` configurable via `jwtAuth.envoy.ingressTimeout` / `ingressPerTryTimeout` in values.yaml. Also template the gateway replica count (was hardcoded to 2).
- **Separate ROS processor resources**: Give the ROS processor its own `resources.rosProcessor` block instead of sharing `resources.application` with lighter services. The processor's Go-based workload has different memory characteristics than the Python API services.
- **Template replica counts**: Make Kruize (`kruize.replicas`) and ROS processor (`ros.processor.replicas`) replica counts overridable at deploy time for performance tuning.

## Test plan

- [x] `helm template` renders correctly with default values (all defaults preserved)
- [x] `helm template` renders correctly with overridden values (e.g., `--set jwtAuth.envoy.ingressTimeout=120s`)
- [x] Deploy to test cluster and verify gateway, Kruize, and ROS processor pods start normally
- [x] Run chart test suite: `./scripts/run-pytest.sh --helm`
- [x] Run E2E suite: `./scripts/run-pytest.sh --e2e`

Ref: FLPATH-4091