### PR TITLE
FLPATH-4302: Increase Kruize CPU limits to prevent pod restarts under load

### DIFF
--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -1138,14 +1138,14 @@ resources:
       memory: "1Gi"
       cpu: "1"
 
-  # Kruize is memory-intensive (Java workload)
+  # Kruize is CPU-intensive under load (Java workload, liveness probe sensitive)
   kruize:
     requests:
       memory: "1Gi"
-      cpu: "500m"
+      cpu: "1000m"
     limits:
       memory: "2Gi"
-      cpu: "1000m"
+      cpu: "2000m"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- Doubles Kruize CPU requests (`500m` → `1000m`) and limits (`1000m` → `2000m`) to prevent liveness probe failures and pod restarts during moderate-to-heavy ROS workloads
- No memory changes — peak usage was 786 MB (38% of 2Gi limit), confirming memory is not the bottleneck
- More right-sizing details here: https://github.com/insights-onprem/cost-onprem-chart/pull/187
## Test plan

- [x] Validated with `ros_004` memory pressure test (50 concurrent experiments): 0 restarts with 2 CPU cores vs 1 restart with 1 CPU core
- [x] CI e2e smoke passes
- [x] Verify Kruize pod stability under full IQE profile