### PR TITLE
Update RETAIN_NUM_MONTHS to 4

### DIFF
--- a/cost-onprem/values.yaml
+++ b/cost-onprem/values.yaml
@@ -201,7 +201,7 @@ costManagement:
       PROMETHEUS_MULTIPROC_DIR: /tmp
       KOKU_ENABLE_SENTRY: "False"
       CACHED_VIEWS_DISABLED: "False"
-      RETAIN_NUM_MONTHS: "3"
+      RETAIN_NUM_MONTHS: "4"
       NOTIFICATION_CHECK_TIME: "24"
       ENHANCED_ORG_ADMIN: "False"
       RBAC_CACHE_TIMEOUT: "300"
@@ -237,7 +237,7 @@ costManagement:
       # Data retention: how many months of cost data to keep in the database.
       # The MASU vacuum process purges data older than this threshold.
       # Must match the value set in costManagement.api.env for consistency.
-      RETAIN_NUM_MONTHS: "3"
+      RETAIN_NUM_MONTHS: "4"
       # Initial ingest: how many months of historical data to process when
       # a new cost data source (provider) is first registered.
       INITIAL_INGEST_NUM_MONTHS: "2"


### PR DESCRIPTION
Bumps RETAIN_NUM_MONTHS from "3" to "4" in both costManagement.api.env and costManagement.masu.env

Setting it to 4 (Koku's built-in default) restores normal behavior: the env var no longer overrides the API, allowing retention to be managed through the API as intended. This also MIGHT unblock the ~120 IQE 90-day date range tests that require RETAIN_NUM_MONTHS >= 4 (FLPATH-4131, COST-7253), which are currently skipped in the full Prow profile. 

IF nothing else shakes out, we'll remove the relevant rests from the filter as part of FLPATH-4161. This, at the very least, is to enable net-new tests in IQE and ensure that nothing breaks in nightlies right now.

There will likely be more cleanup around these variables, but I'd rather cover that with the operator work.