### PR TITLE
[COST-7740] Fix koku migration job missing TLS volume mounts

### DIFF
--- a/cost-onprem/templates/cost-management/jobs/migration.yaml
+++ b/cost-onprem/templates/cost-management/jobs/migration.yaml
@@ -26,9 +26,6 @@ spec:
       securityContext:
         {{- include "cost-onprem.securityContext.pod" . | nindent 8 }}
 
-      initContainers:
-      {{- include "cost-onprem.koku.initContainer.combineCA" . | nindent 6 }}
-
       containers:
       - name: migrate
         image: "{{ include "cost-onprem.koku.image" . }}"
@@ -115,7 +112,13 @@ spec:
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
 
         volumeMounts:
-        {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
+        - name: tmp
+          mountPath: /tmp
+        {{- if and .Values.valkey.tls.enabled .Values.valkey.tls.caCertSecretName }}
+        - name: redis-tls-ca
+          mountPath: /etc/redis-tls
+          readOnly: true
+        {{- end }}
 
         securityContext:
           {{- include "cost-onprem.securityContext.container" . | nindent 10 }}
@@ -129,4 +132,13 @@ spec:
             memory: 1Gi
 
       volumes:
-      {{- include "cost-onprem.koku.volumes" . | nindent 6 }}
+      - name: tmp
+        emptyDir: {}
+      {{- if and .Values.valkey.tls.enabled .Values.valkey.tls.caCertSecretName }}
+      - name: redis-tls-ca
+        secret:
+          secretName: {{ .Values.valkey.tls.caCertSecretName }}
+          items:
+            - key: ca.crt
+              path: ca.crt
+      {{- end }}

--- a/cost-onprem/templates/cost-management/jobs/migration.yaml
+++ b/cost-onprem/templates/cost-management/jobs/migration.yaml
@@ -26,6 +26,9 @@ spec:
       securityContext:
         {{- include "cost-onprem.securityContext.pod" . | nindent 8 }}
 
+      initContainers:
+      {{- include "cost-onprem.koku.initContainer.combineCA" . | nindent 6 }}
+
       containers:
       - name: migrate
         image: "{{ include "cost-onprem.koku.image" . }}"
@@ -112,8 +115,7 @@ spec:
         {{- include "cost-onprem.koku.commonEnv" . | nindent 8 }}
 
         volumeMounts:
-        - name: tmp
-          mountPath: /tmp
+        {{- include "cost-onprem.koku.volumeMounts" . | nindent 8 }}
 
         securityContext:
           {{- include "cost-onprem.securityContext.container" . | nindent 10 }}
@@ -127,5 +129,4 @@ spec:
             memory: 1Gi
 
       volumes:
-      - name: tmp
-        emptyDir: {}
+      {{- include "cost-onprem.koku.volumes" . | nindent 6 }}


### PR DESCRIPTION
## Summary

- Replace hardcoded `volumeMounts`/`volumes` in the koku migration job with the shared helpers (`cost-onprem.koku.volumeMounts` / `cost-onprem.koku.volumes`)
- Add `cost-onprem.koku.initContainer.combineCA` init container to populate the combined CA bundle
- Ensures `redis-tls-ca` volume is mounted when `valkey.tls.caCertSecretName` is set, matching all other 12 koku workloads

## Root Cause

PR #169 (FLPATH-3267) added TLS volume support to the RBAC migration job but missed the koku migration job. The koku job had hardcoded volumes (`tmp` only) and was never updated to use the shared helpers that were later extended for TLS.

## Impact

When `valkey.tls.caCertSecretName` is set, the `commonEnv` helper injects `REDIS_SSL_CA_CERTS="/etc/redis-tls/ca.crt"` into the job's environment, but the Secret volume containing `ca.crt` was never mounted — the file didn't exist in the container. Currently latent (Django migrations don't touch Redis), but would cause `FileNotFoundError` if any future code adds a cache operation during `django.setup()` or migration execution.

## Test plan

- [x] `helm lint` passes with TLS values enabled
- [x] `helm template` with `--set valkey.tls.enabled=true --set valkey.tls.caCertSecretName=redis-tls-ca` renders `redis-tls-ca` volume + mount in the migration job
- [x] `helm template` without TLS values omits `redis-tls-ca` (conditional logic preserved)
- [x] Deploy to cluster and verify migration job pod has correct volumes


Made with [Cursor](https://cursor.com)