### PR TITLE
COST-7627 + COST-7600 — Stress Ramp-to-Failure & Backlog Recovery Tests

### DIFF
--- a/.cursor/prompts/run-tests.md
+++ b/.cursor/prompts/run-tests.md
@@ -64,12 +64,13 @@ The `apply_perf_profile_config()` function automatically adjusts the live cluste
 # Performance-only against existing deployment
 ./scripts/deploy-test-cost-onprem.sh --namespace cost-onprem --perf-only
 
-# With a specific profile (baseline, small, medium, large)
+# With a specific profile (baseline, small, medium, large, xlarge)
 ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium
 
-# Run specific perf suite(s): api, ros, ingestion, scale, soak
+# Run specific perf suite(s): api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress, stress_ramp, stress_recovery
 ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-suite ros
 ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-suite api,ingestion
+./scripts/deploy-test-cost-onprem.sh --perf-only --perf-suite stress_ramp
 ```
 
 #### Profile Scaling Matrix

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -98,6 +98,7 @@ resource limits, timeouts, upload sizes) via Helm upgrade + `oc scale` before te
 ./scripts/deploy-test-cost-onprem.sh --namespace cost-onprem --run-perf --perf-profile medium
 
 # Performance-only (skip deploy)
+# Suites: api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress, stress_ramp, stress_recovery
 ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite ros,api
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ before tests run.
 # Performance tests only (skip deploy)
 ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium
 
-# Specific perf suite(s): api, ros, ingestion, scale, soak
+# Specific perf suite(s): api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress, stress_ramp, stress_recovery
 ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-suite ros,api
 ```
 
@@ -127,6 +127,8 @@ to node max for perf runs.
 - `scripts/lib/perf-observability.sh` — Metrics collection + S3 upload
 - `tests/suites/performance/profiles.py` — Data generation profiles (cluster/node/pod counts)
 - `tests/suites/performance/conftest.py` — Fixtures, cleanup tracker, cluster info
+- `tests/suites/performance/test_stress.py` — Stress ramp-to-failure + backlog recovery (STR-001, STR-002)
+- `tests/suites/performance/tracker.py` — Resource cleanup tracker with configurable timeout
 
 ---
 

--- a/docs/performance/FINDINGS.md
+++ b/docs/performance/FINDINGS.md
@@ -809,6 +809,44 @@ everything.
 
 ---
 
+## Stress Testing Findings (COST-7627 + COST-7600)
+
+### PERF-FINDING-036: Stress Ramp Breaking Points Scale with Profile
+
+**Status**: Validated (medium, large, xlarge)
+**Severity**: Informational
+**Category**: Capacity planning
+
+**Tests**: `PERF-STR-001` (ramp-to-failure), `PERF-STR-002` (backlog recovery)
+
+**Breaking points by profile** (with `listener-cpu=max`):
+
+| Profile | Last Good Step | Breaking Point | Reason |
+|---------|---------------|---------------|--------|
+| Medium | 50 sources | 75 sources | Step time exceeded MAX_STEP_TIME |
+| Large | 75 sources | 100 sources | Step time exceeded MAX_STEP_TIME |
+| XLarge | 100 sources | 150 sources | pytest timeout (processing still ongoing, not failure) |
+
+**Key observations**:
+- System never crashed or OOMed at any profile — breaking point is always
+  "processing too slow", not "component failure".
+- API remained responsive (4-10ms p50) throughout all ramp steps.
+- Backlog recovery (STR-002) passed cleanly at all profiles — queues drain
+  and API latencies return to baseline after overload stops.
+- XLarge step 8 (150 sources) was still processing when the 2h pytest timeout
+  fired — the system was making progress, just slowly.
+
+**Suite split**: The `stress` suite was split into `stress_ramp` (STR-001) and
+`stress_recovery` (STR-002) to allow running them independently. STR-001 is
+the heavyweight long-running test; STR-002 is shorter and can reuse STR-001
+results or fall back to defaults.
+
+**Cleanup timeout**: Resource cleanup is now capped at `PERF_CLEANUP_TIMEOUT`
+(default 900s / 15 min) to prevent pipeline hangs. During xlarge runs with
+300+ tracked resources, cleanup was observed to hang indefinitely.
+
+---
+
 ## Environment Issues
 
 ### PERF-FINDING-010: ODF Default Resources Exhaust Cluster Memory
@@ -872,9 +910,10 @@ results are maintained in the [Sizing Guide](sizing-guide.md#performance-baselin
 | FINDING-033 | OCP workers survive at 256Mi — OOM floor at 128-256Mi | [COST-7598](https://redhat.atlassian.net/browse/COST-7598) | Validated (medium + large + xlarge) |
 | FINDING-034 | Multi-replica Kruize confirms single-replica recommendation | [COST-7598](https://redhat.atlassian.net/browse/COST-7598) | Validated (medium + large + xlarge) |
 | FINDING-035 | Chart defaults pass small; medium needs worker/ingress scaling, not listener CPU | [COST-7599](https://redhat.atlassian.net/browse/COST-7599) | Validated (VTC-001a complete) |
+| FINDING-036 | Stress ramp breaking points scale with profile; system never crashes | [COST-7627](https://redhat.atlassian.net/browse/COST-7627), [COST-7600](https://redhat.atlassian.net/browse/COST-7600) | Validated (medium + large + xlarge) |
 
 **Parent epic**: [COST-7567](https://redhat.atlassian.net/browse/COST-7567) (CoP Performance Tuning & Hardware Sizing Guidelines)
 
 ---
 
-_Last Updated: 2026-07-23_
+_Last Updated: 2026-07-30_

--- a/docs/performance/performance-testing-plan.md
+++ b/docs/performance/performance-testing-plan.md
@@ -450,6 +450,20 @@ histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="koku-api
 - [x] Jenkins CI integration (`insights_onprem.groovy` with `PERF_PROFILE` and `PERF_SUITE` params)
 - [x] Self-contained HTML run reports and JSON summaries
 - [x] S3 result archival to shared MinIO
+- [x] Stress ramp-to-failure + backlog recovery (`test_stress.py`, COST-7627 + COST-7600)
+
+### Stress Test Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STRESS_RAMP_STEPS` | `5,10,20,30,50,75,100` | Comma-separated source counts per ramp step |
+| `STRESS_MAX_STEP_TIME` | `1800` | Absolute max seconds per step before declaring failure |
+| `STRESS_STEP_TIMEOUT_BASE` | `120` | Base timeout per step (seconds) |
+| `STRESS_STEP_TIMEOUT_PER_SOURCE` | `60` | Additional seconds per source |
+| `STRESS_RECOVERY_SOURCE_COUNT` | `0` | Sources for recovery test; 0 = auto from STR-001 |
+| `STRESS_RECOVERY_DURATION_S` | `300` | Overload duration for STR-002 (seconds) |
+| `PERF_CLEANUP_TIMEOUT` | `900` | Max seconds for post-test resource cleanup (prevents hangs) |
+| `METRICS_MAX_DURATION` | `14400` | Max seconds for metrics collector (auto-set from `JOB_TIMEOUT_HOURS` in Jenkins) |
 
 ### Validated Profiles
 
@@ -470,7 +484,9 @@ histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="koku-api
 | `test_scale.py` | 5 | Multi-cluster scale (SCALE-001 through SCALE-005) |
 | `test_ros.py` | 4 | ROS/Kruize performance (ROS-001 through ROS-004) |
 | `test_soak.py` | 4 | Soak stability (SOAK-001 through SOAK-004, opt-in) |
+| `test_stress.py` | 2 | Stress ramp-to-failure + backlog recovery (STR-001, STR-002) |
 | `profiles.py` | — | Profile definitions + NISE YAML generation |
+| `tracker.py` | — | Resource cleanup tracker with configurable timeout |
 | `conftest.py` | — | Fixtures, cleanup, data generation |
 | `verify_infrastructure.py` | — | Pre-run infrastructure validation |
 
@@ -489,6 +505,11 @@ PERF_PROFILE=medium pytest -m performance tests/suites/performance/
 # Specific suite
 PERF_PROFILE=xlarge pytest -m "performance and ingestion" tests/suites/performance/
 
+# Stress tests — all, ramp only, or recovery only
+./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite stress
+./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite stress_ramp
+./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite stress_recovery
+
 # Via Jenkins
 # Job: flightpath-insights-onprem (RUN_PERF_TESTS=true, PERF_PROFILE=xlarge, PERF_SUITE=all)
 ```
@@ -500,7 +521,7 @@ PERF_PROFILE=xlarge pytest -m "performance and ingestion" tests/suites/performan
 | ID | Criteria | Status | Evidence |
 |----|----------|--------|----------|
 | SC-1 | Sizing table | **Done** | [sizing-guide.md](./sizing-guide.md) — small through xlarge validated |
-| SC-2 | Cluster count limits | **Partial** | XLarge (23 clusters) validated; stress profiles (33+) not yet tested |
+| SC-2 | Cluster count limits | **Done** | XLarge (23 clusters) validated; stress ramp tested at medium (75), large (100), xlarge (100+) concurrent sources |
 | SC-3 | Bottleneck analysis | **Done** | [FINDINGS.md](./FINDINGS.md) — 13 findings documented with severity and evidence |
 | SC-4 | Processing window | **Partial** | XLarge completes in ~2h; need to validate against 6-hour SLA formally |
 | SC-5 | Soak test | **Not started** | Tests exist but require `SOAK_TESTS=true` and dedicated 7-day run window |
@@ -508,7 +529,7 @@ PERF_PROFILE=xlarge pytest -m "performance and ingestion" tests/suites/performan
 ## Next Steps
 
 1. [x] Run medium profile for a clean validated baseline (target: 0 failures) — 28/28 api+ingestion, 4/4 ros passed
-2. [ ] Execute stress_p99 profile (33 clusters) to find the actual breaking point
+2. [x] Execute stress ramp-to-failure across medium, large, xlarge — breaking points identified (75, 100, 100+ sources)
 3. [ ] Execute 7-day soak test (SC-5) — requires dedicated cluster time
 4. [x] Publish sizing profile overlays + operator mapping draft (COST-7618) — see `cost-onprem/values-*.yaml` and `operator-profile-crd-mapping.md`
 5. [x] File tickets for untracked findings — FLPATH-4428 (013), FLPATH-4429 (020), FLPATH-4430 (022), FLPATH-4431 (024)

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -47,7 +47,7 @@ set -euo pipefail
 #   --include-ui              Include UI tests (requires Playwright system dependencies)
 #   --run-perf                Run performance tests after deployment (FLPATH-4036)
 #   --perf-profile PROFILE    Performance profile: baseline, small, medium, large (default: baseline)
-#   --perf-suite SUITES       Performance suite(s): all, api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress
+#   --perf-suite SUITES       Performance suite(s): all, api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress, stress_ramp, stress_recovery
 #                             Comma-separated for multiple (e.g., ros,ingestion). Default: all
 #   --perf-only               Run only performance tests (skip deployment and chart tests)
 #   --skip-profile-config     Skip apply_perf_profile_config() — test with chart defaults only
@@ -1227,8 +1227,8 @@ main() {
         IFS=',' read -ra _suites <<< "${PERF_SUITE}"
         for _s in "${_suites[@]}"; do
             case "${_s}" in
-                api|ros|ingestion|scale|soak|valkey|db|kafka|celery|stress) ;;
-                *) log_error "Invalid --perf-suite value: ${_s} (valid: all, api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress)"
+                api|ros|ingestion|scale|soak|valkey|db|kafka|celery|stress|stress_ramp|stress_recovery) ;;
+                *) log_error "Invalid --perf-suite value: ${_s} (valid: all, api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress, stress_ramp, stress_recovery)"
                    exit 1 ;;
             esac
         done

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -47,7 +47,7 @@ set -euo pipefail
 #   --include-ui              Include UI tests (requires Playwright system dependencies)
 #   --run-perf                Run performance tests after deployment (FLPATH-4036)
 #   --perf-profile PROFILE    Performance profile: baseline, small, medium, large (default: baseline)
-#   --perf-suite SUITES       Performance suite(s): all, api, ros, ingestion, scale, soak, valkey, db
+#   --perf-suite SUITES       Performance suite(s): all, api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress
 #                             Comma-separated for multiple (e.g., ros,ingestion). Default: all
 #   --perf-only               Run only performance tests (skip deployment and chart tests)
 #   --skip-profile-config     Skip apply_perf_profile_config() — test with chart defaults only
@@ -1227,8 +1227,8 @@ main() {
         IFS=',' read -ra _suites <<< "${PERF_SUITE}"
         for _s in "${_suites[@]}"; do
             case "${_s}" in
-                api|ros|ingestion|scale|soak|valkey|db|kafka|celery) ;;
-                *) log_error "Invalid --perf-suite value: ${_s} (valid: all, api, ros, ingestion, scale, soak, valkey, db, kafka, celery)"
+                api|ros|ingestion|scale|soak|valkey|db|kafka|celery|stress) ;;
+                *) log_error "Invalid --perf-suite value: ${_s} (valid: all, api, ros, ingestion, scale, soak, valkey, db, kafka, celery, stress)"
                    exit 1 ;;
             esac
         done

--- a/scripts/lib/perf-observability.sh
+++ b/scripts/lib/perf-observability.sh
@@ -111,7 +111,8 @@ start_metrics_collection() {
     log_info "    results/  - Test results JSON"
     log_info "    reports/  - JUnit XML, HTML report"
 
-    "${collect_script}" --continuous "${METRICS_INTERVAL}" &
+    local max_dur="${METRICS_MAX_DURATION:-14400}"
+    "${collect_script}" --continuous "${METRICS_INTERVAL}" --max-duration "${max_dur}" &
     METRICS_COLLECTOR_PID=$!
 
     log_success "Metrics collection started (PID: ${METRICS_COLLECTOR_PID})"

--- a/scripts/lib/perf-testing.sh
+++ b/scripts/lib/perf-testing.sh
@@ -402,6 +402,8 @@ run_performance_tests() {
                 kafka)     perf_args+=("--perf-kafka") ;;
                 celery)    perf_args+=("--perf-celery") ;;
                 stress)    perf_args+=("--perf-stress") ;;
+                stress_ramp)    perf_args+=("--perf-stress-ramp") ;;
+                stress_recovery) perf_args+=("--perf-stress-recovery") ;;
             esac
         done
     fi

--- a/scripts/lib/perf-testing.sh
+++ b/scripts/lib/perf-testing.sh
@@ -182,7 +182,7 @@ apply_perf_profile_config() {
             --set "jwtAuth.envoy.ingressTimeout=${ingress_timeout}" \
             --set "jwtAuth.envoy.ingressPerTryTimeout=${ingress_per_try_timeout}" \
             --set "gatewayRoute.annotations.haproxy\\.router\\.openshift\\.io/timeout=${haproxy_timeout}" \
-            --wait --timeout 5m 2>&1; then
+            --wait --timeout 10m 2>&1; then
         log_warning "helm upgrade for profile config failed — continuing with oc scale only; resource limits may not match profile"
     else
         log_success "Resource/timeout overrides applied"

--- a/scripts/lib/perf-testing.sh
+++ b/scripts/lib/perf-testing.sh
@@ -401,6 +401,7 @@ run_performance_tests() {
                 db)        perf_args+=("--perf-db") ;;
                 kafka)     perf_args+=("--perf-kafka") ;;
                 celery)    perf_args+=("--perf-celery") ;;
+                stress)    perf_args+=("--perf-stress") ;;
             esac
         done
     fi

--- a/scripts/observability/collect-metrics.sh
+++ b/scripts/observability/collect-metrics.sh
@@ -178,8 +178,8 @@ query_prometheus() {
     local query="$1"
     local token
     token=$(get_prometheus_token)
-    
-    curl -s -k \
+
+    curl -s -k --connect-timeout 10 --max-time 30 \
         ${token:+-H "Authorization: Bearer $token"} \
         --data-urlencode "query=$query" \
         "$PROMETHEUS_URL/api/v1/query" 2>/dev/null
@@ -193,8 +193,8 @@ query_prometheus_range() {
     local step="${4:-15s}"
     local token
     token=$(get_prometheus_token)
-    
-    curl -s -k \
+
+    curl -s -k --connect-timeout 10 --max-time 60 \
         ${token:+-H "Authorization: Bearer $token"} \
         --data-urlencode "query=$query" \
         --data-urlencode "start=$start" \

--- a/scripts/run-pytest.sh
+++ b/scripts/run-pytest.sh
@@ -30,9 +30,9 @@
 #   --perf-valkey       Run Valkey eviction correlation tests only
 #   --perf-db           Run PostgreSQL resource sweep tests only
 #   --perf-kafka        Run Kafka throughput/scaling tests only
-#   --perf-stress       Run stress ramp + recovery tests only
-#   --perf-stress-ramp  Run stress ramp-to-failure only (PERF-STR-001)
-#   --perf-stress-recovery  Run stress backlog recovery only (PERF-STR-002)
+#   --perf-stress          Run stress ramp + recovery tests only
+#   --perf-stress-ramp     Run stress ramp-to-failure only (PERF-STR-001)
+#   --perf-stress-recovery Run stress backlog recovery only (PERF-STR-002)
 #
 # Filter Options:
 #   --smoke             Run only smoke tests (quick validation)
@@ -143,9 +143,9 @@ show_help() {
     echo "  --perf-db         Run PostgreSQL resource sweep tests (PERF-DB-*)"
     echo "  --perf-kafka      Run Kafka throughput/scaling tests (PERF-KAF-*)"
     echo "  --perf-celery     Run Celery worker scaling tests (PERF-CEL-*)"
-    echo "  --perf-stress     Run stress ramp + recovery tests (PERF-STR-*)"
-    echo "  --perf-stress-ramp      Run stress ramp-to-failure only (PERF-STR-001)"
-    echo "  --perf-stress-recovery  Run stress backlog recovery only (PERF-STR-002)"
+    echo "  --perf-stress          Run stress ramp + recovery tests (PERF-STR-*)"
+    echo "  --perf-stress-ramp     Run stress ramp-to-failure only (PERF-STR-001)"
+    echo "  --perf-stress-recovery Run stress backlog recovery only (PERF-STR-002)"
     echo ""
     echo "UI Tests:"
     echo "  UI tests are included by default. Use --no-ui to exclude them."

--- a/scripts/run-pytest.sh
+++ b/scripts/run-pytest.sh
@@ -31,6 +31,8 @@
 #   --perf-db           Run PostgreSQL resource sweep tests only
 #   --perf-kafka        Run Kafka throughput/scaling tests only
 #   --perf-stress       Run stress ramp + recovery tests only
+#   --perf-stress-ramp  Run stress ramp-to-failure only (PERF-STR-001)
+#   --perf-stress-recovery  Run stress backlog recovery only (PERF-STR-002)
 #
 # Filter Options:
 #   --smoke             Run only smoke tests (quick validation)
@@ -142,6 +144,8 @@ show_help() {
     echo "  --perf-kafka      Run Kafka throughput/scaling tests (PERF-KAF-*)"
     echo "  --perf-celery     Run Celery worker scaling tests (PERF-CEL-*)"
     echo "  --perf-stress     Run stress ramp + recovery tests (PERF-STR-*)"
+    echo "  --perf-stress-ramp      Run stress ramp-to-failure only (PERF-STR-001)"
+    echo "  --perf-stress-recovery  Run stress backlog recovery only (PERF-STR-002)"
     echo ""
     echo "UI Tests:"
     echo "  UI tests are included by default. Use --no-ui to exclude them."
@@ -400,6 +404,16 @@ main() {
             --perf-stress)
                 # Run stress ramp + recovery tests (COST-7627)
                 pytest_markers+=("performance and stress")
+                include_ui=false
+                shift
+                ;;
+            --perf-stress-ramp)
+                pytest_markers+=("performance and stress_ramp")
+                include_ui=false
+                shift
+                ;;
+            --perf-stress-recovery)
+                pytest_markers+=("performance and stress_recovery")
                 include_ui=false
                 shift
                 ;;

--- a/scripts/run-pytest.sh
+++ b/scripts/run-pytest.sh
@@ -30,6 +30,7 @@
 #   --perf-valkey       Run Valkey eviction correlation tests only
 #   --perf-db           Run PostgreSQL resource sweep tests only
 #   --perf-kafka        Run Kafka throughput/scaling tests only
+#   --perf-stress       Run stress ramp + recovery tests only
 #
 # Filter Options:
 #   --smoke             Run only smoke tests (quick validation)
@@ -140,6 +141,7 @@ show_help() {
     echo "  --perf-db         Run PostgreSQL resource sweep tests (PERF-DB-*)"
     echo "  --perf-kafka      Run Kafka throughput/scaling tests (PERF-KAF-*)"
     echo "  --perf-celery     Run Celery worker scaling tests (PERF-CEL-*)"
+    echo "  --perf-stress     Run stress ramp + recovery tests (PERF-STR-*)"
     echo ""
     echo "UI Tests:"
     echo "  UI tests are included by default. Use --no-ui to exclude them."
@@ -392,6 +394,12 @@ main() {
             --perf-celery)
                 # Run Celery worker scaling tests (COST-7598)
                 pytest_markers+=("performance and celery_scaling")
+                include_ui=false
+                shift
+                ;;
+            --perf-stress)
+                # Run stress ramp + recovery tests (COST-7627)
+                pytest_markers+=("performance and stress")
                 include_ui=false
                 shift
                 ;;

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -95,6 +95,8 @@ markers =
     kafka_throughput: Kafka throughput and scaling tests (PERF-KAF-*, COST-7638)
     celery_scaling: Celery worker scaling and OOM tests (PERF-CEL-*, COST-7598)
     stress: Stress ramp-to-failure and backlog recovery tests (PERF-STR-*, COST-7627)
+    stress_ramp: Stress ramp-to-failure only (PERF-STR-001)
+    stress_recovery: Stress backlog recovery only (PERF-STR-002)
 
 # Default timeout for non-performance tests (seconds).
 # Performance tests set their own @pytest.mark.timeout() — ensure those are

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -94,6 +94,7 @@ markers =
     db_sweep: PostgreSQL resource sweep tests (PERF-DB-*, COST-7605)
     kafka_throughput: Kafka throughput and scaling tests (PERF-KAF-*, COST-7638)
     celery_scaling: Celery worker scaling and OOM tests (PERF-CEL-*, COST-7598)
+    stress: Stress ramp-to-failure and backlog recovery tests (PERF-STR-*, COST-7627)
 
 # Default timeout for non-performance tests (seconds).
 # Performance tests set their own @pytest.mark.timeout() — ensure those are

--- a/tests/suites/performance/helpers.py
+++ b/tests/suites/performance/helpers.py
@@ -665,11 +665,15 @@ def get_oomkill_events(namespace: str, label: str) -> List[Dict[str, str]]:
 
 
 def get_pod_restart_counts(namespace: str, label: str) -> Dict[str, int]:
-    """Get restart counts for pods matching a label."""
+    """Get total restart counts for pods matching a label.
+
+    Sums restart counts across all containers in each pod so multi-container
+    pods (e.g. database with pgbouncer sidecar) are counted correctly.
+    """
     result = run_oc_command(
         ["get", "pods", "-n", namespace, "-l", label,
          "-o", "jsonpath={range .items[*]}{.metadata.name} "
-               "{range .status.containerStatuses[*]}{.restartCount}{end}{'\\n'}{end}"],
+               "{range .status.containerStatuses[*]}{.restartCount}{\" \"}{end}{'\\n'}{end}"],
         check=False,
     )
     counts = {}
@@ -677,8 +681,9 @@ def get_pod_restart_counts(namespace: str, label: str) -> Dict[str, int]:
         for line in result.stdout.strip().splitlines():
             parts = line.split()
             if len(parts) >= 2:
+                pod_name = parts[0]
                 try:
-                    counts[parts[0]] = int(parts[1])
+                    counts[pod_name] = sum(int(c) for c in parts[1:])
                 except ValueError:
                     pass
     return counts

--- a/tests/suites/performance/helpers.py
+++ b/tests/suites/performance/helpers.py
@@ -720,7 +720,8 @@ class APIProbeThread:
     Usage::
 
         session = create_authenticated_session(keycloak_config)
-        probe = APIProbeThread(session, gateway_url, namespace)
+        probe = APIProbeThread(session, gateway_url, namespace,
+                               keycloak_config=keycloak_config)
         probe.start()
         # ... do heavy work ...
         summary = probe.stop()   # returns percentile stats per endpoint
@@ -732,6 +733,7 @@ class APIProbeThread:
         gateway_url: str,
         namespace: str,
         poll_interval: float = 2.0,
+        keycloak_config=None,
     ):
         self.session = session
         self.namespace = namespace
@@ -739,6 +741,8 @@ class APIProbeThread:
         self.snapshots: List[APIProbeSnapshot] = []
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
+        self._keycloak_config = keycloak_config
+        self._token_refreshes = 0
 
         base = gateway_url.rstrip("/")
         self._urls = {
@@ -750,9 +754,25 @@ class APIProbeThread:
             "cost_models": f"{base}/api/cost-management/v1/cost-models/",
         }
 
+    def _refresh_token(self) -> bool:
+        """Refresh the session's JWT token. Returns True on success."""
+        if not self._keycloak_config:
+            return False
+        try:
+            from conftest import obtain_jwt_token
+            token = obtain_jwt_token(self._keycloak_config)
+            self.session.headers["Authorization"] = f"Bearer {token.access_token}"
+            self._token_refreshes += 1
+            print(f"[api-probe] Refreshed JWT token (refresh #{self._token_refreshes})")
+            return True
+        except Exception as e:
+            print(f"[api-probe] Token refresh failed: {e}")
+            return False
+
     def _probe_once(self) -> APIProbeSnapshot:
         snap = APIProbeSnapshot(timestamp=time.time())
         errors = 0
+        got_401 = False
 
         for attr, url in [
             ("report_baseline_s", self._urls["report_baseline"]),
@@ -766,11 +786,16 @@ class APIProbeThread:
                 setattr(snap, attr, latency)
                 if resp.status_code != 200:
                     errors += 1
+                    if resp.status_code == 401:
+                        got_401 = True
             except _requests.RequestException:
                 setattr(snap, attr, time.time() - start)
                 errors += 1
 
         snap.errors = errors
+
+        if got_401 and self._refresh_token():
+            snap.errors = 0
 
         depths = get_celery_queue_depths(self.namespace)
         snap.queue_depth = sum(depths.values())
@@ -783,11 +808,14 @@ class APIProbeThread:
                 snap = self._probe_once()
                 self.snapshots.append(snap)
 
+                err_str = ""
+                if snap.errors:
+                    err_str = f" errors={snap.errors}"
                 print(
                     f"[api-probe] report={snap.report_baseline_s:.3f}s "
                     f"group_by={snap.group_by_s:.3f}s "
                     f"cost_models={snap.cost_models_s:.3f}s "
-                    f"queue={snap.queue_depth} errors={snap.errors}"
+                    f"queue={snap.queue_depth}{err_str}"
                 )
             except Exception as e:
                 print(f"[api-probe] poll error: {e}")

--- a/tests/suites/performance/helpers.py
+++ b/tests/suites/performance/helpers.py
@@ -638,6 +638,53 @@ def register_tracked_source(
 
 
 # ---------------------------------------------------------------------------
+# Pod health helpers (OOMKill detection, restart counts)
+# ---------------------------------------------------------------------------
+
+
+def get_oomkill_events(namespace: str, label: str) -> List[Dict[str, str]]:
+    """Check for OOMKilled containers in pods matching *label*."""
+    result = run_oc_command(
+        ["get", "pods", "-n", namespace,
+         "-l", label,
+         "-o", "jsonpath={range .items[*]}{.metadata.name}|"
+               "{range .status.containerStatuses[*]}"
+               "{.lastState.terminated.reason}{end}{'\\n'}{end}"],
+        check=False,
+    )
+    events = []
+    if result.returncode == 0:
+        for line in result.stdout.strip().splitlines():
+            if "OOMKilled" in line:
+                pod_name = line.split("|", 1)[0]
+                events.append({
+                    "pod": pod_name,
+                    "reason": "OOMKilled",
+                })
+    return events
+
+
+def get_pod_restart_counts(namespace: str, label: str) -> Dict[str, int]:
+    """Get restart counts for pods matching a label."""
+    result = run_oc_command(
+        ["get", "pods", "-n", namespace, "-l", label,
+         "-o", "jsonpath={range .items[*]}{.metadata.name} "
+               "{range .status.containerStatuses[*]}{.restartCount}{end}{'\\n'}{end}"],
+        check=False,
+    )
+    counts = {}
+    if result.returncode == 0:
+        for line in result.stdout.strip().splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    counts[parts[0]] = int(parts[1])
+                except ValueError:
+                    pass
+    return counts
+
+
+# ---------------------------------------------------------------------------
 # API Probe Thread (for concurrent load testing)
 # ---------------------------------------------------------------------------
 

--- a/tests/suites/performance/test_celery_scaling.py
+++ b/tests/suites/performance/test_celery_scaling.py
@@ -32,6 +32,8 @@ from .helpers import (
     PerfResultCollector,
     PerfTimer,
     generate_and_upload_data,
+    get_oomkill_events,
+    get_pod_restart_counts,
 )
 from .k8s_helpers import (
     capture_pg_stats,
@@ -92,46 +94,6 @@ def _wait_for_pod_metrics(
     return result
 
 
-def get_oomkill_events(namespace: str, label: str) -> List[Dict[str, str]]:
-    """Check for OOMKilled containers in pods matching *label*."""
-    result = run_oc_command(
-        ["get", "pods", "-n", namespace,
-         "-l", label,
-         "-o", "jsonpath={range .items[*]}{.metadata.name}|"
-               "{range .status.containerStatuses[*]}"
-               "{.lastState.terminated.reason}{end}{'\\n'}{end}"],
-        check=False,
-    )
-    events = []
-    if result.returncode == 0:
-        for line in result.stdout.strip().splitlines():
-            if "OOMKilled" in line:
-                pod_name = line.split("|", 1)[0]
-                events.append({
-                    "pod": pod_name,
-                    "reason": "OOMKilled",
-                })
-    return events
-
-
-def get_pod_restart_counts(namespace: str, label: str) -> Dict[str, int]:
-    """Get restart counts for pods matching a label."""
-    result = run_oc_command(
-        ["get", "pods", "-n", namespace, "-l", label,
-         "-o", "jsonpath={range .items[*]}{.metadata.name} "
-               "{range .status.containerStatuses[*]}{.restartCount}{end}{'\\n'}{end}"],
-        check=False,
-    )
-    counts = {}
-    if result.returncode == 0:
-        for line in result.stdout.strip().splitlines():
-            parts = line.split()
-            if len(parts) >= 2:
-                try:
-                    counts[parts[0]] = int(parts[1])
-                except ValueError:
-                    pass
-    return counts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/suites/performance/test_db_resource_sweep.py
+++ b/tests/suites/performance/test_db_resource_sweep.py
@@ -590,7 +590,8 @@ class TestAPIUnderLoad:
 
         session = create_authenticated_session(self._keycloak_config)
         probe = APIProbeThread(
-            session, gateway_url, self.namespace, poll_interval=2.0
+            session, gateway_url, self.namespace, poll_interval=2.0,
+            keycloak_config=self._keycloak_config,
         )
         probe.start()
 

--- a/tests/suites/performance/test_stress.py
+++ b/tests/suites/performance/test_stress.py
@@ -1,0 +1,682 @@
+"""
+Stress & Spike/Backlog Recovery Tests (COST-7627 + COST-7600).
+
+Ramp concurrent source count at medium profile until a component fails,
+then verify the system recovers gracefully after the load stops.
+
+Test IDs:
+- PERF-STR-001: Ramp-to-failure (single test, internal loop over source counts)
+- PERF-STR-002: Backlog recovery (sustained overload then drain)
+
+Usage:
+    # Via deploy script (recommended)
+    ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite stress
+
+    # Direct pytest
+    PERF_PROFILE=medium pytest -m "performance and stress" tests/suites/performance/
+
+Environment Variables:
+    STRESS_RAMP_STEPS: Comma-separated source counts (default: 5,10,20,30,50,75,100)
+    STRESS_STEP_TIMEOUT_BASE: Base timeout per step in seconds (default: 120)
+    STRESS_STEP_TIMEOUT_PER_SOURCE: Additional seconds per source (default: 60)
+    STRESS_MAX_STEP_TIME: Absolute max seconds before declaring step failed (default: 1800)
+    STRESS_RECOVERY_SOURCE_COUNT: Sources for recovery test; 0 = auto from STR-001 (default: 0)
+    STRESS_RECOVERY_DURATION_S: How long to sustain overload in STR-002 (default: 300)
+"""
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from conftest import ClusterConfig, DatabaseConfig, JWTToken, obtain_jwt_token
+from e2e_helpers import (
+    cleanup_database_records,
+    ensure_nise_available,
+    generate_cluster_id,
+    register_source,
+    wait_for_processing_complete,
+)
+from utils import run_oc_command
+
+from .data_classes import PerformanceResult
+from .helpers import (
+    APIProbeThread,
+    PerfResultCollector,
+    PerfTimer,
+    create_authenticated_session,
+    generate_and_upload_data,
+    get_oomkill_events,
+    get_pod_restart_counts,
+)
+from .k8s_helpers import capture_pg_stats, diff_pg_stats
+from .profiles import ACTIVE_PROFILE as _ACTIVE_PROFILE
+from .queue_helpers import get_celery_queue_depths, wait_for_queue_drain
+from .tracker import PerfCleanupTracker
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+RAMP_STEPS = [
+    int(x) for x in os.environ.get("STRESS_RAMP_STEPS", "5,10,20,30,50,75,100").split(",")
+]
+
+STEP_TIMEOUT_BASE = int(os.environ.get("STRESS_STEP_TIMEOUT_BASE", "120"))
+STEP_TIMEOUT_PER_SOURCE = int(os.environ.get("STRESS_STEP_TIMEOUT_PER_SOURCE", "60"))
+MAX_STEP_TIME = int(os.environ.get("STRESS_MAX_STEP_TIME", "1800"))
+
+RECOVERY_SOURCE_COUNT = int(os.environ.get("STRESS_RECOVERY_SOURCE_COUNT", "0"))
+RECOVERY_DURATION_S = int(os.environ.get("STRESS_RECOVERY_DURATION_S", "300"))
+
+COMPONENT_LABELS = [
+    "app.kubernetes.io/component=listener",
+    "app.kubernetes.io/component=cost-worker",
+    "app.kubernetes.io/component=cost-processor",
+    "app.kubernetes.io/component=database",
+    "app.kubernetes.io/component=ros-processor",
+    "app.kubernetes.io/component=ros-optimization",
+    "app.kubernetes.io/component=cache",
+    "app.kubernetes.io/component=ingress",
+]
+
+# Module-level state shared between STR-001 and STR-002.
+_ramp_result: Dict[str, Any] = {}
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+@dataclass
+class StepResult:
+    """Metrics captured during a single ramp step."""
+    source_count: int = 0
+    upload_successes: int = 0
+    upload_errors: int = 0
+    processed_count: int = 0
+    step_time_s: float = 0
+    upload_time_s: float = 0
+    processing_time_s: float = 0
+    queue_drain_s: float = 0
+    oomkill_events: List[Dict[str, str]] = field(default_factory=list)
+    restart_delta: Dict[str, int] = field(default_factory=dict)
+    total_new_restarts: int = 0
+    pg_stats: Dict[str, Any] = field(default_factory=dict)
+    queue_depths_peak: Dict[str, int] = field(default_factory=dict)
+    stop_reason: Optional[str] = None
+
+
+def _collect_restart_baseline(namespace: str) -> Dict[str, int]:
+    """Snapshot restart counts across all components."""
+    baseline: Dict[str, int] = {}
+    for label in COMPONENT_LABELS:
+        baseline.update(get_pod_restart_counts(namespace, label))
+    return baseline
+
+
+def _compute_restart_delta(
+    before: Dict[str, int], after: Dict[str, int]
+) -> Tuple[Dict[str, int], int]:
+    """Compute per-pod restart deltas and total new restarts."""
+    delta = {}
+    total = 0
+    for pod, count in after.items():
+        prev = before.get(pod, 0)
+        if count > prev:
+            delta[pod] = count - prev
+            total += count - prev
+    return delta, total
+
+
+def _collect_oomkill_events(namespace: str) -> List[Dict[str, str]]:
+    """Check for OOMKills across all monitored components."""
+    events = []
+    for label in COMPONENT_LABELS:
+        events.extend(get_oomkill_events(namespace, label))
+    return events
+
+
+def _check_stop_conditions(
+    step: StepResult,
+    queue_stall_detected: bool,
+) -> Optional[str]:
+    """Evaluate stop conditions. Returns a reason string or None."""
+    if step.oomkill_events:
+        pods = ", ".join(e["pod"] for e in step.oomkill_events)
+        return f"OOMKill detected: {pods}"
+
+    if step.total_new_restarts > 3:
+        return f"Excessive restarts: {step.total_new_restarts} new restarts ({step.restart_delta})"
+
+    if step.step_time_s > MAX_STEP_TIME:
+        return f"Step took {step.step_time_s:.0f}s (max {MAX_STEP_TIME}s)"
+
+    if queue_stall_detected:
+        return "Queue stall: depth grew monotonically for >5 minutes"
+
+    error_rate = step.upload_errors / max(step.source_count, 1)
+    if error_rate > 0.05:
+        return f"Upload error rate {error_rate:.0%} exceeds 5% threshold"
+
+    return None
+
+
+# =============================================================================
+# Test Class
+# =============================================================================
+
+@pytest.mark.performance
+@pytest.mark.stress
+@pytest.mark.slow
+class TestStress:
+    """Stress and spike/backlog recovery tests (COST-7627 + COST-7600)."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, cluster_config: ClusterConfig, keycloak_config):
+        self.namespace = cluster_config.namespace
+        self.helm_release = cluster_config.helm_release_name
+
+        if not ensure_nise_available():
+            pytest.skip("NISE (koku-nise) not available")
+
+        self._keycloak_config = keycloak_config
+
+    def _get_fresh_token(self) -> JWTToken:
+        return obtain_jwt_token(self._keycloak_config)
+
+    # -----------------------------------------------------------------
+    # STR-001: Ramp-to-failure
+    # -----------------------------------------------------------------
+
+    @pytest.mark.timeout(7200)
+    def test_perf_str_001_ramp_to_failure(
+        self,
+        cluster_config: ClusterConfig,
+        ingress_url: str,
+        database_config: DatabaseConfig,
+        koku_api_url: str,
+        perf_timer: PerfTimer,
+        perf_result: PerformanceResult,
+        perf_collector: PerfResultCollector,
+        rh_identity_header: str,
+        perf_cleanup: PerfCleanupTracker,
+        ingress_pod: str,
+        keycloak_config,
+        gateway_url: str,
+    ):
+        """PERF-STR-001: Ramp concurrent sources until the system breaks.
+
+        Iterates through increasing source counts, uploading concurrently at
+        each step. Captures comprehensive metrics and stops when a failure
+        condition is detected.
+        """
+        global _ramp_result
+
+        print(f"\n{'='*72}")
+        print(f"PERF-STR-001: Ramp-to-failure (steps: {RAMP_STEPS})")
+        print(f"Profile: {_ACTIVE_PROFILE}")
+        print(f"{'='*72}\n")
+
+        # Start background API probe for the entire ramp
+        session = create_authenticated_session(keycloak_config)
+        api_probe = APIProbeThread(session, gateway_url, self.namespace, poll_interval=5.0)
+        api_probe.start()
+
+        step_results: List[StepResult] = []
+        breaking_point: Optional[int] = None
+        last_good_count = 0
+
+        try:
+            for step_idx, source_count in enumerate(RAMP_STEPS):
+                print(f"\n{'─'*60}")
+                print(f"Step {step_idx + 1}/{len(RAMP_STEPS)}: {source_count} concurrent sources")
+                print(f"{'─'*60}")
+
+                step = StepResult(source_count=source_count)
+                step_start = time.time()
+
+                # Snapshot state before step
+                restart_baseline = _collect_restart_baseline(self.namespace)
+                pg_before = capture_pg_stats(
+                    self.namespace,
+                    database_config.pod_name,
+                    database_config.database,
+                    database_config.user,
+                )
+
+                # Register sources
+                sources = []
+                for i in range(source_count):
+                    cluster_id = generate_cluster_id()
+                    source_name = f"perf-str-001-s{step_idx}-{i:03d}-{cluster_id[-6:]}"
+
+                    source = register_source(
+                        self.namespace,
+                        ingress_pod,
+                        koku_api_url,
+                        rh_identity_header,
+                        cluster_id,
+                        "org1234567",
+                        source_name,
+                    )
+                    perf_cleanup.track(
+                        source_id=source.source_id,
+                        cluster_id=cluster_id,
+                        source_name=source_name,
+                    )
+                    sources.append({
+                        "cluster_id": cluster_id,
+                        "source_name": source_name,
+                        "source": source,
+                    })
+
+                # Upload concurrently
+                end_date = datetime.now(timezone.utc)
+                start_date = end_date - timedelta(days=7)
+                upload_errors = []
+                upload_successes = []
+
+                def upload_source(source_info):
+                    try:
+                        jwt_token = self._get_fresh_token()
+                        return generate_and_upload_data(
+                            source_info["cluster_id"],
+                            source_info["source_name"],
+                            start_date, end_date,
+                            ingress_url, jwt_token,
+                            profile_name="baseline",
+                        )
+                    except Exception as e:
+                        return {"error": str(e), "cluster_id": source_info["cluster_id"]}
+
+                upload_start = time.time()
+                with ThreadPoolExecutor(max_workers=min(source_count, 20)) as executor:
+                    futures = {executor.submit(upload_source, s): s for s in sources}
+                    for future in as_completed(futures):
+                        result = future.result()
+                        if "error" in result:
+                            upload_errors.append(result)
+                        else:
+                            upload_successes.append(result)
+
+                step.upload_time_s = time.time() - upload_start
+                step.upload_successes = len(upload_successes)
+                step.upload_errors = len(upload_errors)
+
+                print(f"  Uploads: {step.upload_successes} OK, {step.upload_errors} failed "
+                      f"({step.upload_time_s:.0f}s)")
+
+                # Wait for processing with scaled timeout
+                timeout = min(
+                    STEP_TIMEOUT_BASE + source_count * STEP_TIMEOUT_PER_SOURCE,
+                    MAX_STEP_TIME,
+                )
+                deadline = time.time() + timeout
+                processed = 0
+
+                # Monitor queue depths during processing for stall detection
+                queue_samples: List[int] = []
+                processing_start = time.time()
+
+                for source_info in sources:
+                    remaining = max(15, int(deadline - time.time()))
+                    proc = wait_for_processing_complete(
+                        self.namespace,
+                        database_config.pod_name,
+                        source_info["cluster_id"],
+                        max_wait_seconds=remaining,
+                    )
+                    if proc["complete"]:
+                        processed += 1
+
+                    depths = get_celery_queue_depths(self.namespace)
+                    queue_samples.append(sum(depths.values()))
+
+                step.processing_time_s = time.time() - processing_start
+                step.processed_count = processed
+
+                # Drain queues
+                drain = wait_for_queue_drain(
+                    self.namespace,
+                    max_wait_seconds=600,
+                    label=f"STR-001[{source_count}]",
+                )
+                step.queue_drain_s = drain.get("elapsed_s", 0)
+
+                # Collect post-step metrics
+                pg_after = capture_pg_stats(
+                    self.namespace,
+                    database_config.pod_name,
+                    database_config.database,
+                    database_config.user,
+                )
+                step.pg_stats = diff_pg_stats(pg_before, pg_after)
+
+                restarts_after = _collect_restart_baseline(self.namespace)
+                step.restart_delta, step.total_new_restarts = _compute_restart_delta(
+                    restart_baseline, restarts_after,
+                )
+
+                step.oomkill_events = _collect_oomkill_events(self.namespace)
+                step.step_time_s = time.time() - step_start
+
+                # Detect queue stall: depth grew monotonically over 5+ samples
+                queue_stall = False
+                if len(queue_samples) >= 5:
+                    tail = queue_samples[-5:]
+                    if all(tail[i] <= tail[i + 1] for i in range(len(tail) - 1)) and tail[-1] > 0:
+                        queue_stall = True
+
+                # Check stop conditions
+                step.stop_reason = _check_stop_conditions(step, queue_stall)
+
+                print(f"  Processed: {processed}/{source_count} "
+                      f"({step.processing_time_s:.0f}s processing, "
+                      f"{step.queue_drain_s:.0f}s drain)")
+                print(f"  PG stats: {step.pg_stats.get('xact_commit_delta', '?')} commits, "
+                      f"cache hit {step.pg_stats.get('cache_hit_ratio', '?')}")
+                if step.total_new_restarts > 0:
+                    print(f"  Restarts: {step.restart_delta}")
+                if step.oomkill_events:
+                    print(f"  OOMKills: {step.oomkill_events}")
+
+                step_results.append(step)
+
+                if step.stop_reason:
+                    print(f"\n  *** STOP: {step.stop_reason} ***")
+                    breaking_point = source_count
+                    break
+                else:
+                    last_good_count = source_count
+                    print(f"  ✓ Step passed")
+
+        finally:
+            api_summary = api_probe.stop()
+
+        # Store results for STR-002
+        _ramp_result = {
+            "breaking_point": breaking_point,
+            "last_good_count": last_good_count,
+            "steps": [
+                {
+                    "source_count": s.source_count,
+                    "upload_successes": s.upload_successes,
+                    "upload_errors": s.upload_errors,
+                    "processed_count": s.processed_count,
+                    "step_time_s": round(s.step_time_s, 1),
+                    "upload_time_s": round(s.upload_time_s, 1),
+                    "processing_time_s": round(s.processing_time_s, 1),
+                    "queue_drain_s": round(s.queue_drain_s, 1),
+                    "total_new_restarts": s.total_new_restarts,
+                    "oomkill_count": len(s.oomkill_events),
+                    "pg_commits": s.pg_stats.get("xact_commit_delta", 0),
+                    "pg_cache_hit": s.pg_stats.get("cache_hit_ratio", 0),
+                    "stop_reason": s.stop_reason,
+                }
+                for s in step_results
+            ],
+            "api_probe": api_summary,
+        }
+
+        # Summary
+        print(f"\n{'='*72}")
+        print("STR-001 SUMMARY")
+        print(f"{'='*72}")
+        print(f"Steps completed: {len(step_results)}/{len(RAMP_STEPS)}")
+        print(f"Last good count: {last_good_count}")
+        print(f"Breaking point:  {breaking_point or 'none (system survived all steps)'}")
+        if breaking_point:
+            final = step_results[-1]
+            print(f"Failure reason:  {final.stop_reason}")
+        print(f"\nAPI probe: {api_summary.get('probe_count', 0)} samples, "
+              f"peak queue {api_summary.get('peak_queue_depth', '?')}, "
+              f"errors {api_summary.get('total_errors', '?')}")
+        for step in step_results:
+            status = "FAIL" if step.stop_reason else "PASS"
+            print(f"  [{status}] {step.source_count:3d} sources: "
+                  f"{step.processed_count}/{step.source_count} processed, "
+                  f"{step.step_time_s:.0f}s total, "
+                  f"{step.total_new_restarts} restarts")
+
+        # Persist results
+        perf_result.test_id = "PERF-STR-001"
+        perf_result.metrics = _ramp_result
+        perf_result.passed = breaking_point is None or last_good_count > 0
+        perf_collector.add_result(perf_result)
+
+        # The test "passes" as long as we collected data. The breaking point
+        # is a finding, not a failure — the whole point is to find it.
+        assert last_good_count > 0 or breaking_point is None, (
+            f"System failed at the first step ({RAMP_STEPS[0]} sources)"
+        )
+
+    # -----------------------------------------------------------------
+    # STR-002: Backlog recovery
+    # -----------------------------------------------------------------
+
+    @pytest.mark.timeout(3600)
+    def test_perf_str_002_backlog_recovery(
+        self,
+        cluster_config: ClusterConfig,
+        ingress_url: str,
+        database_config: DatabaseConfig,
+        koku_api_url: str,
+        perf_timer: PerfTimer,
+        perf_result: PerformanceResult,
+        perf_collector: PerfResultCollector,
+        rh_identity_header: str,
+        perf_cleanup: PerfCleanupTracker,
+        ingress_pod: str,
+        keycloak_config,
+        gateway_url: str,
+    ):
+        """PERF-STR-002: Verify system recovers after sustained overload.
+
+        Uploads at a rate near the breaking point for RECOVERY_DURATION_S
+        seconds, then stops and monitors the system until all queues drain
+        and API latencies return to baseline.
+        """
+        global _ramp_result
+
+        # Determine load level
+        if RECOVERY_SOURCE_COUNT > 0:
+            load_count = RECOVERY_SOURCE_COUNT
+            source_label = f"configured ({RECOVERY_SOURCE_COUNT})"
+        elif _ramp_result.get("breaking_point"):
+            load_count = _ramp_result["breaking_point"]
+            source_label = f"breaking point from STR-001 ({load_count})"
+        elif _ramp_result.get("last_good_count"):
+            load_count = _ramp_result["last_good_count"]
+            source_label = f"last good from STR-001 ({load_count})"
+        else:
+            load_count = 20
+            source_label = "default (STR-001 not run or no data)"
+
+        print(f"\n{'='*72}")
+        print(f"PERF-STR-002: Backlog recovery")
+        print(f"Load level: {load_count} sources ({source_label})")
+        print(f"Overload duration: {RECOVERY_DURATION_S}s")
+        print(f"{'='*72}\n")
+
+        # Capture quiescent API baseline
+        session = create_authenticated_session(keycloak_config)
+        api_probe_baseline = APIProbeThread(session, gateway_url, self.namespace, poll_interval=2.0)
+        api_probe_baseline.start()
+        time.sleep(30)
+        baseline_summary = api_probe_baseline.stop()
+
+        baseline_p95 = baseline_summary.get("report_baseline", {}).get("p95", 999)
+        print(f"Quiescent API baseline p95: {baseline_p95:.3f}s")
+
+        # Sustained overload: keep uploading for RECOVERY_DURATION_S
+        restart_baseline = _collect_restart_baseline(self.namespace)
+        overload_start = time.time()
+        batch_num = 0
+        all_sources: List[Dict[str, Any]] = []
+
+        # Start API probe during overload + recovery
+        session2 = create_authenticated_session(keycloak_config)
+        api_probe_recovery = APIProbeThread(session2, gateway_url, self.namespace, poll_interval=5.0)
+        api_probe_recovery.start()
+
+        try:
+            while time.time() - overload_start < RECOVERY_DURATION_S:
+                batch_num += 1
+                print(f"\n  Overload batch {batch_num}: uploading {load_count} sources...")
+
+                sources = []
+                for i in range(load_count):
+                    cluster_id = generate_cluster_id()
+                    source_name = f"perf-str-002-b{batch_num}-{i:03d}-{cluster_id[-6:]}"
+
+                    source = register_source(
+                        self.namespace,
+                        ingress_pod,
+                        koku_api_url,
+                        rh_identity_header,
+                        cluster_id,
+                        "org1234567",
+                        source_name,
+                    )
+                    perf_cleanup.track(
+                        source_id=source.source_id,
+                        cluster_id=cluster_id,
+                        source_name=source_name,
+                    )
+                    sources.append({
+                        "cluster_id": cluster_id,
+                        "source_name": source_name,
+                        "source": source,
+                    })
+
+                end_date = datetime.now(timezone.utc)
+                start_date = end_date - timedelta(days=7)
+
+                def upload_source(source_info):
+                    try:
+                        jwt_token = self._get_fresh_token()
+                        return generate_and_upload_data(
+                            source_info["cluster_id"],
+                            source_info["source_name"],
+                            start_date, end_date,
+                            ingress_url, jwt_token,
+                            profile_name="baseline",
+                        )
+                    except Exception as e:
+                        return {"error": str(e), "cluster_id": source_info["cluster_id"]}
+
+                with ThreadPoolExecutor(max_workers=min(load_count, 20)) as executor:
+                    futures = {executor.submit(upload_source, s): s for s in sources}
+                    for future in as_completed(futures):
+                        future.result()
+
+                all_sources.extend(sources)
+
+                depths = get_celery_queue_depths(self.namespace)
+                total_queued = sum(depths.values())
+                elapsed = time.time() - overload_start
+                print(f"  Batch {batch_num} uploaded. Queue depth: {total_queued}. "
+                      f"Elapsed: {elapsed:.0f}/{RECOVERY_DURATION_S}s")
+
+            print(f"\n  Overload phase complete ({batch_num} batches, "
+                  f"{len(all_sources)} total sources)")
+
+            # Recovery phase: stop uploading, monitor until healthy
+            print(f"\n{'─'*60}")
+            print("Recovery phase: waiting for queue drain + API stabilization")
+            print(f"{'─'*60}")
+
+            recovery_start = time.time()
+
+            # Wait for all queues to drain (generous timeout)
+            drain_result = wait_for_queue_drain(
+                self.namespace,
+                max_wait_seconds=1800,
+                poll_interval=15,
+                label="STR-002-recovery",
+            )
+
+            recovery_time = time.time() - recovery_start
+
+            # Check pod health
+            restarts_after = _collect_restart_baseline(self.namespace)
+            restart_delta, total_new = _compute_restart_delta(restart_baseline, restarts_after)
+            oomkills = _collect_oomkill_events(self.namespace)
+
+            # Check for CrashLoopBackOff
+            clb_result = run_oc_command(
+                ["get", "pods", "-n", self.namespace,
+                 "-l", f"app.kubernetes.io/instance={self.helm_release}",
+                 "--field-selector=status.phase!=Running,status.phase!=Succeeded",
+                 "--no-headers"],
+                check=False,
+            )
+            unhealthy_pods = [
+                line.split()[0]
+                for line in (clb_result.stdout or "").strip().splitlines()
+                if line.strip()
+            ]
+
+        finally:
+            recovery_api = api_probe_recovery.stop()
+
+        # Evaluate recovery
+        recovered = drain_result.get("drained", False)
+        recovery_p95 = recovery_api.get("report_baseline", {}).get("p95", 999)
+        latency_ratio = recovery_p95 / baseline_p95 if baseline_p95 > 0 else 999
+
+        print(f"\n{'='*72}")
+        print("STR-002 SUMMARY")
+        print(f"{'='*72}")
+        print(f"Overload: {batch_num} batches, {len(all_sources)} sources")
+        print(f"Queue drained: {recovered} ({drain_result.get('elapsed_s', '?')}s)")
+        print(f"Recovery time: {recovery_time:.0f}s")
+        print(f"API p95 — baseline: {baseline_p95:.3f}s, recovery: {recovery_p95:.3f}s "
+              f"(ratio: {latency_ratio:.1f}x)")
+        print(f"New restarts: {total_new} {restart_delta if restart_delta else ''}")
+        print(f"OOMKills: {len(oomkills)}")
+        print(f"Unhealthy pods: {unhealthy_pods or 'none'}")
+
+        healthy = (
+            recovered
+            and not unhealthy_pods
+            and not oomkills
+        )
+        print(f"\nVerdict: {'RECOVERED' if healthy else 'NOT RECOVERED'}")
+
+        perf_result.test_id = "PERF-STR-002"
+        perf_result.metrics = {
+            "load_count": load_count,
+            "batches": batch_num,
+            "total_sources": len(all_sources),
+            "recovery_time_s": round(recovery_time, 1),
+            "queue_drained": recovered,
+            "queue_drain_s": drain_result.get("elapsed_s", 0),
+            "baseline_p95": round(baseline_p95, 4),
+            "recovery_p95": round(recovery_p95, 4),
+            "latency_ratio": round(latency_ratio, 2),
+            "new_restarts": total_new,
+            "oomkill_count": len(oomkills),
+            "unhealthy_pods": unhealthy_pods,
+            "api_probe": recovery_api,
+        }
+        perf_result.passed = healthy
+        perf_collector.add_result(perf_result)
+
+        assert recovered, (
+            f"Queues did not drain within 30 minutes. "
+            f"Final depths: {drain_result.get('final_depths', {})}"
+        )
+        assert not unhealthy_pods, (
+            f"Pods not recovered: {unhealthy_pods}"
+        )
+        assert latency_ratio < 3.0, (
+            f"API latency did not return to near-baseline: "
+            f"{recovery_p95:.3f}s vs {baseline_p95:.3f}s ({latency_ratio:.1f}x)"
+        )

--- a/tests/suites/performance/test_stress.py
+++ b/tests/suites/performance/test_stress.py
@@ -9,11 +9,19 @@ Test IDs:
 - PERF-STR-002: Backlog recovery (sustained overload then drain)
 
 Usage:
-    # Via deploy script (recommended)
+    # Both tests (recommended)
     ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite stress
+
+    # Ramp only (long-running, heavyweight)
+    ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite stress_ramp
+
+    # Recovery only (shorter, uses STR-001 results or defaults)
+    ./scripts/deploy-test-cost-onprem.sh --perf-only --perf-profile medium --perf-suite stress_recovery
 
     # Direct pytest
     PERF_PROFILE=medium pytest -m "performance and stress" tests/suites/performance/
+    PERF_PROFILE=medium pytest -m "performance and stress_ramp" tests/suites/performance/
+    PERF_PROFILE=medium pytest -m "performance and stress_recovery" tests/suites/performance/
 
 Environment Variables:
     STRESS_RAMP_STEPS: Comma-separated source counts (default: 5,10,20,30,50,75,100)
@@ -194,6 +202,7 @@ class TestStress:
     # STR-001: Ramp-to-failure
     # -----------------------------------------------------------------
 
+    @pytest.mark.stress_ramp
     @pytest.mark.timeout(14400)
     def test_perf_str_001_ramp_to_failure(
         self,
@@ -460,6 +469,7 @@ class TestStress:
     # STR-002: Backlog recovery
     # -----------------------------------------------------------------
 
+    @pytest.mark.stress_recovery
     @pytest.mark.timeout(3600)
     def test_perf_str_002_backlog_recovery(
         self,

--- a/tests/suites/performance/test_stress.py
+++ b/tests/suites/performance/test_stress.py
@@ -194,7 +194,7 @@ class TestStress:
     # STR-001: Ramp-to-failure
     # -----------------------------------------------------------------
 
-    @pytest.mark.timeout(7200)
+    @pytest.mark.timeout(14400)
     def test_perf_str_001_ramp_to_failure(
         self,
         cluster_config: ClusterConfig,

--- a/tests/suites/performance/test_stress.py
+++ b/tests/suites/performance/test_stress.py
@@ -236,7 +236,8 @@ class TestStress:
 
         # Start background API probe for the entire ramp
         session = create_authenticated_session(keycloak_config)
-        api_probe = APIProbeThread(session, gateway_url, self.namespace, poll_interval=5.0)
+        api_probe = APIProbeThread(session, gateway_url, self.namespace,
+                                   poll_interval=5.0, keycloak_config=keycloak_config)
         api_probe.start()
 
         step_results: List[StepResult] = []
@@ -521,7 +522,8 @@ class TestStress:
 
         # Capture quiescent API baseline
         session = create_authenticated_session(keycloak_config)
-        api_probe_baseline = APIProbeThread(session, gateway_url, self.namespace, poll_interval=2.0)
+        api_probe_baseline = APIProbeThread(session, gateway_url, self.namespace,
+                                            poll_interval=2.0, keycloak_config=keycloak_config)
         api_probe_baseline.start()
         time.sleep(30)
         baseline_summary = api_probe_baseline.stop()
@@ -537,7 +539,8 @@ class TestStress:
 
         # Start API probe during overload phase (informational only)
         session2 = create_authenticated_session(keycloak_config)
-        api_probe_overload = APIProbeThread(session2, gateway_url, self.namespace, poll_interval=5.0)
+        api_probe_overload = APIProbeThread(session2, gateway_url, self.namespace,
+                                            poll_interval=5.0, keycloak_config=keycloak_config)
         api_probe_overload.start()
 
         def _upload_batch(sources_batch, batch_start, batch_end):
@@ -654,7 +657,8 @@ class TestStress:
             # have drained, so the comparison against the quiescent baseline
             # actually proves the API returned to normal.
             session3 = create_authenticated_session(keycloak_config)
-            api_probe_post = APIProbeThread(session3, gateway_url, self.namespace, poll_interval=2.0)
+            api_probe_post = APIProbeThread(session3, gateway_url, self.namespace,
+                                            poll_interval=2.0, keycloak_config=keycloak_config)
             api_probe_post.start()
             time.sleep(30)
             post_recovery_api = api_probe_post.stop()

--- a/tests/suites/performance/test_stress.py
+++ b/tests/suites/performance/test_stress.py
@@ -168,7 +168,7 @@ def _check_stop_conditions(
         return f"Step took {step.step_time_s:.0f}s (max {MAX_STEP_TIME}s)"
 
     if queue_stall_detected:
-        return "Queue stall: depth grew monotonically over last 5 samples"
+        return "Queue stall: depth strictly increasing over last 5 samples"
 
     error_rate = step.upload_errors / max(step.source_count, 1)
     if error_rate > 0.05:
@@ -380,11 +380,11 @@ class TestStress:
                 step.oomkill_events = _collect_oomkill_events(self.namespace)
                 step.step_time_s = time.time() - step_start
 
-                # Detect queue stall: depth grew monotonically over 5+ samples
+                # Detect queue stall: depth strictly increasing over 5+ samples
                 queue_stall = False
                 if len(queue_samples) >= 5:
                     tail = queue_samples[-5:]
-                    if all(tail[i] <= tail[i + 1] for i in range(len(tail) - 1)) and tail[-1] > 0:
+                    if all(tail[i] < tail[i + 1] for i in range(len(tail) - 1)):
                         queue_stall = True
 
                 # Check stop conditions
@@ -555,6 +555,8 @@ class TestStress:
                 except Exception as e:
                     return {"error": str(e), "cluster_id": source_info["cluster_id"]}
 
+            if not sources_batch:
+                return
             with ThreadPoolExecutor(max_workers=min(len(sources_batch), 20)) as executor:
                 futures = {executor.submit(_upload_one, s): s for s in sources_batch}
                 for future in as_completed(futures):
@@ -659,6 +661,8 @@ class TestStress:
 
         except Exception:
             api_probe_overload.stop()
+            if "api_probe_post" in locals():
+                api_probe_post.stop()
             raise
 
         # Evaluate recovery

--- a/tests/suites/performance/test_stress.py
+++ b/tests/suites/performance/test_stress.py
@@ -94,6 +94,8 @@ COMPONENT_LABELS = [
 ]
 
 # Module-level state shared between STR-001 and STR-002.
+# Relies on pytest running methods in definition order within a class
+# (str_001 before str_002). STR-002 has a fallback chain if this is empty.
 _ramp_result: Dict[str, Any] = {}
 
 
@@ -166,7 +168,7 @@ def _check_stop_conditions(
         return f"Step took {step.step_time_s:.0f}s (max {MAX_STEP_TIME}s)"
 
     if queue_stall_detected:
-        return "Queue stall: depth grew monotonically for >5 minutes"
+        return "Queue stall: depth grew monotonically over last 5 samples"
 
     error_rate = step.upload_errors / max(step.source_count, 1)
     if error_rate > 0.05:
@@ -291,13 +293,13 @@ class TestStress:
                 upload_errors = []
                 upload_successes = []
 
-                def upload_source(source_info):
+                def _upload_one(source_info, s_date, e_date):
                     try:
                         jwt_token = self._get_fresh_token()
                         return generate_and_upload_data(
                             source_info["cluster_id"],
                             source_info["source_name"],
-                            start_date, end_date,
+                            s_date, e_date,
                             ingress_url, jwt_token,
                             profile_name="baseline",
                         )
@@ -306,7 +308,10 @@ class TestStress:
 
                 upload_start = time.time()
                 with ThreadPoolExecutor(max_workers=min(source_count, 20)) as executor:
-                    futures = {executor.submit(upload_source, s): s for s in sources}
+                    futures = {
+                        executor.submit(_upload_one, s, start_date, end_date): s
+                        for s in sources
+                    }
                     for future in as_completed(futures):
                         result = future.result()
                         if "error" in result:
@@ -560,6 +565,7 @@ class TestStress:
                 batch_num += 1
                 print(f"\n  Overload batch {batch_num}: uploading {load_count} sources...")
 
+                reg_start = time.time()
                 sources = []
                 for i in range(load_count):
                     cluster_id = generate_cluster_id()
@@ -584,17 +590,21 @@ class TestStress:
                         "source_name": source_name,
                         "source": source,
                     })
+                reg_time = time.time() - reg_start
 
                 end_date = datetime.now(timezone.utc)
                 start_date = end_date - timedelta(days=7)
+                upload_start = time.time()
                 _upload_batch(sources, start_date, end_date)
+                upload_time = time.time() - upload_start
 
                 all_sources.extend(sources)
 
                 depths = get_celery_queue_depths(self.namespace)
                 total_queued = sum(depths.values())
                 elapsed = time.time() - overload_start
-                print(f"  Batch {batch_num} uploaded. Queue depth: {total_queued}. "
+                print(f"  Batch {batch_num}: register {reg_time:.0f}s, upload {upload_time:.0f}s. "
+                      f"Queue depth: {total_queued}. "
                       f"Elapsed: {elapsed:.0f}/{RECOVERY_DURATION_S}s")
 
             overload_api = api_probe_overload.stop()

--- a/tests/suites/performance/test_stress.py
+++ b/tests/suites/performance/test_stress.py
@@ -530,10 +530,30 @@ class TestStress:
         batch_num = 0
         all_sources: List[Dict[str, Any]] = []
 
-        # Start API probe during overload + recovery
+        # Start API probe during overload phase (informational only)
         session2 = create_authenticated_session(keycloak_config)
-        api_probe_recovery = APIProbeThread(session2, gateway_url, self.namespace, poll_interval=5.0)
-        api_probe_recovery.start()
+        api_probe_overload = APIProbeThread(session2, gateway_url, self.namespace, poll_interval=5.0)
+        api_probe_overload.start()
+
+        def _upload_batch(sources_batch, batch_start, batch_end):
+            """Upload a batch of sources concurrently."""
+            def _upload_one(source_info):
+                try:
+                    jwt_token = self._get_fresh_token()
+                    return generate_and_upload_data(
+                        source_info["cluster_id"],
+                        source_info["source_name"],
+                        batch_start, batch_end,
+                        ingress_url, jwt_token,
+                        profile_name="baseline",
+                    )
+                except Exception as e:
+                    return {"error": str(e), "cluster_id": source_info["cluster_id"]}
+
+            with ThreadPoolExecutor(max_workers=min(len(sources_batch), 20)) as executor:
+                futures = {executor.submit(_upload_one, s): s for s in sources_batch}
+                for future in as_completed(futures):
+                    future.result()
 
         try:
             while time.time() - overload_start < RECOVERY_DURATION_S:
@@ -567,24 +587,7 @@ class TestStress:
 
                 end_date = datetime.now(timezone.utc)
                 start_date = end_date - timedelta(days=7)
-
-                def upload_source(source_info):
-                    try:
-                        jwt_token = self._get_fresh_token()
-                        return generate_and_upload_data(
-                            source_info["cluster_id"],
-                            source_info["source_name"],
-                            start_date, end_date,
-                            ingress_url, jwt_token,
-                            profile_name="baseline",
-                        )
-                    except Exception as e:
-                        return {"error": str(e), "cluster_id": source_info["cluster_id"]}
-
-                with ThreadPoolExecutor(max_workers=min(load_count, 20)) as executor:
-                    futures = {executor.submit(upload_source, s): s for s in sources}
-                    for future in as_completed(futures):
-                        future.result()
+                _upload_batch(sources, start_date, end_date)
 
                 all_sources.extend(sources)
 
@@ -594,8 +597,10 @@ class TestStress:
                 print(f"  Batch {batch_num} uploaded. Queue depth: {total_queued}. "
                       f"Elapsed: {elapsed:.0f}/{RECOVERY_DURATION_S}s")
 
+            overload_api = api_probe_overload.stop()
             print(f"\n  Overload phase complete ({batch_num} batches, "
                   f"{len(all_sources)} total sources)")
+            print(f"  Overload API p95: {overload_api.get('report_baseline', {}).get('p95', '?')}s")
 
             # Recovery phase: stop uploading, monitor until healthy
             print(f"\n{'─'*60}")
@@ -633,12 +638,22 @@ class TestStress:
                 if line.strip()
             ]
 
-        finally:
-            recovery_api = api_probe_recovery.stop()
+            # Post-recovery API probe: measures latency *after* queues
+            # have drained, so the comparison against the quiescent baseline
+            # actually proves the API returned to normal.
+            session3 = create_authenticated_session(keycloak_config)
+            api_probe_post = APIProbeThread(session3, gateway_url, self.namespace, poll_interval=2.0)
+            api_probe_post.start()
+            time.sleep(30)
+            post_recovery_api = api_probe_post.stop()
+
+        except Exception:
+            api_probe_overload.stop()
+            raise
 
         # Evaluate recovery
         recovered = drain_result.get("drained", False)
-        recovery_p95 = recovery_api.get("report_baseline", {}).get("p95", 999)
+        recovery_p95 = post_recovery_api.get("report_baseline", {}).get("p95", 999)
         latency_ratio = recovery_p95 / baseline_p95 if baseline_p95 > 0 else 999
 
         print(f"\n{'='*72}")
@@ -647,7 +662,7 @@ class TestStress:
         print(f"Overload: {batch_num} batches, {len(all_sources)} sources")
         print(f"Queue drained: {recovered} ({drain_result.get('elapsed_s', '?')}s)")
         print(f"Recovery time: {recovery_time:.0f}s")
-        print(f"API p95 — baseline: {baseline_p95:.3f}s, recovery: {recovery_p95:.3f}s "
+        print(f"API p95 — baseline: {baseline_p95:.3f}s, post-recovery: {recovery_p95:.3f}s "
               f"(ratio: {latency_ratio:.1f}x)")
         print(f"New restarts: {total_new} {restart_delta if restart_delta else ''}")
         print(f"OOMKills: {len(oomkills)}")
@@ -657,6 +672,7 @@ class TestStress:
             recovered
             and not unhealthy_pods
             and not oomkills
+            and latency_ratio < 3.0
         )
         print(f"\nVerdict: {'RECOVERED' if healthy else 'NOT RECOVERED'}")
 
@@ -670,11 +686,13 @@ class TestStress:
             "queue_drain_s": drain_result.get("elapsed_s", 0),
             "baseline_p95": round(baseline_p95, 4),
             "recovery_p95": round(recovery_p95, 4),
+            "overload_p95": round(overload_api.get("report_baseline", {}).get("p95", 0), 4),
             "latency_ratio": round(latency_ratio, 2),
             "new_restarts": total_new,
             "oomkill_count": len(oomkills),
             "unhealthy_pods": unhealthy_pods,
-            "api_probe": recovery_api,
+            "api_probe_overload": overload_api,
+            "api_probe_post_recovery": post_recovery_api,
         }
         perf_result.passed = healthy
         perf_collector.add_result(perf_result)

--- a/tests/suites/performance/tracker.py
+++ b/tests/suites/performance/tracker.py
@@ -148,7 +148,7 @@ class PerfCleanupTracker:
             print(f"  [s3-cleanup] Could not get S3 config: {e}")
             return None
 
-    def _cleanup_s3_data(self, failures: List[str]):
+    def _cleanup_s3_data(self, failures: List[str], deadline: float):
         """Clean up S3 data for all tracked clusters."""
         from cleanup import cleanup_s3_data
 
@@ -164,7 +164,14 @@ class PerfCleanupTracker:
         org_id = os.environ.get("ORG_ID", "6089719")
 
         total_deleted = 0
+        skipped = 0
         for cluster_id in cluster_ids:
+            if time.time() >= deadline:
+                skipped = len(cluster_ids) - total_deleted - skipped
+                msg = f"S3 cleanup timeout — {skipped} cluster(s) skipped"
+                print(f"  [s3-cleanup] {msg}")
+                failures.append(msg)
+                break
             try:
                 result = cleanup_s3_data(
                     endpoint=s3_config["endpoint"],
@@ -283,7 +290,7 @@ class PerfCleanupTracker:
             cleaned += 1
 
         if time.time() < deadline:
-            self._cleanup_s3_data(failures)
+            self._cleanup_s3_data(failures, deadline)
 
         self.resources.clear()
 

--- a/tests/suites/performance/tracker.py
+++ b/tests/suites/performance/tracker.py
@@ -31,6 +31,8 @@ class PerfCleanupTracker:
             # Cleanup happens automatically after test
     """
 
+    CLEANUP_TIMEOUT_S = int(os.environ.get("PERF_CLEANUP_TIMEOUT", "900"))
+
     def __init__(self, namespace: str, helm_release: str):
         self.namespace = namespace
         self.helm_release = helm_release
@@ -190,6 +192,12 @@ class PerfCleanupTracker:
     def cleanup(self, rh_identity_header: str):
         """Clean up all tracked resources.
 
+        The entire cleanup is capped at CLEANUP_TIMEOUT_S (default 900s /
+        15 min, configurable via PERF_CLEANUP_TIMEOUT env var).  If the
+        timeout fires, remaining resources are skipped and a warning is
+        emitted.  This prevents hung cleanup from blocking the pipeline
+        (see xlarge stress run #97 where cleanup hung for 30+ minutes).
+
         Emits a RuntimeWarning if any cleanup operations fail, so test
         output surfaces dirty state without failing the test itself.
         """
@@ -205,11 +213,19 @@ class PerfCleanupTracker:
         if not self.resources:
             return
 
-        print(f"\n[PERF CLEANUP] Cleaning {len(self.resources)} tracked resources...")
+        deadline = time.time() + self.CLEANUP_TIMEOUT_S
+        total = len(self.resources)
+        print(f"\n[PERF CLEANUP] Cleaning {total} tracked resources "
+              f"(timeout: {self.CLEANUP_TIMEOUT_S}s)...")
 
         # Wait for the ROS processor to consume any pending Kafka events
         # before deleting sources (PERF-FINDING-013).
         self._wait_for_ros_drain()
+
+        if time.time() >= deadline:
+            print(f"[PERF CLEANUP] Timeout reached during ros-drain, skipping resource deletion")
+            self.resources.clear()
+            return
 
         ingress_pod = get_pod_by_label(self.namespace, "app.kubernetes.io/component=ingress")
         db_pod = get_pod_by_label(self.namespace, "app.kubernetes.io/component=database")
@@ -217,8 +233,17 @@ class PerfCleanupTracker:
         koku_api_url = build_koku_api_url(self.helm_release, self.namespace)
 
         failures: List[str] = []
+        cleaned = 0
 
         for resource in self.resources:
+            if time.time() >= deadline:
+                remaining = total - cleaned
+                msg = (f"Cleanup timeout ({self.CLEANUP_TIMEOUT_S}s) reached after "
+                       f"{cleaned}/{total} resources — {remaining} skipped")
+                print(f"\n[PERF CLEANUP] {msg}")
+                failures.append(msg)
+                break
+
             if resource.source_id and ingress_pod:
                 try:
                     if delete_source(
@@ -252,17 +277,20 @@ class PerfCleanupTracker:
                     print(f"  {msg}")
                     failures.append(msg)
 
-        self._cleanup_s3_data(failures)
+            cleaned += 1
+
+        if time.time() < deadline:
+            self._cleanup_s3_data(failures)
 
         self.resources.clear()
 
         if failures:
-            print(f"[PERF CLEANUP] Completed with {len(failures)} failure(s)")
+            print(f"[PERF CLEANUP] Completed with {len(failures)} issue(s) ({cleaned}/{total} cleaned)")
             warnings.warn(
-                f"Performance test cleanup had {len(failures)} failure(s): "
+                f"Performance test cleanup had {len(failures)} issue(s): "
                 + "; ".join(failures[:3]),
                 RuntimeWarning,
                 stacklevel=2,
             )
         else:
-            print("[PERF CLEANUP] Complete")
+            print(f"[PERF CLEANUP] Complete ({cleaned}/{total})")

--- a/tests/suites/performance/tracker.py
+++ b/tests/suites/performance/tracker.py
@@ -223,8 +223,11 @@ class PerfCleanupTracker:
         self._wait_for_ros_drain()
 
         if time.time() >= deadline:
-            print(f"[PERF CLEANUP] Timeout reached during ros-drain, skipping resource deletion")
+            msg = (f"Cleanup timeout ({self.CLEANUP_TIMEOUT_S}s) exhausted during "
+                   f"ros-drain — skipping {total} resource deletion(s)")
+            print(f"[PERF CLEANUP] {msg}")
             self.resources.clear()
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
             return
 
         ingress_pod = get_pod_by_label(self.namespace, "app.kubernetes.io/component=ingress")


### PR DESCRIPTION
- Adds two new stress tests: **PERF-STR-001** (ramp concurrent sources until the system breaks) and **PERF-STR-002** (sustain overload, stop, verify recovery)
- Splits the `stress` suite into independently runnable `stress_ramp` and `stress_recovery` suites so the heavyweight ramp can run separately from the lighter recovery test
- Adds a configurable cleanup timeout (`PERF_CLEANUP_TIMEOUT`, default 15 min) to prevent pipeline hangs when post-test resource deletion stalls on large tracked-resource sets
- Wires `--max-duration` through to the metrics collector so it scales with `JOB_TIMEOUT_HOURS` instead of hitting a hardcoded 4-hour ceiling
- Documents FINDING-036 (stress ramp breaking points) and updates success criteria

## Test plan

- [ ] Run `--perf-suite stress_ramp` at medium profile to validate the suite split selects only STR-001
- [ ] Run `--perf-suite stress_recovery` to confirm STR-002 runs independently (falls back to default load)
- [ ] Verify cleanup timeout triggers correctly when resource count is large (observable via `[PERF CLEANUP] Cleanup timeout` message)
- [ ] Confirm Prow CI (`not extended` marker) is unaffected — stress tests are `performance` marker only

## Changes by area

### New test: `test_stress.py` (+692 lines)

| Test | What it does |
|------|-------------|
| `PERF-STR-001` | Iterates through configurable ramp steps (default: 5→100 concurrent sources), uploading concurrently and monitoring for OOMKills, excessive restarts, upload errors, processing timeout, and queue stalls. Stops at the first failure and records the breaking point. |
| `PERF-STR-002` | Captures quiescent API baseline, sustains overload at or near the breaking-point level (env var override → STR-001 breaking point → STR-001 last good → default 20) for a configurable duration, stops uploading, and monitors until queues drain and API latency returns within 3× of baseline. |

STR-001 captures PostgreSQL stats, restart deltas, OOM events, and API probe summaries. STR-002 captures restart deltas, OOM events, and API probe summaries (no PG stats). Results are persisted via `PerfResultCollector`. STR-001 shares its breaking point with STR-002 via module-level state.

All tuning knobs are environment-variable-driven and exposed as Jenkins parameters in `insights_onprem.groovy` in FP auto-tests:

| Variable | Default | Purpose |
|----------|---------|---------|
| `STRESS_RAMP_STEPS` | `5,10,20,30,50,75,100` | Source counts per step |
| `STRESS_MAX_STEP_TIME` | `1800` | Absolute max seconds per step |
| `STRESS_RECOVERY_DURATION_S` | `300` | Overload duration for STR-002 |

### Cleanup timeout: `tracker.py`

`PerfCleanupTracker.cleanup()` now enforces a deadline of `PERF_CLEANUP_TIMEOUT` seconds (default 900). This was added after the xlarge stress run produced 300+ tracked resources and cleanup hung indefinitely, blocking the Jenkins pipeline. The timeout checks fire:
1. After `_wait_for_ros_drain()` completes
2. Before each individual resource deletion
3. Before S3 cleanup

Skipped resources are reported as warnings, not test failures.

### Shared helpers refactor: `helpers.py`, `test_celery_scaling.py`

`get_oomkill_events()` and `get_pod_restart_counts()` moved from `test_celery_scaling.py` to `helpers.py` so both the celery and stress tests can reuse them.

### Script wiring

| File | Change |
|------|--------|
| `pytest.ini` | Added `stress`, `stress_ramp`, `stress_recovery` markers |
| `run-pytest.sh` | Added `--perf-stress`, `--perf-stress-ramp`, `--perf-stress-recovery` flags |
| `perf-testing.sh` | Added suite→flag mappings; increased Helm upgrade timeout from 5m→10m |
| `deploy-test-cost-onprem.sh` | Added `stress`, `stress_ramp`, `stress_recovery` to suite validation |
| `perf-observability.sh` | Passes `METRICS_MAX_DURATION` (default 14400s) as `--max-duration` to `collect-metrics.sh` |

### Documentation

| File | Change |
|------|--------|
| `FINDINGS.md` | Added FINDING-036 (stress breaking points by profile), updated Jira tracking table, bumped date |
| `performance-testing-plan.md` | Added `test_stress.py` and `tracker.py` to file table, stress env var reference table, stress suite examples, marked SC-2 Done |
| `CLAUDE.md` | Updated suite list, added `test_stress.py` and `tracker.py` to key files |
| `.cursor/prompts/run-tests.md` | Updated suite list, added xlarge to profile list, added stress_ramp example |
| `.cursor/rules/testing.mdc` | Updated suite list |