### PR TITLE
fix(helm): decouple Kafka TLS env vars from SASL gate (COST-7893)

### DIFF
--- a/cost-onprem/templates/_helpers-koku.tpl
+++ b/cost-onprem/templates/_helpers-koku.tpl
@@ -339,6 +339,7 @@ Common environment variables for Koku API and Celery
 - name: INSIGHTS_KAFKA_PORT
   value: {{ include "cost-onprem.koku.kafka.port" . | quote }}
 {{- include "cost-onprem.kafka.saslEnv" . }}
+{{- include "cost-onprem.kafka.tlsEnv" . }}
 - name: S3_ENDPOINT
   value: {{ include "cost-onprem.storage.endpointWithProtocol" . | quote }}
 - name: REQUESTED_BUCKET

--- a/cost-onprem/templates/_helpers.tpl
+++ b/cost-onprem/templates/_helpers.tpl
@@ -427,14 +427,12 @@ Kafka security protocol resolver (supports both internal and external Kafka)
 {{- end }}
 
 {{/*
-Kafka SASL environment variables (reusable across all Kafka-consuming deployments)
-Renders env var block for SASL authentication; no-op when kafka.sasl.mechanism is empty.
+Kafka SASL authentication environment variables (mechanism + credentials only)
+No-op when kafka.sasl.mechanism is empty. Pair with tlsEnv for transport security.
 Usage: {{ include "cost-onprem.kafka.saslEnv" . | nindent 12 }}
 */}}
 {{- define "cost-onprem.kafka.saslEnv" -}}
 {{- if .Values.kafka.sasl.mechanism }}
-- name: KAFKA_SECURITY_PROTOCOL
-  value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
 - name: KAFKA_SASL_MECHANISM
   value: {{ .Values.kafka.sasl.mechanism | quote }}
 {{- if .Values.kafka.sasl.existingSecret }}
@@ -449,10 +447,23 @@ Usage: {{ include "cost-onprem.kafka.saslEnv" . | nindent 12 }}
       name: {{ .Values.kafka.sasl.existingSecret | quote }}
       key: password
 {{- end }}
-{{- if .Values.kafka.tls.enabled }}
+{{- end }}
+{{- end }}
+
+{{/*
+Kafka TLS/transport-security environment variables (independent of SASL)
+Renders KAFKA_SECURITY_PROTOCOL when non-PLAINTEXT, and KAFKA_SSL_CA_LOCATION
+when TLS is enabled with a CA cert secret (matching tlsVolume/tlsVolumeMount gates).
+Usage: {{ include "cost-onprem.kafka.tlsEnv" . | nindent 12 }}
+*/}}
+{{- define "cost-onprem.kafka.tlsEnv" -}}
+{{- if ne (include "cost-onprem.kafka.securityProtocol" .) "PLAINTEXT" }}
+- name: KAFKA_SECURITY_PROTOCOL
+  value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
+{{- end }}
+{{- if and .Values.kafka.tls.enabled .Values.kafka.tls.caCertSecret }}
 - name: KAFKA_SSL_CA_LOCATION
   value: "/etc/kafka/certs/ca.crt"
-{{- end }}
 {{- end }}
 {{- end }}
 
@@ -462,8 +473,6 @@ Usage: {{ include "cost-onprem.kafka.ingressSaslEnv" . | nindent 12 }}
 */}}
 {{- define "cost-onprem.kafka.ingressSaslEnv" -}}
 {{- if .Values.kafka.sasl.mechanism }}
-- name: INGRESS_KAFKASECURITYPROTOCOL
-  value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
 - name: INGRESS_SASLMECHANISM
   value: {{ .Values.kafka.sasl.mechanism | quote }}
 {{- if .Values.kafka.sasl.existingSecret }}
@@ -478,10 +487,21 @@ Usage: {{ include "cost-onprem.kafka.ingressSaslEnv" . | nindent 12 }}
       name: {{ .Values.kafka.sasl.existingSecret | quote }}
       key: password
 {{- end }}
-{{- if .Values.kafka.tls.enabled }}
+{{- end }}
+{{- end }}
+
+{{/*
+Kafka TLS/transport-security environment variables for Ingress (uses INGRESS_* prefix)
+Usage: {{ include "cost-onprem.kafka.ingressTlsEnv" . | nindent 12 }}
+*/}}
+{{- define "cost-onprem.kafka.ingressTlsEnv" -}}
+{{- if ne (include "cost-onprem.kafka.securityProtocol" .) "PLAINTEXT" }}
+- name: INGRESS_KAFKASECURITYPROTOCOL
+  value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
+{{- end }}
+{{- if and .Values.kafka.tls.enabled .Values.kafka.tls.caCertSecret }}
 - name: INGRESS_KAFKACA
   value: "/etc/kafka/certs/ca.crt"
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/cost-onprem/templates/cost-management/jobs/migration.yaml
+++ b/cost-onprem/templates/cost-management/jobs/migration.yaml
@@ -114,6 +114,7 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        {{- include "cost-onprem.kafka.tlsVolumeMount" . | nindent 8 }}
         {{- if and .Values.valkey.tls.enabled .Values.valkey.tls.caCertSecretName }}
         - name: redis-tls-ca
           mountPath: /etc/redis-tls
@@ -134,6 +135,7 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
+      {{- include "cost-onprem.kafka.tlsVolume" . | nindent 6 }}
       {{- if and .Values.valkey.tls.enabled .Values.valkey.tls.caCertSecretName }}
       - name: redis-tls-ca
         secret:

--- a/cost-onprem/templates/ingress/deployment.yaml
+++ b/cost-onprem/templates/ingress/deployment.yaml
@@ -88,6 +88,7 @@ spec:
             - name: INGRESS_KAFKAGROUPID
               value: {{ .Values.ingress.kafka.groupId | default "ingress" | quote }}
             {{- include "cost-onprem.kafka.ingressSaslEnv" . | nindent 12 }}
+            {{- include "cost-onprem.kafka.ingressTlsEnv" . | nindent 12 }}
 
             # Authentication configuration
             # JWT is handled by centralized gateway, backend trusts X-Rh-Identity header

--- a/cost-onprem/templates/ros/api/deployment.yaml
+++ b/cost-onprem/templates/ros/api/deployment.yaml
@@ -91,9 +91,8 @@ spec:
               value: {{ include "cost-onprem.database.url" . }}
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
-            - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
             {{- include "cost-onprem.kafka.saslEnv" . | nindent 12 }}
+            {{- include "cost-onprem.kafka.tlsEnv" . | nindent 12 }}
           {{- if and .Values.kafka.tls.enabled .Values.kafka.tls.caCertSecret }}
           volumeMounts:
             {{- include "cost-onprem.kafka.tlsVolumeMount" . | nindent 12 }}

--- a/cost-onprem/templates/ros/housekeeper/deployment.yaml
+++ b/cost-onprem/templates/ros/housekeeper/deployment.yaml
@@ -78,9 +78,8 @@ spec:
               value: {{ include "cost-onprem.database.url" . }}
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
-            - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
             {{- include "cost-onprem.kafka.saslEnv" . | nindent 12 }}
+            {{- include "cost-onprem.kafka.tlsEnv" . | nindent 12 }}
             # Topic for source deletion events from Koku (matches hardcoded topic in Koku)
             - name: SOURCES_EVENT_TOPIC
               value: "platform.sources.event-stream"

--- a/cost-onprem/templates/ros/processor/deployment.yaml
+++ b/cost-onprem/templates/ros/processor/deployment.yaml
@@ -82,9 +82,8 @@ spec:
               value: {{ include "cost-onprem.database.url" . }}
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
-            - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
             {{- include "cost-onprem.kafka.saslEnv" . | nindent 12 }}
+            {{- include "cost-onprem.kafka.tlsEnv" . | nindent 12 }}
             - name: KAFKA_CONSUMER_GROUP_ID
               value: {{ .Values.ros.processor.kafkaConsumerGroupId | quote }}
             - name: KAFKA_AUTO_COMMIT

--- a/cost-onprem/templates/ros/recommendation-poller/deployment.yaml
+++ b/cost-onprem/templates/ros/recommendation-poller/deployment.yaml
@@ -83,9 +83,8 @@ spec:
               value: {{ include "cost-onprem.database.url" . }}
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "cost-onprem.kafka.bootstrapServers" . | quote }}
-            - name: KAFKA_SECURITY_PROTOCOL
-              value: {{ include "cost-onprem.kafka.securityProtocol" . | quote }}
             {{- include "cost-onprem.kafka.saslEnv" . | nindent 12 }}
+            {{- include "cost-onprem.kafka.tlsEnv" . | nindent 12 }}
             - name: KAFKA_CONSUMER_GROUP_ID
               value: {{ .Values.ros.recommendationPoller.kafkaConsumerGroupId | quote }}
             - name: KAFKA_AUTO_COMMIT


### PR DESCRIPTION
## Summary

Kafka TLS environment variables (KAFKA_SECURITY_PROTOCOL, KAFKA_SSL_CA_LOCATION) were nested inside the SASL gate, so TLS-only deployments (SSL without SASL) never rendered them. Extract into independent tlsEnv/ingressTlsEnv helpers, align the CA location gate with volume/mount requirements (both tls.enabled AND tls.caCertSecret), remove duplicate KAFKA_SECURITY_PROTOCOL from ROS templates, and add Kafka TLS to the migration job.

For rendered before/after YAML showing exactly what was missing and what the fix produces for each affected manifest, see the [detailed Jira comment on COST-7893](https://redhat.atlassian.net/browse/COST-7893?focusedId=17561306&focusedCommentId=17561306#comment-17561306).

## Changes

- Refactored `_helpers.tpl` to separate TLS env vars from SASL logic
- Added `tlsEnv` and `ingressTlsEnv` helpers for consistent CA/security protocol rendering
- Updated all Koku, ROS, and ingress deployments to use the new helpers
- Fixed CA location gating to match volume/mount logic (prevents phantom env vars)
- Removed duplicate KAFKA_SECURITY_PROTOCOL declarations in ROS templates
- Added TLS volume/mount to migration job so it can reach Kafka with certs

## Verification

All four bugs are fixed by the refactored helpers:
1. TLS env vars now render regardless of SASL configuration
2. CA location gate aligned with volume availability
3. No more duplicate env vars in ROS deployments
4. Migration job has TLS support matching other components