### PR TITLE
FLPATH-4489: Pre-seed exchange rates before IQE tests

### DIFF
--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -667,8 +667,8 @@ fi
 echo ""
 echo "Seeding exchange rates via masu internal API..."
 MASU_INTERNAL_URL="http://${MASU_HOSTNAME}:${MASU_PORT}/api/cost-management/v1"
-EXCHANGE_RATE_RESPONSE=$(kubectl exec -n "${NAMESPACE}" deploy/${HELM_RELEASE_NAME}-koku-api -c koku-api -- \
-    curl -sf "${MASU_INTERNAL_URL}/update_exchange_rates/" 2>/dev/null || echo "")
+EXCHANGE_RATE_RESPONSE=$(kubectl exec --request-timeout=30s -n "${NAMESPACE}" deploy/${HELM_RELEASE_NAME}-koku-api -c koku-api -- \
+    curl -sf --max-time 20 "${MASU_INTERNAL_URL}/update_exchange_rates/" 2>/dev/null || echo "")
 if [ -n "$EXCHANGE_RATE_RESPONSE" ]; then
     RATE_COUNT=$(echo "$EXCHANGE_RATE_RESPONSE" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('updated_exchange_rates',{})))" 2>/dev/null || echo "0")
     echo "✓ Exchange rates seeded (${RATE_COUNT} currencies)"

--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -661,6 +661,21 @@ else
     echo "WARNING: Could not extract cluster CA certificates"
 fi
 
+# Pre-seed exchange rates so currency-filtered tests have valid rates available.
+# The get_daily_currency_rates Celery task runs on a schedule and may not have
+# executed yet on fresh/ephemeral deployments.
+echo ""
+echo "Seeding exchange rates via masu internal API..."
+MASU_INTERNAL_URL="http://${MASU_HOSTNAME}:${MASU_PORT}/api/cost-management/v1"
+EXCHANGE_RATE_RESPONSE=$(kubectl exec -n "${NAMESPACE}" deploy/${HELM_RELEASE_NAME}-koku-api -c koku-api -- \
+    curl -sf "${MASU_INTERNAL_URL}/update_exchange_rates/" 2>/dev/null || echo "")
+if [ -n "$EXCHANGE_RATE_RESPONSE" ]; then
+    RATE_COUNT=$(echo "$EXCHANGE_RATE_RESPONSE" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('updated_exchange_rates',{})))" 2>/dev/null || echo "0")
+    echo "✓ Exchange rates seeded (${RATE_COUNT} currencies)"
+else
+    echo "⚠ WARNING: Could not seed exchange rates. Currency-filtered tests may fail."
+fi
+
 echo ""
 echo "Creating IQE test pod..."
 


### PR DESCRIPTION
- Calls the masu `update_exchange_rates/` endpoint before creating the IQE test pod to ensure the `exchange_rates` table is populated on fresh/ephemeral deployments
- Prevents currency-filtered IQE tests from failing with HTTP 400 when the `get_daily_currency_rates` periodic Celery task hasn't run yet

## Testing

- [x] Verified on ocp-edge94: endpoint returns 22 currencies, `test_api_ocp_cost_items_match_csv_items_report_filter` passes 16/16
- [x] Non-blocking — warns but continues if seeding fails (e.g., no external network access); this could be an issue in disconnected, but all external dependencies will generally need to be managed in such cases.