### PR TITLE
Update koku-ui-onprem image tag to b1d82e5

### DIFF
--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -1072,7 +1072,7 @@ ui:
   app:
     image:
       repository: quay.io/insights-onprem/koku-ui-onprem
-      tag: "a15e49551a33ed1718f1434c012cc38a2174fc64"
+      tag: "b1d82e5291897be83be574a56acd63f4ac54464d"
       pullPolicy: IfNotPresent
     port: 8080
     resources:

--- a/tests/suites/ui/test_navigation.py
+++ b/tests/suites/ui/test_navigation.py
@@ -62,8 +62,10 @@ class TestDefaultNavigation:
         authenticated_page.goto(ui_url)
         authenticated_page.wait_for_load_state("networkidle")
         
-        # Navigation list should be visible
-        nav_list = authenticated_page.locator("ul.pf-v6-c-nav__list")
+        # Primary nav list (direct child of Global nav; excludes IAM subnav)
+        nav_list = authenticated_page.locator(
+            'nav[aria-label="Global"] > ul.pf-v6-c-nav__list'
+        )
         expect(nav_list).to_be_visible()
         
         # Check that expected nav items exist


### PR DESCRIPTION
## Summary
- Bump the default `koku-ui-onprem` UI image tag in `cost-onprem/values.yaml` from `a15e495` to `b1d82e5291897be83be574a56acd63f4ac54464d`.
- The new image is the latest Quay build (`insights-onprem/koku-ui-onprem:latest`, 2026-07-14) and includes COST-7671 / [koku-ui PR #5391](https://github.com/project-koku/koku-ui/pull/5391) RBAC UI changes (My User Access in user menu, etc.).

## Test plan
- [x] Verified image pulls from Quay (`sha256:4d47c85cee9d84ae471c9e5fc9fe0da3d3849ec6a4b572981113f8a3ee56b91d`)
- [x] Deployed to `rbac-test` on `ocp-edge122` and confirmed rollout succeeds
- [ ] CI/chart validation passes on PR


Made with [Cursor](https://cursor.com)