### PR TITLE
COST-7618 - Sizing Profile Overlays

### DIFF
--- a/.github/workflows/validate-deploy-test-script.yml
+++ b/.github/workflows/validate-deploy-test-script.yml
@@ -186,6 +186,8 @@ jobs:
           # Sizing profile (COST-7618)
           run_case         "--sizing-profile medium"                   "--sizing-profile medium"                  "Full deployment"       true    true   false  false
           run_case         "--sizing-profile large"                    "--sizing-profile large"                   "Full deployment"       true    true   false  false
+          run_case         "--perf-only --sizing-profile medium"       "--perf-only --sizing-profile medium"      "Performance-only"      false   false  true   false
+          run_case         "--skip-deploy --sizing-profile large"      "--skip-deploy --sizing-profile large"     "Tests-only"            false   true   false  false
 
           # Chart version flags
           run_case         "--devel"                                   "--devel"                                  "Full deployment"       true    true   false  false

--- a/.github/workflows/validate-deploy-test-script.yml
+++ b/.github/workflows/validate-deploy-test-script.yml
@@ -183,6 +183,10 @@ jobs:
           run_case         "--perf-only --deploy-observability"        "--perf-only --deploy-observability"        "Performance-only"      false   false  true   false
           run_case         "--perf-only --collect-metrics"             "--perf-only --collect-metrics"             "Performance-only"      false   false  true   false
 
+          # Sizing profile (COST-7618)
+          run_case         "--sizing-profile medium"                   "--sizing-profile medium"                  "Full deployment"       true    true   false  false
+          run_case         "--sizing-profile large"                    "--sizing-profile large"                   "Full deployment"       true    true   false  false
+
           # Chart version flags
           run_case         "--devel"                                   "--devel"                                  "Full deployment"       true    true   false  false
           run_case         "--chart-version 0.2.19"                    "--chart-version 0.2.19"                   "Full deployment"       true    true   false  false

--- a/cost-onprem/values-large.yaml
+++ b/cost-onprem/values-large.yaml
@@ -1,0 +1,87 @@
+# Large profile overlay — Cost On-Prem
+# =====================================
+# COST-7618 / sizing-guide.md
+# Aligned with apply_perf_profile_config() large case in
+# scripts/lib/perf-testing.sh, plus database sizing from the sizing guide.
+#
+# Usage:
+#   helm upgrade --install cost-onprem ./cost-onprem \
+#     -n cost-onprem -f openshift-values.yaml \
+#     -f cost-onprem/values-large.yaml
+#
+# Target workload: ~7 clusters, ~133 nodes, ~1,964 CPU cores (21% of customers)
+#
+# After helm upgrade, restart the gateway deployment so Envoy picks up timeout
+# ConfigMap changes (PERF-FINDING-020):
+#   oc rollout restart deployment/cost-onprem-gateway -n cost-onprem
+
+resources:
+  database:
+    requests:
+      cpu: "2000m"
+      memory: "4Gi"
+    limits:
+      cpu: "4000m"
+      memory: "16Gi"
+  kruize:
+    requests:
+      cpu: "1000m"
+      memory: "2Gi"
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+  rosProcessor:
+    requests:
+      memory: "2Gi"
+    limits:
+      memory: "4Gi"
+  application:
+    requests:
+      memory: "2Gi"
+    limits:
+      memory: "4Gi"
+
+costManagement:
+  listener:
+    replicas: 3
+    resources:
+      requests:
+        memory: "2Gi"
+      limits:
+        memory: "4Gi"
+  celery:
+    workers:
+      ocp:
+        replicas: 3
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "1000m"
+            memory: "2Gi"
+      summary:
+        replicas: 3
+        resources:
+          requests:
+            cpu: "500m"
+          limits:
+            cpu: "1000m"
+
+ros:
+  processor:
+    replicas: 3
+
+ingress:
+  upload:
+    maxUploadSize: 524288000  # 500MB
+    maxMemory: 134217728      # 128MB — larger values destabilize the pipeline
+
+jwtAuth:
+  envoy:
+    ingressTimeout: "600s"
+    ingressPerTryTimeout: "300s"
+
+gatewayRoute:
+  annotations:
+    haproxy.router.openshift.io/timeout: "600s"

--- a/cost-onprem/values-medium.yaml
+++ b/cost-onprem/values-medium.yaml
@@ -1,0 +1,86 @@
+# Medium profile overlay — Cost On-Prem
+# ======================================
+# COST-7618 / sizing-guide.md
+# Aligned with apply_perf_profile_config() medium case in
+# scripts/lib/perf-testing.sh, plus database sizing from the sizing guide.
+#
+# Usage:
+#   helm upgrade --install cost-onprem ./cost-onprem \
+#     -n cost-onprem -f openshift-values.yaml \
+#     -f cost-onprem/values-medium.yaml
+#
+# Target workload: ~2 clusters, ~49 nodes, ~544 CPU cores (35% of customers)
+#
+# Evidence: PERF-FINDING-022 (ingress memory), PERF-FINDING-035 (listener CPU
+# at chart default is sufficient when medium resources are applied).
+
+resources:
+  database:
+    requests:
+      cpu: "1000m"
+      memory: "2Gi"
+    limits:
+      cpu: "4000m"
+      memory: "8Gi"
+  kruize:
+    # Always 1 replica (PERF-FINDING-004). CPU limit ≥2000m required.
+    requests:
+      cpu: "1000m"
+    limits:
+      cpu: "2000m"
+  rosProcessor:
+    requests:
+      memory: "2Gi"
+    limits:
+      memory: "4Gi"
+  application:
+    # Shared by ingress + other app services (PERF-FINDING-022)
+    requests:
+      memory: "1Gi"
+    limits:
+      memory: "2Gi"
+
+costManagement:
+  listener:
+    replicas: 2
+    resources:
+      requests:
+        memory: "1Gi"
+      limits:
+        memory: "2Gi"
+  celery:
+    workers:
+      ocp:
+        replicas: 2
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "1000m"
+            memory: "2Gi"
+      summary:
+        replicas: 2
+        resources:
+          requests:
+            cpu: "250m"
+          limits:
+            cpu: "1000m"
+
+ros:
+  processor:
+    replicas: 2
+
+ingress:
+  upload:
+    maxUploadSize: 209715200  # 200MB
+    maxMemory: 67108864       # 64MB
+
+jwtAuth:
+  envoy:
+    ingressTimeout: "180s"
+    ingressPerTryTimeout: "180s"
+
+gatewayRoute:
+  annotations:
+    haproxy.router.openshift.io/timeout: "180s"

--- a/cost-onprem/values-small.yaml
+++ b/cost-onprem/values-small.yaml
@@ -1,0 +1,89 @@
+# Small profile overlay — Cost On-Prem
+# =====================================
+# COST-7618 / sizing-guide.md
+#
+# Chart defaults already match the small profile (COST-7599). This file is
+# optional for helm install; it exists so profiles can be compared side-by-side
+# and so a future operator can map spec.profile: small to an explicit baseline.
+#
+# Usage (optional — identical to chart defaults):
+#   helm upgrade --install cost-onprem ./cost-onprem \
+#     -n cost-onprem -f openshift-values.yaml \
+#     -f cost-onprem/values-small.yaml
+#
+# Target workload: ~1 cluster, ~15 nodes, ~200 CPU cores (37% of customers)
+
+resources:
+  database:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+  kruize:
+    requests:
+      cpu: "1000m"
+      memory: "1Gi"
+    limits:
+      cpu: "2000m"
+      memory: "2Gi"
+  rosProcessor:
+    requests:
+      memory: "1Gi"
+    limits:
+      memory: "1Gi"
+  application:
+    requests:
+      memory: "1Gi"
+    limits:
+      memory: "1Gi"
+
+costManagement:
+  listener:
+    replicas: 2
+    resources:
+      requests:
+        cpu: 150m
+        memory: 300Mi
+      limits:
+        cpu: 300m
+        memory: 600Mi
+  celery:
+    workers:
+      ocp:
+        replicas: 2
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+      summary:
+        replicas: 2
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 2Gi
+
+ros:
+  processor:
+    replicas: 1
+
+ingress:
+  upload:
+    maxUploadSize: 104857600  # 100MB
+    maxMemory: 33554432       # 32MB
+
+jwtAuth:
+  envoy:
+    ingressTimeout: "180s"
+    ingressPerTryTimeout: "60s"
+
+gatewayRoute:
+  annotations:
+    haproxy.router.openshift.io/timeout: "180s"

--- a/cost-onprem/values-xlarge.yaml
+++ b/cost-onprem/values-xlarge.yaml
@@ -1,0 +1,90 @@
+# XLarge profile overlay — Cost On-Prem
+# ======================================
+# COST-7618 / sizing-guide.md
+# Aligned with apply_perf_profile_config() xlarge case in
+# scripts/lib/perf-testing.sh, plus database sizing from the sizing guide.
+#
+# Usage:
+#   helm upgrade --install cost-onprem ./cost-onprem \
+#     -n cost-onprem -f openshift-values.yaml \
+#     -f cost-onprem/values-xlarge.yaml
+#
+# Target workload: ~23 clusters, ~346 nodes, ~6,954 CPU cores (6% of customers)
+#
+# Same replica counts as large; worker CPU/memory raised for tag-based cost
+# model processing. Cluster headroom is the primary constraint.
+#
+# After helm upgrade, restart the gateway deployment so Envoy picks up timeout
+# ConfigMap changes (PERF-FINDING-020):
+#   oc rollout restart deployment/cost-onprem-gateway -n cost-onprem
+
+resources:
+  database:
+    requests:
+      cpu: "4000m"
+      memory: "8Gi"
+    limits:
+      cpu: "8000m"
+      memory: "32Gi"
+  kruize:
+    requests:
+      cpu: "1000m"
+      memory: "2Gi"
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+  rosProcessor:
+    requests:
+      memory: "2Gi"
+    limits:
+      memory: "4Gi"
+  application:
+    requests:
+      memory: "2Gi"
+    limits:
+      memory: "4Gi"
+
+costManagement:
+  listener:
+    replicas: 3
+    resources:
+      requests:
+        memory: "2Gi"
+      limits:
+        memory: "4Gi"
+  celery:
+    workers:
+      ocp:
+        replicas: 3
+        resources:
+          requests:
+            cpu: "1000m"
+            memory: "2Gi"
+          limits:
+            cpu: "2000m"
+            memory: "4Gi"
+      summary:
+        replicas: 3
+        resources:
+          requests:
+            cpu: "1000m"
+          limits:
+            cpu: "2000m"
+
+ros:
+  processor:
+    replicas: 3
+
+ingress:
+  upload:
+    maxUploadSize: 524288000  # 500MB
+    maxMemory: 134217728      # 128MB
+
+jwtAuth:
+  envoy:
+    ingressTimeout: "600s"
+    ingressPerTryTimeout: "300s"
+
+gatewayRoute:
+  annotations:
+    haproxy.router.openshift.io/timeout: "600s"

--- a/docs/examples/sizing/README.md
+++ b/docs/examples/sizing/README.md
@@ -1,0 +1,20 @@
+# Sizing Profile Values Overlays
+
+**Moved**: Profile overlays now live alongside the chart at
+[`cost-onprem/values-{small,medium,large,xlarge}.yaml`](../../../cost-onprem/).
+
+See the [sizing guide](../../performance/sizing-guide.md) for usage and the
+[operator CRD mapping](../../performance/operator-profile-crd-mapping.md) for
+the future operator recommendation.
+
+```bash
+# Deploy with medium profile
+./scripts/deploy-test-cost-onprem.sh --namespace cost-onprem --sizing-profile medium
+
+# Or manually
+helm upgrade --install cost-onprem ./cost-onprem \
+  -n cost-onprem \
+  -f openshift-values.yaml \
+  -f cost-onprem/values-medium.yaml \
+  --wait
+```

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -14,6 +14,8 @@ Stress profiles (P99/Max) and soak tests pending.
 | [TEST-MATRIX.md](TEST-MATRIX.md) | Complete test matrix with all permutations and parameters |
 | [FINDINGS.md](FINDINGS.md) | Product issues discovered during testing (Jira-ready summaries) |
 | [sizing-guide.md](sizing-guide.md) | Resource sizing recommendations validated through testing |
+| [operator-profile-crd-mapping.md](operator-profile-crd-mapping.md) | Soft recommendation: Helm profiles → future operator CRD |
+| [cost-onprem/values-*.yaml](../../cost-onprem/) | Helm values overlays per sizing profile (COST-7618) |
 | [OBSERVABILITY.md](OBSERVABILITY.md) | Metrics collection, S3 archival, and report generation |
 | [cost-onprem-group-by-investigation.md](cost-onprem-group-by-investigation.md) | API group_by dimension limit investigation |
 

--- a/docs/performance/operator-profile-crd-mapping.md
+++ b/docs/performance/operator-profile-crd-mapping.md
@@ -1,0 +1,210 @@
+# Soft Recommendation: Operator CRD ↔ Helm Profile Mapping
+
+> **Status**: Soft recommendation for discussion (COST-7618). Not a committed
+> design. Grounded in the early operator architecture and scaffold repo.
+
+## Context
+
+| Source | What it is |
+|--------|------------|
+| [masayag gist](https://gist.github.com/masayag/cdb5906331e6f6cef2285118c89f02dd) | Architecture plan: native Go operator, OLM/OperatorHub, full `CostManagement` CRD sketch |
+| [project-koku/koku-server-operator](https://github.com/project-koku/koku-server-operator) | Early scaffold (`CostManagement` CR exists; `spec` is still placeholder `Foo`) |
+| This chart | Reference implementation — Helm overlays encode validated sizing |
+
+Key constraints from the architecture plan that affect sizing:
+
+- **No Helm→operator migration path** — chart is reference only; CRD API can be designed cleanly
+- **Native Go operator** (not Helm-based) — profile defaults live in Go / webhook defaulting, not Helm merges
+- **CMMO is out of scope** — separate product; this operator is the self-managed server
+- **S3 is always a prerequisite** — never installed by the operator
+- **Kafka / RHBK**: CR-only management when `deploy: true` (no OLM Subscription meta-operator)
+- Planned samples: `costmanagement-minimal.yaml`, `costmanagement-production.yaml`, `costmanagement-byoi.yaml`
+
+## Purpose of this recommendation
+
+The architecture gist already defines a **component-level** CR (`database`, `cache`, `costManagement.listener`, `workers`, …). That is the right long-term shape for day-2 control.
+
+What the gist does **not** yet have is a **sizing profile** abstraction. Our Helm overlays fill that gap for the chart today. Recommendation: add a thin `spec.profile` (or equivalent) that **defaults** the component fields to the same numbers as the overlays, without replacing the component-level API.
+
+| Profile | Helm overlay (reference numbers) |
+|---------|----------------------------------|
+| Small | [`cost-onprem/values-small.yaml`](../../cost-onprem/values-small.yaml) (≡ chart defaults) |
+| Medium | [`cost-onprem/values-medium.yaml`](../../cost-onprem/values-medium.yaml) |
+| Large | [`cost-onprem/values-large.yaml`](../../cost-onprem/values-large.yaml) |
+| XLarge | [`cost-onprem/values-xlarge.yaml`](../../cost-onprem/values-xlarge.yaml) |
+
+## Recommended layering on the existing CRD sketch
+
+Keep the gist's CR structure. Add one optional field:
+
+```yaml
+apiVersion: cost.redhat.com/v1alpha1
+kind: CostManagement
+metadata:
+  name: costmanagement
+  namespace: cost-onprem
+spec:
+  # NEW — soft recommendation (not in gist yet)
+  # Mutating webhook / defaulting expands this into component fields below
+  # when those fields are unset. Explicit component values always win.
+  profile: medium  # small | medium | large | xlarge
+
+  # --- Existing gist shape (abridged) ---
+  database:
+    deploy: true
+    storage: { size: 50Gi }          # profile can default size + resources
+    resources: {}                    # filled by profile if empty
+
+  cache:
+    deploy: true
+
+  kafka:
+    deploy: true
+
+  objectStorage: {}                  # prerequisite / auto-detect
+
+  authentication:
+    deploy: true
+
+  costManagement:
+    listener:
+      replicas: 2                    # or omit → profile supplies
+      resources: {}
+    workers:
+      ocp: { replicas: 2 }
+      summary: { replicas: 2 }
+
+  resourceOptimization:
+    processor:
+      replicas: 2
+    kruize:
+      resources: {}                  # replicas forced to 1 (PERF-FINDING-004)
+
+  gateway: {}
+  ingress:
+    maxUploadSize: 209715200         # or omit → profile supplies
+
+  ui:
+    enabled: true
+```
+
+**Defaulting rule (suggested):**
+
+1. If `spec.profile` is set, apply profile defaults to any **unset** nested fields.
+2. If a nested field is set in the CR, it wins (sparse override).
+3. If `spec.profile` is unset, use **small** defaults (matches chart defaults / COST-7599).
+4. Reflect the effective profile in `status.appliedProfile` (and optionally `status.discoveredConfig`).
+
+This matches the gist's planned mutating webhook for defaulting, and maps cleanly onto the planned sample files:
+
+| Planned operator sample | Suggested profile |
+|-------------------------|-------------------|
+| `costmanagement-minimal.yaml` | `small` |
+| `costmanagement-production.yaml` | `medium` or `large` (product call) |
+| `costmanagement-byoi.yaml` | any profile + `database/cache/kafka/authentication.deploy: false` |
+
+## Field mapping: Helm overlay → gist CR paths
+
+| Helm overlay path | Gist / operator CR path | Profile-relevant? |
+|-------------------|-------------------------|-------------------|
+| `resources.database.*` | `spec.database.resources` (+ `spec.database.storage.size`) | Yes |
+| *(Valkey not in overlays today)* | `spec.cache.resources` / `persistence.size` | Optional later |
+| `costManagement.listener.*` | `spec.costManagement.listener.*` | Yes |
+| `costManagement.celery.workers.ocp.*` | `spec.costManagement.workers.ocp.*` | Yes |
+| `costManagement.celery.workers.summary.*` | `spec.costManagement.workers.summary.*` | Yes |
+| `ros.processor.replicas` | `spec.resourceOptimization.processor.replicas` | Yes |
+| `resources.rosProcessor.*` | `spec.resourceOptimization.processor.resources` *(add if missing)* | Yes |
+| `resources.kruize.*` | `spec.resourceOptimization.kruize.resources` | Yes |
+| `resources.application.*` | Prefer dedicated `spec.ingress.resources` (FINDING-022) | Yes |
+| `ingress.upload.maxUploadSize` / `maxMemory` | `spec.ingress.maxUploadSize` (+ add `maxMemory` if needed) | Yes |
+| `jwtAuth.envoy.ingressTimeout` | `spec.gateway.ingressTimeout` *(add; gist has resources only)* | Yes |
+| `jwtAuth.envoy.ingressPerTryTimeout` | `spec.gateway.ingressPerTryTimeout` | Yes |
+| `gatewayRoute.annotations.haproxy...timeout` | Operator-owned Route annotation from same gateway timeout | Yes |
+
+Gaps to close in the gist CR when sizing lands:
+
+1. **Gateway timeouts** — needed for large/xlarge (PERF-FINDING-001 / 020); operator should restart Envoy on change.
+2. **Ingress `maxMemory`** — chart has it; gist only shows `maxUploadSize`.
+3. **ROS processor resources** — chart uses `resources.rosProcessor`; gist shows replicas only under `resourceOptimization.processor`.
+4. **Dedicated ingress memory** — avoid sharing a generic application block (FINDING-022).
+
+## Example: medium profile
+
+**Helm (today):**
+
+```bash
+helm upgrade --install cost-onprem ./cost-onprem \
+  -n cost-onprem \
+  -f openshift-values.yaml \
+  -f cost-onprem/values-medium.yaml
+```
+
+**Operator (proposed equivalent using gist + profile):**
+
+```yaml
+apiVersion: cost.redhat.com/v1alpha1
+kind: CostManagement
+metadata:
+  name: costmanagement
+  namespace: cost-onprem
+spec:
+  profile: medium
+  database:
+    deploy: true
+  cache:
+    deploy: true
+  kafka:
+    deploy: true
+  authentication:
+    deploy: true
+  objectStorage: {}   # auto-detect ODF / OBC, or set endpoint + credentialsSecret
+  ui:
+    enabled: true
+```
+
+Sparse override (same CR, bump only listener replicas):
+
+```yaml
+spec:
+  profile: medium
+  costManagement:
+    listener:
+      replicas: 3
+```
+
+## Validation rules (from performance findings)
+
+Worth encoding as CEL / webhook checks on the gist CR:
+
+| Rule | Source |
+|------|--------|
+| `resourceOptimization.kruize` effective replicas = 1 | PERF-FINDING-004 |
+| Kruize CPU limit ≥ 2000m | Liveness under load |
+| `ingress.maxMemory` ≤ 128Mi until multipart upload lands | Pipeline stability / FINDING-024 |
+| Large/xlarge → gateway timeouts ≥ 600s | PERF-FINDING-001 |
+| Listener CPU boost is optional; not required for correctness through medium | PERF-FINDING-035 / VTC-001a |
+
+## How this fits the operator roadmap
+
+From the gist Phase 4 ("Performance testing at scale") and sample CR plans:
+
+1. Keep building the component-level CR as designed.
+2. Treat `cost-onprem/values-*.yaml` as the **numeric contract** for profile tables in Go (or generated assets).
+3. Add `spec.profile` + webhook defaulting before OperatorHub GA so samples stay short.
+4. Map `costmanagement-minimal.yaml` → small; production sample → medium/large with profile set.
+5. Reuse chart E2E/perf suites against operator-deployed clusters (gist §9 already assumes this).
+
+## Non-goals
+
+- Replacing or wrapping CMMO
+- Changing the gist's `deploy: true/false` infrastructure model
+- Managing OLM Subscriptions for AMQ Streams / RHBK (Alternative D in the gist)
+- Committing Helm coexistence — chart remains reference/test harness only
+
+## Related
+
+- Architecture: [Cost Management On-Premise Operator Architecture](https://gist.github.com/masayag/cdb5906331e6f6cef2285118c89f02dd)
+- Scaffold: [project-koku/koku-server-operator](https://github.com/project-koku/koku-server-operator)
+- [Sizing guide](./sizing-guide.md)
+- [Profile overlays](../../cost-onprem/) — `values-{small,medium,large,xlarge}.yaml`
+- [FINDINGS.md](./FINDINGS.md)

--- a/docs/performance/performance-testing-plan.md
+++ b/docs/performance/performance-testing-plan.md
@@ -507,8 +507,8 @@ PERF_PROFILE=xlarge pytest -m "performance and ingestion" tests/suites/performan
 
 ## Next Steps
 
-1. [ ] Run medium profile for a clean validated baseline (target: 0 failures)
+1. [x] Run medium profile for a clean validated baseline (target: 0 failures) — 28/28 api+ingestion, 4/4 ros passed
 2. [ ] Execute stress_p99 profile (33 clusters) to find the actual breaking point
 3. [ ] Execute 7-day soak test (SC-5) — requires dedicated cluster time
-4. [ ] Publish sizing guide to product documentation (COST-7618)
-5. [ ] File tickets for untracked findings (FINDING-013, -020, -022, -024)
+4. [x] Publish sizing profile overlays + operator mapping draft (COST-7618) — see `cost-onprem/values-*.yaml` and `operator-profile-crd-mapping.md`
+5. [x] File tickets for untracked findings — FLPATH-4428 (013), FLPATH-4429 (020), FLPATH-4430 (022), FLPATH-4431 (024)

--- a/docs/performance/sizing-guide.md
+++ b/docs/performance/sizing-guide.md
@@ -297,7 +297,7 @@ Large/xlarge profiles should increase to 600s for bulk uploads.
 | Profile | HAProxy Timeout | Envoy Route Timeout | Envoy Per-Try Timeout |
 |---------|-----------------|---------------------|----------------------|
 | Small | 180s (default) | 180s (default) | 60s (default) |
-| Medium | 180s (default) | 180s (default) | 60s (default) |
+| Medium | 180s (default) | 180s (default) | 180s |
 | Large | 600s | 600s | 300s |
 | XLarge | 600s | 600s | 300s |
 

--- a/docs/performance/sizing-guide.md
+++ b/docs/performance/sizing-guide.md
@@ -35,6 +35,14 @@ is the downstream pipeline (worker replicas, worker CPU/memory, ingress memory,
 upload limits), not the listener. See [FINDINGS.md](./FINDINGS.md#perf-finding-035)
 for the full VTC-001a characterization.
 
+### COST-7618: Profile Values Overlays (2026-07-27)
+
+Published declarative Helm overlays for each sizing profile under
+[`cost-onprem/`](../../cost-onprem/). These are the deploy-time
+equivalent of `apply_perf_profile_config()`, plus database sizing. Soft
+recommendation for mapping overlays to a future operator CRD:
+[operator-profile-crd-mapping.md](./operator-profile-crd-mapping.md).
+
 ---
 
 ## Quick Reference
@@ -56,9 +64,9 @@ with clean (0-failure) automated runs. Stress profiles have not yet been execute
 
 **Chart defaults = Small profile** (as of COST-7599). A fresh install with no
 `values.yaml` overrides provides the small-profile resource allocations listed
-below. Medium, large, and xlarge profiles require explicit overrides — see the
-[Helm Values Examples](#helm-values-examples) section. Performance test runs
-can apply overrides dynamically via `apply_perf_profile_config()`.
+below. Medium, large, and xlarge profiles require explicit overlays — see
+[Helm Values Overlays](#helm-values-overlays). Performance test runs can apply
+the same settings dynamically via `apply_perf_profile_config()`.
 
 Kruize memory and Database resources should be set in `values.yaml` at
 deployment time. All values have been validated through successful end-to-end
@@ -293,15 +301,13 @@ Large/xlarge profiles should increase to 600s for bulk uploads.
 | Large | 600s | 600s | 300s |
 | XLarge | 600s | 600s | 300s |
 
-**Configuration** (`values.yaml`):
+**Configuration** (see large/xlarge overlays for full context):
 
 ```yaml
-gateway:
+jwtAuth:
   envoy:
-    routes:
-      ingress:
-        timeout: 600s
-        per_try_timeout: 300s
+    ingressTimeout: "600s"
+    ingressPerTryTimeout: "300s"
 
 gatewayRoute:
   annotations:
@@ -406,204 +412,39 @@ For perf testing clusters, 10 Gi saves 270 Gi of ODF PV capacity.
 
 ---
 
-## Helm Values Examples
+## Helm Values Overlays
 
-### Small Profile (Chart Defaults)
+Declarative profile overlays live in
+`cost-onprem/` alongside `values.yaml`. They use the same chart keys as
+`apply_perf_profile_config()` and add database sizing (which the perf script
+does not change at runtime).
 
-No overrides needed — the chart defaults match the small profile as of
-COST-7599. A fresh `helm install` produces these settings:
+| Profile | Overlay | Notes |
+|---------|---------|-------|
+| Small | [values-small.yaml](../../cost-onprem/values-small.yaml) | ≡ chart defaults (COST-7599); optional `-f` |
+| Medium | [values-medium.yaml](../../cost-onprem/values-medium.yaml) | Required for medium workloads |
+| Large | [values-large.yaml](../../cost-onprem/values-large.yaml) | Restart gateway after upgrade (FINDING-020) |
+| XLarge | [values-xlarge.yaml](../../cost-onprem/values-xlarge.yaml) | Same replicas as large; higher worker CPU/memory |
 
-```yaml
-# These are the chart defaults — no values.yaml overrides required
-resources:
-  database:
-    requests: { cpu: "500m", memory: "1Gi" }
-    limits:   { cpu: "2000m", memory: "4Gi" }
-  kruize:
-    requests: { cpu: "1000m" }
-    limits:   { cpu: "2000m" }
+```bash
+# Medium example (manual)
+helm upgrade --install cost-onprem ./cost-onprem \
+  -n cost-onprem \
+  -f openshift-values.yaml \
+  -f cost-onprem/values-medium.yaml \
+  --wait
 
-costManagement:
-  listener:
-    replicas: 2
-  celeryWorker:
-    workers:
-      ocp:
-        replicas: 2
-      summary:
-        replicas: 2
-
-jwtAuth:
-  envoy:
-    ingressTimeout: 180s
-    ingressPerTryTimeout: 60s
-
-gatewayRoute:
-  annotations:
-    haproxy.router.openshift.io/timeout: "180s"
+# Via deploy script
+./scripts/deploy-test-cost-onprem.sh --namespace cost-onprem --sizing-profile medium
 ```
 
-**Validated**: 25/25 passed with `--skip-profile-config --listener-cpu none`
-(pure chart defaults, no runtime overrides).
+**Small validated** with `--skip-profile-config --listener-cpu none` (pure
+chart defaults, no runtime overrides). Medium through xlarge validated via
+profile-config performance runs.
 
-### Medium Profile
-
-```yaml
-resources:
-  kruize:
-    requests: { cpu: "500m" }
-    limits:   { cpu: "2000m" }
-  rosProcessor:
-    requests: { memory: "2Gi" }
-    limits:   { memory: "4Gi" }
-  application:
-    requests: { memory: "1Gi" }
-    limits:   { memory: "2Gi" }
-
-costManagement:
-  listener:
-    replicas: 2
-    resources:
-      requests: { memory: "1Gi" }
-      limits:   { memory: "2Gi" }
-  celeryWorker:
-    workers:
-      ocp:
-        replicas: 2
-        resources:
-          requests: { cpu: "250m" }
-          limits:   { cpu: "1000m" }
-      summary:
-        replicas: 2
-        resources:
-          requests: { cpu: "250m" }
-          limits:   { cpu: "1000m" }
-
-ros:
-  processor:
-    replicas: 2
-
-ingress:
-  upload:
-    maxSize: "200MB"
-    maxMemory: "64MB"
-
-gateway:
-  envoy:
-    routes:
-      ingress:
-        timeout: 180s
-        per_try_timeout: 180s
-gatewayRoute:
-  annotations:
-    haproxy.router.openshift.io/timeout: "180s"
-```
-
-### Large Profile
-
-```yaml
-resources:
-  kruize:
-    requests: { cpu: "500m" }
-    limits:   { cpu: "2000m" }
-  rosProcessor:
-    requests: { memory: "2Gi" }
-    limits:   { memory: "4Gi" }
-  application:
-    requests: { memory: "2Gi" }
-    limits:   { memory: "4Gi" }
-
-costManagement:
-  listener:
-    replicas: 3
-    resources:
-      requests: { memory: "2Gi" }
-      limits:   { memory: "4Gi" }
-  celeryWorker:
-    workers:
-      ocp:
-        replicas: 3
-        resources:
-          requests: { cpu: "500m" }
-          limits:   { cpu: "1000m", memory: "2Gi" }
-      summary:
-        replicas: 3
-        resources:
-          requests: { cpu: "500m" }
-          limits:   { cpu: "1000m" }
-
-ros:
-  processor:
-    replicas: 3
-
-ingress:
-  upload:
-    maxSize: "500MB"
-    maxMemory: "128MB"
-
-gateway:
-  envoy:
-    routes:
-      ingress:
-        timeout: 600s
-        per_try_timeout: 300s
-gatewayRoute:
-  annotations:
-    haproxy.router.openshift.io/timeout: "600s"
-```
-
-### XLarge Profile
-
-```yaml
-resources:
-  kruize:
-    requests: { cpu: "1000m" }
-    limits:   { cpu: "2000m" }
-  rosProcessor:
-    requests: { memory: "2Gi" }
-    limits:   { memory: "4Gi" }
-  application:
-    requests: { memory: "2Gi" }
-    limits:   { memory: "4Gi" }
-
-costManagement:
-  listener:
-    replicas: 3
-    resources:
-      requests: { memory: "2Gi" }
-      limits:   { memory: "4Gi" }
-  celeryWorker:
-    workers:
-      ocp:
-        replicas: 3
-        resources:
-          requests: { cpu: "1000m" }
-          limits:   { cpu: "2000m", memory: "4Gi" }
-      summary:
-        replicas: 3
-        resources:
-          requests: { cpu: "1000m" }
-          limits:   { cpu: "2000m" }
-
-ros:
-  processor:
-    replicas: 3
-
-ingress:
-  upload:
-    maxSize: "500MB"
-    maxMemory: "128MB"
-
-gateway:
-  envoy:
-    routes:
-      ingress:
-        timeout: 600s
-        per_try_timeout: 300s
-gatewayRoute:
-  annotations:
-    haproxy.router.openshift.io/timeout: "600s"
-```
+For a soft recommendation on how these overlays map to a future Cost
+Management OpenShift Operator CRD, see
+[operator-profile-crd-mapping.md](./operator-profile-crd-mapping.md).
 
 ---
 
@@ -631,7 +472,9 @@ gatewayRoute:
 - [FINDINGS.md](./FINDINGS.md) — detailed product findings and evidence
 - [TEST-MATRIX.md](./TEST-MATRIX.md) — test coverage matrix
 - [OBSERVABILITY.md](./OBSERVABILITY.md) — metrics collection infrastructure
+- [Profile overlays](../../cost-onprem/) — `values-{small,medium,large,xlarge}.yaml`
+- [Operator CRD mapping](./operator-profile-crd-mapping.md) — soft recommendation for a future operator
 
 ---
 
-_Based on FLPATH-4036 / COST-7567 performance testing. Last updated: 2026-07-23._
+_Based on FLPATH-4036 / COST-7567 performance testing. Last updated: 2026-07-27._

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -592,9 +592,62 @@ deploy_s4() {
     log_info "Storage credentials secret: cost-onprem-storage-credentials (in ${NAMESPACE})"
 }
 
+apply_sizing_profile() {
+    local release="${HELM_RELEASE_NAME:-cost-onprem}"
+    local namespace="${NAMESPACE:-cost-onprem}"
+    local sizing_file="${PROJECT_ROOT}/cost-onprem/values-${SIZING_PROFILE}.yaml"
+
+    if [[ ! -f "${sizing_file}" ]]; then
+        log_error "Sizing profile '${SIZING_PROFILE}' not found at: ${sizing_file}"
+        log_error "Valid profiles: small, medium, large, xlarge"
+        exit 1
+    fi
+
+    log_step "Applying sizing profile '${SIZING_PROFILE}' to existing deployment"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "DRY RUN: Would run helm upgrade ${release} --reuse-values -f ${sizing_file}"
+        return 0
+    fi
+
+    local chart_ref
+    if [[ "${USE_LOCAL_CHART:-false}" == "true" ]]; then
+        chart_ref="${PROJECT_ROOT}/cost-onprem"
+    else
+        chart_ref="${release}"
+    fi
+
+    if ! helm upgrade "${release}" "${chart_ref}" \
+            --reuse-values \
+            --namespace "${namespace}" \
+            -f "${sizing_file}" \
+            --wait --timeout 5m 2>&1; then
+        log_error "Failed to apply sizing profile '${SIZING_PROFILE}'"
+        return 1
+    fi
+
+    log_success "Sizing profile '${SIZING_PROFILE}' applied"
+
+    # Restart gateway so Envoy picks up timeout changes (PERF-FINDING-020)
+    local gw_deploy="${release}-gateway"
+    if oc rollout restart deployment "${gw_deploy}" -n "${namespace}" 2>/dev/null; then
+        if oc rollout status deployment "${gw_deploy}" -n "${namespace}" --timeout=2m 2>/dev/null; then
+            log_success "Gateway restarted (Envoy config reloaded)"
+        else
+            log_warning "Gateway rollout did not stabilize — Envoy may still use old timeouts"
+        fi
+    fi
+}
+
 deploy_helm_chart() {
     if [[ "${SKIP_HELM}" == "true" ]]; then
-        log_warning "Skipping Cost On-Prem Helm chart installation (--skip-helm)"
+        # When deploy is skipped but --sizing-profile is set, apply the overlay
+        # to the existing release so the cluster matches the requested profile.
+        if [[ -n "${SIZING_PROFILE}" ]]; then
+            apply_sizing_profile
+        else
+            log_warning "Skipping Cost On-Prem Helm chart installation (--skip-helm)"
+        fi
         return 0
     fi
 

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -35,6 +35,9 @@ set -euo pipefail
 #   --use-local-chart         Use local Helm chart instead of GitHub release
 #   --devel                   Include pre-release (rc) charts in Helm installation
 #   --chart-version VERSION   Pin a specific Helm chart version (e.g., 0.2.9, 0.3.0-rc1)
+#   --sizing-profile PROFILE  Apply a sizing profile on deploy: small, medium, large, xlarge.
+#                             Passes cost-onprem/values-<PROFILE>.yaml as an additional -f overlay.
+#                             Small = chart defaults (no-op); medium+ adds resource/replica overrides.
 #
 #   Test options:
 #   --iqe-marker EXPR         Pytest marker for IQE tests (default: cost_ocp_on_prem)
@@ -175,6 +178,7 @@ SCRIPT_DEPLOY_S4="deploy-s4-test.sh"  # S4 (Super Simple Storage Service)
 SCRIPT_INSTALL_HELM="install-helm-chart.sh"
 SCRIPT_SETUP_TLS="setup-cost-mgmt-tls.sh"
 OPENSHIFT_VALUES_FILE="${OPENSHIFT_VALUES_FILE:-openshift-values.yaml}"
+SIZING_PROFILE="${SIZING_PROFILE:-}"
 
 # Step flags (default: run all steps)
 SKIP_RHBK=false  # Red Hat Build of Keycloak
@@ -601,6 +605,18 @@ deploy_helm_chart() {
     download_openshift_values "${values_file}"
     export VALUES_FILE="${values_file}"
 
+    # Sizing profile overlay (--sizing-profile small|medium|large|xlarge)
+    if [[ -n "${SIZING_PROFILE}" ]]; then
+        local sizing_file="${PROJECT_ROOT}/cost-onprem/values-${SIZING_PROFILE}.yaml"
+        if [[ ! -f "${sizing_file}" ]]; then
+            log_error "Sizing profile '${SIZING_PROFILE}' not found at: ${sizing_file}"
+            log_error "Valid profiles: small, medium, large, xlarge"
+            exit 1
+        fi
+        export SIZING_VALUES_FILE="${sizing_file}"
+        log_info "Sizing profile: ${SIZING_PROFILE} (${sizing_file})"
+    fi
+
     # Export environment variables for Helm script
     export NAMESPACE="${NAMESPACE}"
     export JWT_AUTH_ENABLED="true"
@@ -922,6 +938,7 @@ print_summary() {
     echo "  Namespace:           ${NAMESPACE}"
     [[ "${DEPLOY_S4}" == "true" ]] && echo "  S4 Namespace:        ${S4_NAMESPACE}"
     [[ "${OPENSHIFT_VALUES_FILE}" != "openshift-values.yaml" ]] && echo "  Values File:         ${OPENSHIFT_VALUES_FILE}"
+    [[ -n "${SIZING_PROFILE}" ]] && echo "  Sizing Profile:      ${SIZING_PROFILE}"
     echo "  Use Local Chart:     ${USE_LOCAL_CHART}"
     [[ "${USE_HELM_DEVEL}" == "true" ]] && echo "  Include Pre-release: ${USE_HELM_DEVEL}"
     [[ -n "${CHART_VERSION}" ]] && echo "  Chart Version:       ${CHART_VERSION}"
@@ -977,6 +994,7 @@ main() {
     echo ""
 
     # Parse command line arguments
+    local -a ORIGINAL_ARGS=("$@")
     while [[ $# -gt 0 ]]; do
         case $1 in
             --skip-rhbk)
@@ -1025,6 +1043,10 @@ main() {
                 ;;
             --chart-version)
                 CHART_VERSION="$2"
+                shift 2
+                ;;
+            --sizing-profile)
+                SIZING_PROFILE="$2"
                 shift 2
                 ;;
             --verbose)
@@ -1157,6 +1179,24 @@ main() {
                    exit 1 ;;
             esac
         done
+    fi
+
+    # When --sizing-profile is set, the deploy-time overlay already configures
+    # resources/replicas/timeouts.  Auto-enable --skip-profile-config so
+    # apply_perf_profile_config() doesn't overwrite at test time — unless the
+    # user explicitly passed --perf-profile to override.
+    if [[ -n "${SIZING_PROFILE}" ]] && [[ "${SKIP_PROFILE_CONFIG}" == "false" ]]; then
+        # Detect whether --perf-profile was explicitly passed (vs the default)
+        local perf_profile_explicit=false
+        for _arg in "${ORIGINAL_ARGS[@]:-}"; do
+            [[ "${_arg}" == "--perf-profile" ]] && perf_profile_explicit=true
+        done
+        if [[ "${perf_profile_explicit}" == "false" ]]; then
+            SKIP_PROFILE_CONFIG=true
+            log_info "Auto-enabled --skip-profile-config (--sizing-profile ${SIZING_PROFILE} sets resources at deploy time)"
+        else
+            log_warning "--sizing-profile ${SIZING_PROFILE} and --perf-profile ${PERF_PROFILE} both set; perf profile will override sizing at test time"
+        fi
     fi
 
     # In tests-only / skip-deploy mode, skip all deployment steps

--- a/scripts/install-helm-chart.sh
+++ b/scripts/install-helm-chart.sh
@@ -1181,6 +1181,17 @@ deploy_helm_chart() {
         fi
     fi
 
+    # Add sizing profile overlay (applied after VALUES_FILE so it wins on merge)
+    if [ -n "${SIZING_VALUES_FILE:-}" ]; then
+        if [ -f "$SIZING_VALUES_FILE" ]; then
+            echo_info "Using sizing profile overlay: $SIZING_VALUES_FILE"
+            helm_cmd="$helm_cmd -f \"$SIZING_VALUES_FILE\""
+        else
+            echo_error "Sizing profile overlay not found: $SIZING_VALUES_FILE"
+            return 1
+        fi
+    fi
+
     # -------------------------------------------------------------------------
     # Cluster-detected values (FLPATH-3181: chart no longer uses lookup())
     # The install script is the single source of truth for cluster-specific


### PR DESCRIPTION
Publishes declarative Helm values overlays for each validated sizing profile
(small, medium, large, xlarge) and adds a `--sizing-profile` flag to the deploy
script. Includes a soft recommendation for mapping these overlays to a future
Cost Management OpenShift Operator CRD.

## Changes

### Helm Values Overlays (new files)

- **`cost-onprem/values-{small,medium,large,xlarge}.yaml`** — Deploy-time
  equivalents of `apply_perf_profile_config()`, plus database sizing (which the
  perf script does not adjust at runtime). Each overlay uses the same chart keys
  validated through automated performance runs. Small is a no-op (matches chart
  defaults from COST-7599).

### Deploy Script (`scripts/deploy-test-cost-onprem.sh`)

- **`--sizing-profile PROFILE`** flag — Passes the corresponding
  `cost-onprem/values-<PROFILE>.yaml` as an additional `-f` overlay during
  Helm install.
- **`apply_sizing_profile()`** function — When `--sizing-profile` is combined
  with `--skip-deploy` or `--perf-only`, performs a lightweight
  `helm upgrade --reuse-values -f <overlay>` on the existing release and
  restarts the gateway so Envoy picks up timeout changes (FINDING-020).
- **Auto `--skip-profile-config`** — When `--sizing-profile` is set and
  `--perf-profile` is NOT explicitly passed, automatically enables
  `--skip-profile-config` to prevent `apply_perf_profile_config()` from
  overwriting the deploy-time sizing. Warns if both flags are used together.

### Install Script (`scripts/install-helm-chart.sh`)

- Consumes `SIZING_VALUES_FILE` as a second `-f` overlay, applied after
  `VALUES_FILE` so profile values win on merge.

### Documentation

- **`docs/performance/operator-profile-crd-mapping.md`** (new) — Soft
  recommendation for adding `spec.profile` to a future operator CRD. Maps each
  Helm overlay path to the proposed CR field, identifies gaps in the current CRD
  sketch (gateway timeouts, ingress maxMemory, ROS processor resources), and
  suggests validation rules from performance findings.
- **`docs/performance/sizing-guide.md`** — Replaced inline Helm values examples
  with a reference table pointing to the overlay files. Added COST-7618
  changelog entry. Corrected gateway timeout YAML to match actual chart keys.
- **`docs/performance/README.md`** — Added links to operator CRD mapping and
  updated overlay file paths.
- **`docs/performance/performance-testing-plan.md`** — Marked COST-7618
  deliverable as complete.
- **`docs/examples/sizing/README.md`** (new) — Redirect pointing to the
  canonical location in `cost-onprem/`.

### CI Validation

- **`.github/workflows/validate-deploy-test-script.yml`** — Added 4 test cases:
  `--sizing-profile medium`, `--sizing-profile large`,
  `--perf-only --sizing-profile medium`, `--skip-deploy --sizing-profile large`.

## Usage

```bash
# Full deployment with medium sizing
./scripts/deploy-test-cost-onprem.sh --namespace cost-onprem --sizing-profile medium

# Apply sizing to existing cluster (no redeploy)
./scripts/deploy-test-cost-onprem.sh --skip-deploy --sizing-profile large

# Perf tests with sizing overlay (auto-skips profile config)
./scripts/deploy-test-cost-onprem.sh --perf-only --sizing-profile medium --perf-suite api,ingestion

# Manual Helm
helm upgrade --install cost-onprem ./cost-onprem \
  -n cost-onprem -f openshift-values.yaml \
  -f cost-onprem/values-medium.yaml --wait
```

## Stats

12 files changed, 746 insertions, 209 deletions

## Test Plan

- [x] `--sizing-profile medium` dry run passes
- [x] `--sizing-profile large` dry run passes
- [x] `--perf-only --sizing-profile medium` dry run passes (auto-enables `--skip-profile-config`)
- [x] `--skip-deploy --sizing-profile large` dry run passes
- [x] `--sizing-profile medium --perf-profile large` warns about override interaction
- [x] `helm template` succeeds with each overlay
- [x] All 4 new CI validation cases pass
- [ ] Prow CI (triggered on PR)